### PR TITLE
fix: split enterprise-only scopes behind --enterprise flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ go mod tidy         # After changing dependencies
 ## Architecture
 
 - **CLI framework**: `github.com/alecthomas/kong` — commands are Go structs with `Run(ctx *RunContext) error`
-- **Auth**: Raw OAuth2 device code flow against `login.microsoftonline.com` — no MSAL. Scopes defined in `internal/msauth/scopes.go` (includes `MailboxSettings.ReadWrite`, `User.ReadBasic.All` for enterprise directory search)
+- **Auth**: Raw OAuth2 device code flow against `login.microsoftonline.com` — no MSAL. Scopes defined in `internal/msauth/scopes.go`. Enterprise-only scopes (`MailboxSettings.ReadWrite`, `User.ReadBasic.All`) are only requested with `--enterprise` flag — personal accounts cannot consent to them
 - **API**: Official `msgraph-sdk-go` wrapped in `internal/graphapi/` for ergonomic access
 - **Secrets**: OS keyring via `github.com/99designs/keyring` (macOS Keychain, Linux Secret Service, Windows WinCred)
 - **Output**: JSON envelope (`--json`), aligned table (default), TSV (`--plain`)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fast, scriptable CLI for Microsoft Outlook via the Microsoft Graph API. Manage email, calendar, contacts, and tasks from the command line.
 
-Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Entra ID)** accounts. Zero-config setup with device-code authentication — just run `olk auth login` and go.
+Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Entra ID)** accounts. Zero-config setup with device-code authentication — just run `olk auth login` and go. For enterprise accounts, use `olk auth login --enterprise` to enable additional features like out-of-office, inbox rules, and directory search.
 
 ## Key Capabilities
 
@@ -149,10 +149,14 @@ olk mail list --select from,subject
 ### Default (Zero Config)
 
 ```bash
+# Personal accounts (Outlook.com, Hotmail, Live.com)
 olk auth login
+
+# Enterprise accounts (work/school) — enables OOO, inbox rules, directory search
+olk auth login --enterprise
 ```
 
-Uses an embedded public client ID with device-code flow. Works for both personal and enterprise accounts.
+Uses an embedded public client ID with device-code flow. The `--enterprise` flag requests additional scopes (`User.ReadBasic.All`, `MailboxSettings.ReadWrite`) needed for enterprise-only features. Personal accounts should not use `--enterprise` as these scopes are not supported.
 
 ### Custom App Registration
 
@@ -233,7 +237,7 @@ For common workflows, `olk` provides top-level shortcuts:
 ### Auth
 
 ```
-olk auth login [--client-id ID] [--tenant-id ID]    Login via device code
+olk auth login [--enterprise] [--client-id ID] [--tenant-id ID]  Login via device code
 olk auth logout [EMAIL]                              Remove stored credentials
 olk auth clean --force                               Remove ALL accounts and tokens
 olk auth list                                        List authenticated accounts
@@ -403,7 +407,7 @@ Then ask your AI assistant to "check my inbox" or "send an email" and it will us
 
 ## Account Compatibility
 
-Most features work with both personal and enterprise accounts. A few features require an enterprise (work/school) account:
+Most features work with both personal and enterprise accounts. A few features require an enterprise (work/school) account and `olk auth login --enterprise`:
 
 | Feature | Personal | Enterprise |
 |---------|----------|------------|

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,7 +28,8 @@ Use `olk` for Outlook Mail/Calendar/Contacts/Tasks. Works with personal Microsof
 
 Setup (once)
 
-- `olk auth login` — device-code OAuth2 flow (opens browser)
+- `olk auth login` — device-code OAuth2 flow for personal accounts (opens browser)
+- `olk auth login --enterprise` — login with enterprise scopes for work/school accounts (enables OOO, inbox rules, directory search)
 - `olk auth login --client-id ID --tenant-id ID` — enterprise custom app registration
 - `olk auth list` — list authenticated accounts
 - `olk auth status` — check token validity
@@ -80,7 +81,7 @@ Flags & Categories
 - Delete category: `olk mail categories delete <ID> --force`
 - Color presets: `none`, `preset0` (red) through `preset24`
 
-Out-of-Office (enterprise/work accounts only)
+Out-of-Office (enterprise/work accounts only — requires `olk auth login --enterprise`)
 
 - Get auto-reply settings: `olk mail ooo get`
 - Enable auto-reply: `olk mail ooo set --message "I'm out of office"`
@@ -88,7 +89,7 @@ Out-of-Office (enterprise/work accounts only)
 - External message: `olk mail ooo set --message "Internal msg" --external-message "External msg"`
 - Disable auto-reply: `olk mail ooo off`
 
-Inbox Rules (enterprise/work accounts only)
+Inbox Rules (enterprise/work accounts only — requires `olk auth login --enterprise`)
 
 - List rules: `olk mail rules list`
 - Create rule: `olk mail rules create --name "Archive boss" --from boss@co.com --move Archive`
@@ -214,4 +215,4 @@ Notes
 - Destructive commands (`delete`) require `--force` or will prompt for confirmation.
 - Confirm before sending mail or creating/deleting events.
 - If a command fails with an auth error, check `olk auth status` first.
-- Some features are enterprise-only (work/school accounts): out-of-office, inbox rules, find meeting times, and directory search.
+- Some features are enterprise-only (work/school accounts): out-of-office, inbox rules, find meeting times, and directory search. These require `olk auth login --enterprise`.

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -21,9 +21,10 @@ type AuthCmd struct {
 }
 
 type AuthLoginCmd struct {
-	ClientID string `help:"OAuth2 client ID" env:"OLK_CLIENT_ID"`
-	TenantID string `help:"Azure AD tenant ID" env:"OLK_TENANT_ID" default:"common"`
-	ReadOnly bool   `help:"Request read-only permissions"`
+	ClientID   string `help:"OAuth2 client ID" env:"OLK_CLIENT_ID"`
+	TenantID   string `help:"Azure AD tenant ID" env:"OLK_TENANT_ID" default:"common"`
+	ReadOnly   bool   `help:"Request read-only permissions"`
+	Enterprise bool   `help:"Request enterprise scopes (work/school accounts)" env:"OLK_ENTERPRISE"`
 }
 
 func (c *AuthLoginCmd) Run(ctx *RunContext) error {
@@ -37,16 +38,27 @@ func (c *AuthLoginCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	// Personal accounts cannot consent to enterprise-only scopes
+	// (User.ReadBasic.All, MailboxSettings.ReadWrite) — requesting them
+	// causes the device code flow to fail with a misleading "code expired" error.
+	// Use --enterprise for work/school accounts that need these scopes.
 	scopes := msauth.DefaultScopes()
+	if c.Enterprise {
+		scopes = msauth.EnterpriseScopes()
+	}
 	if c.ReadOnly {
-		scopes = msauth.ReadOnlyScopes()
+		if c.Enterprise {
+			scopes = msauth.EnterpriseReadOnlyScopes()
+		} else {
+			scopes = msauth.ReadOnlyScopes()
+		}
 	}
 	// Use a dedicated context for login — the global --timeout (default 60s)
 	// is too short for device-code flow which needs minutes for the user to
 	// open a browser and enter the code.
 	loginCtx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
-	info, err := auth.LoginDeviceCode(loginCtx, scopes)
+	info, err := auth.LoginDeviceCode(loginCtx, scopes, ctx.Flags.Verbose)
 	if err != nil {
 		return err
 	}

--- a/internal/msauth/auth.go
+++ b/internal/msauth/auth.go
@@ -65,18 +65,23 @@ type graphMeResponse struct {
 
 // LoginDeviceCode performs the device code flow, retrieves the user profile,
 // and persists the tokens and account information.
-func (a *Authenticator) LoginDeviceCode(ctx context.Context, scopes []string) (*AccountInfo, error) {
+func (a *Authenticator) LoginDeviceCode(ctx context.Context, scopes []string, verbose bool) (*AccountInfo, error) {
 	// Step 1: Request a device code.
 	dcResp, err := RequestDeviceCode(ctx, a.ClientID, a.TenantID, scopes)
 	if err != nil {
 		return nil, fmt.Errorf("requesting device code: %w", err)
 	}
 
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[verbose] device code response: expires_in=%d interval=%d verification_uri=%s\n", dcResp.ExpiresIn, dcResp.Interval, sanitizeStr(dcResp.VerificationURI))
+		fmt.Fprintf(os.Stderr, "[verbose] client_id=%s tenant=%s scopes=%s\n", a.ClientID, a.TenantID, strings.Join(scopes, " "))
+	}
+
 	// Step 2: Display the user code and verification URL.
 	fmt.Fprintf(os.Stderr, "\nTo sign in, open a browser to:\n  %s\n\nEnter the code: %s\n\nWaiting for authentication...\n", sanitizeStr(dcResp.VerificationURI), sanitizeStr(dcResp.UserCode))
 
 	// Step 3: Poll for the token.
-	tokenResp, err := PollForToken(ctx, a.ClientID, a.TenantID, dcResp.DeviceCode, dcResp.Interval, dcResp.ExpiresIn)
+	tokenResp, err := PollForToken(ctx, a.ClientID, a.TenantID, dcResp.DeviceCode, dcResp.Interval, dcResp.ExpiresIn, verbose)
 	if err != nil {
 		return nil, fmt.Errorf("polling for token: %w", err)
 	}

--- a/internal/msauth/devicecode.go
+++ b/internal/msauth/devicecode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -123,7 +124,7 @@ func RequestDeviceCode(ctx context.Context, clientID, tenantID string, scopes []
 // PollForToken polls the token endpoint until the user completes authentication,
 // the device code expires, or an unrecoverable error occurs.
 // expiresIn from the device code response caps the maximum polling duration.
-func PollForToken(ctx context.Context, clientID, tenantID, deviceCode string, interval int, expiresIn int) (*TokenResponse, error) {
+func PollForToken(ctx context.Context, clientID, tenantID, deviceCode string, interval int, expiresIn int, verbose bool) (*TokenResponse, error) {
 	if err := validateTenantID(tenantID); err != nil {
 		return nil, err
 	}
@@ -173,6 +174,9 @@ func PollForToken(ctx context.Context, clientID, tenantID, deviceCode string, in
 		if resp.StatusCode != http.StatusOK {
 			var errResp ErrorResponse
 			if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil {
+				if verbose {
+					fmt.Fprintf(os.Stderr, "[verbose] poll response: status=%d error=%s description=%s\n", resp.StatusCode, sanitizeStr(errResp.Error), sanitizeStr(errResp.ErrorDescription))
+				}
 				switch errResp.Error {
 				case "authorization_pending":
 					// User hasn't completed auth yet; keep polling.
@@ -186,6 +190,10 @@ func PollForToken(ctx context.Context, clientID, tenantID, deviceCode string, in
 				}
 			}
 			return nil, fmt.Errorf("token request failed with status %d", resp.StatusCode)
+		}
+
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[verbose] poll response: status=%d (success)\n", resp.StatusCode)
 		}
 
 		var tokenResp TokenResponse

--- a/internal/msauth/scopes.go
+++ b/internal/msauth/scopes.go
@@ -24,9 +24,15 @@ func DefaultScopes() []string {
 		ScopeContacts,
 		ScopeTasks,
 		ScopePeople,
-		ScopeUserReadAll,
-		ScopeMailboxSettings,
 	}
+}
+
+// EnterpriseScopes returns all scopes including enterprise-only ones.
+// Personal Microsoft accounts cannot consent to User.ReadBasic.All
+// or MailboxSettings.ReadWrite — requesting them causes device code
+// flow to fail with a misleading "code expired" error.
+func EnterpriseScopes() []string {
+	return append(DefaultScopes(), ScopeUserReadAll, ScopeMailboxSettings)
 }
 
 func ReadOnlyScopes() []string {
@@ -38,7 +44,10 @@ func ReadOnlyScopes() []string {
 		"Contacts.Read",
 		"Tasks.Read",
 		"People.Read",
-		"User.ReadBasic.All",
-		"MailboxSettings.Read",
 	}
+}
+
+// EnterpriseReadOnlyScopes returns read-only scopes including enterprise-only ones.
+func EnterpriseReadOnlyScopes() []string {
+	return append(ReadOnlyScopes(), "User.ReadBasic.All", "MailboxSettings.Read")
 }


### PR DESCRIPTION
## Summary
- Personal Microsoft accounts cannot consent to `User.ReadBasic.All` or `MailboxSettings.ReadWrite` — requesting them causes device code flow to fail with a misleading "code expired" error
- Default `olk auth login` now only requests scopes personal accounts support
- New `--enterprise` flag (`OLK_ENTERPRISE` env) requests additional enterprise scopes
- Added `--verbose` logging to device code flow for debugging auth issues
- Updated README.md, SKILL.md, CLAUDE.md

## Test plan
- [x] `olk auth login` works with personal account
- [x] `olk auth login --enterprise` works with enterprise account
- [x] Enterprise-only features (OOO, inbox rules) work with enterprise login
- [x] Enterprise-only features show graceful error on personal accounts
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)