### PR TITLE
chore: remove GPG signing and SBOM from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,25 +31,6 @@ checksum:
   extra_files:
     - glob: ./prebuilt-archives/*
 
-signs:
-  - artifacts: checksum
-    args:
-      - "--batch"
-      - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}"
-      - "--output"
-      - "${signature}"
-      - "--detach-sig"
-      - "${artifact}"
-
-sboms:
-  - artifacts: archive
-    cmd: syft
-    args:
-      - "${artifact}"
-      - "--output"
-      - "spdx-json=${document}"
-
 release:
   extra_files:
     - glob: ./prebuilt-archives/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,4 +58,4 @@
 - Device code flow uses PKCE (RFC 7636) — `code_challenge` sent with device code request, `code_verifier` sent during token polling.
 - Token refresh is serialized per-email via `sync.Map` of mutexes in `internal/msauth/auth.go` to prevent race conditions.
 - KQL search queries are sanitized by stripping special characters (`"`, `:`, `(`, `)`, `&`, `|`, `!`, `*`, `\`) in `internal/graphapi/mail.go`.
-- Releases are GPG-signed with SBOM (SPDX) via goreleaser. See `SECURITY.md` for vulnerability disclosure policy.
+- See `SECURITY.md` for vulnerability disclosure policy.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,6 @@ Most features work with both personal and enterprise accounts. A few features re
 - **Token storage**: OAuth refresh tokens are stored in your OS credential manager (macOS Keychain, Linux Secret Service, Windows Credential Manager) — never in plain-text files
 - **PKCE**: Device code flow uses Proof Key for Code Exchange (RFC 7636) for defense-in-depth
 - **Data stays local**: Email bodies, attachments, and contacts are streamed to stdout and never cached to disk
-- **Signed releases**: Release checksums are GPG-signed with an SBOM (SPDX) attached
 - **Clean removal**: Run `olk auth clean --force` to remove all stored accounts and tokens
 - **Vulnerability reporting**: See [SECURITY.md](SECURITY.md) for our disclosure policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,4 +53,4 @@ The following are out of scope:
 - **HTTPS only**: All network traffic uses TLS to Microsoft endpoints
 - **PKCE**: Device code flow uses Proof Key for Code Exchange (RFC 7636)
 - **Input validation**: All user inputs are validated before use in API queries
-- **Signed releases**: Release checksums are GPG-signed; SBOM is attached
+- **Release integrity**: Homebrew formula includes SHA256 checksums; `go install` verifies against the Go checksum database


### PR DESCRIPTION
## Summary

- Remove `signs` and `sboms` sections from `.goreleaser.yaml` — not needed for a CLI tool (Homebrew and `go install` have their own integrity checks)
- Remove signed releases references from README, AGENTS.md, SECURITY.md
- Unblocks v0.5.0 release which fails on missing `GPG_FINGERPRINT` and `syft`

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `.goreleaser.yaml` syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)