### PR TITLE
fix(security): address audit findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build linux and windows archives
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --config .goreleaser-prebuild.yaml --clean --timeout 30m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/internal/cmd/mail_attachments.go
+++ b/internal/cmd/mail_attachments.go
@@ -19,7 +19,7 @@ const maxDownloadSize = 50 << 20
 
 // validateOutDir ensures the output directory is not a symlink and exists.
 func validateOutDir(dir string) error {
-	if err := os.MkdirAll(dir, 0o750); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
 	}
 	info, err := os.Lstat(dir)

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -92,7 +92,7 @@ func (s *KeyringStore) Set(key, value string) error {
 func (s *KeyringStore) Get(key string) (string, error) {
 	item, err := s.ring.Get(key)
 	if err != nil {
-		return "", fmt.Errorf("getting key %q: %w", key, err)
+		return "", fmt.Errorf("retrieving stored credential: %w", err)
 	}
 	return string(item.Data), nil
 }


### PR DESCRIPTION
## Summary

Fixes actionable findings from a full security & privacy audit of the codebase.

- **PII leak in error messages**: `secrets/store.go` — keyring `Get()` error included the full key (`olk:token:<email>`), leaking the user's email address in error output. Replaced with generic message.
- **Attachment dir permissions**: `cmd/mail_attachments.go` — output directory created with `0750` (group-readable) while all other sensitive directories use `0700`. Tightened to `0700`.
- **Goreleaser version pin**: `release.yml` — both goreleaser steps used `version: latest`, downloading an unpinned binary at CI time. Pinned to `~> v2` for supply chain safety.

### Audit findings NOT addressed here (tracked separately)

| Severity | Finding | Notes |
|----------|---------|-------|
| Medium | Token refresh race condition (no per-email mutex) | Needs design discussion |
| Medium | OData filter string interpolation (mitigated by allowlist regex) | Pattern is fragile but functional |
| Medium | KQL search incomplete escaping (only strips `"`) | Low impact — user's own mailbox |
| Medium | No SECURITY.md / vulnerability disclosure policy | Non-code change |
| Medium | No GPG signing / SBOM on releases | Needs key setup |
| Medium | Missing PKCE in device code flow | Low practical risk |
| Low | `Clear()` can't zero Go immutable strings | Go limitation |
| Low | Account filename sanitization | `filepath.Base()` already prevents traversal |

## Test plan

- [x] `go build ./...` compiles
- [x] `go vet ./...` passes
- [x] Smoke-tested `mail list`, `mail search`, `calendar events`, `contacts list`, `todo lists list`, `mail rules list` against both consumer and enterprise accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)