### PR TITLE
feat(todo): add checklist, attachments, linked resources & extended fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,9 @@
 ## Project Structure
 
 - `cmd/olk/`: CLI entrypoint — minimal, delegates to `internal/cmd.Execute()`.
-- `internal/cmd/`: Command implementations using kong structs. Each command group has its own file(s): `mail_*.go`, `calendar*.go`, `todo.go`, `whoami.go`, etc.
+- `internal/cmd/`: Command implementations using kong structs. Each command group has its own file(s): `mail_*.go`, `calendar*.go`, `todo.go`, `todo_checklist.go`, `todo_attachments.go`, `todo_links.go`, `whoami.go`, etc.
 - `internal/msauth/`: Microsoft OAuth2 implementation — device code flow, token refresh, credential bridge.
-- `internal/graphapi/`: Microsoft Graph API wrapper — mail, calendar, contacts, todo, availability, mailbox settings, mail rules, people.
+- `internal/graphapi/`: Microsoft Graph API wrapper — mail, calendar, contacts, todo (tasks, checklist items, attachments, linked resources), availability, mailbox settings, mail rules, people.
 - `internal/config/`: Configuration and XDG paths (`~/.config/olk/`).
 - `internal/secrets/`: OS keyring integration via `99designs/keyring`.
 - `internal/outfmt/`: Output formatting — JSON envelope, aligned tables, TSV.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,6 @@ The project uses `msgraph-sdk-go` v1.96.0 which has some naming quirks:
 - FindMeetingTimes: `Me().FindMeetingTimes().Post()` returns `MeetingTimeSuggestionsResultable`
 - Recurrence pattern: `event.GetRecurrence().GetPattern().GetTypeEscaped()` (uses `GetTypeEscaped` not `GetType`)
 - ISODuration: use `serialization.NewDuration()` from `kiota-abstractions-go` for meeting duration
+- Todo checklist items: `Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems()`
+- Todo attachments: `TaskFileAttachment` type for upload; `ByAttachmentBaseId()` for get/delete
+- Todo linked resources: `Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).LinkedResources()`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Ent
 
 ### Tasks (Microsoft To Do)
 - **Manage task lists**: list, create, delete task lists
-- **Create, update, complete, delete** tasks with due dates, importance, and notes
+- **Create, update, complete, delete** tasks with due dates, importance, notes, start dates, reminders, recurrence, and categories
+- **Checklists**: list, create, toggle, update, and delete checklist items within tasks
+- **Attachments**: list, upload, download, and delete task file attachments
+- **Linked resources**: list, create, and delete linked resources on tasks
 
 ### People / Directory
 - **Search** people by name — returns name, email, job title, department, company. Personal accounts search known contacts; enterprise accounts also search the organization directory
@@ -321,10 +324,22 @@ olk todo lists create -n "Name"                      Create a task list
 olk todo lists delete <ID> --force                   Delete a task list
 olk todo list [--list ID] [-n 25] [--status STATUS]  List tasks
 olk todo get <TASK_ID> [--list ID]                   Get task details
-olk todo create -t "Title" [--due DATE] [--importance low|normal|high] [--body TEXT] [--list ID]
-olk todo update <TASK_ID> [--title X] [--due DATE] [--importance low|normal|high] [--body TEXT] [--list ID]
+olk todo create -t "Title" [--due DATE] [--importance low|normal|high] [--body TEXT] [--list ID] [--start DATE] [--reminder DATETIME] [--recurrence daily|weekdays|weekly|monthly|yearly] [--categories CAT]
+olk todo update <TASK_ID> [--title X] [--due DATE] [--importance low|normal|high] [--body TEXT] [--list ID] [--start DATE] [--reminder DATETIME] [--recurrence daily|weekdays|weekly|monthly|yearly] [--categories CAT]
 olk todo complete <TASK_ID> [--list ID]              Mark task complete
 olk todo delete <TASK_ID> --force [--list ID]        Delete a task
+olk todo checklist list <TASK_ID> [--list ID]        List checklist items
+olk todo checklist create <TASK_ID> -n "Name" [--list ID]  Create a checklist item
+olk todo checklist toggle <TASK_ID> <ITEM_ID> [--list ID]  Toggle checked/unchecked
+olk todo checklist update <TASK_ID> <ITEM_ID> -n "Name" [--list ID]  Update checklist item
+olk todo checklist delete <TASK_ID> <ITEM_ID> --force [--list ID]    Delete checklist item
+olk todo attach list <TASK_ID> [--list ID]           List task attachments
+olk todo attach upload <TASK_ID> <FILE> [--list ID]  Upload a file attachment
+olk todo attach download <TASK_ID> <ATTACHMENT_ID> [--list ID] [--out DIR]  Download an attachment
+olk todo attach delete <TASK_ID> <ATTACHMENT_ID> --force [--list ID]        Delete an attachment
+olk todo links list <TASK_ID> [--list ID]            List linked resources
+olk todo links create <TASK_ID> -n "Name" --url "URL" [--list ID]   Create a linked resource
+olk todo links delete <TASK_ID> <RESOURCE_ID> --force [--list ID]   Delete a linked resource
 ```
 
 ### User Profile

--- a/SKILL.md
+++ b/SKILL.md
@@ -145,10 +145,31 @@ Tasks (Microsoft To Do)
 - Delete task list: `olk todo lists delete <LIST_ID> --force`
 - List tasks: `olk todo list [--list LIST_ID] [-n 25] [--status notStarted|inProgress|completed|waitingOnOthers|deferred]`
 - Get task: `olk todo get <TASK_ID> [--list LIST_ID]`
-- Create task: `olk todo create --title "Buy groceries" [--due 2026-04-15] [--importance low|normal|high] [--body "Notes"] [--list LIST_ID]`
-- Update task: `olk todo update <TASK_ID> [--title X] [--due DATE] [--importance low|normal|high] [--body TEXT] [--list LIST_ID]`
+- Create task: `olk todo create --title "Buy groceries" [--due 2026-04-15] [--start 2026-04-10] [--importance low|normal|high] [--body "Notes"] [--reminder 2026-04-14T09:00] [--recurrence daily|weekdays|weekly|monthly|yearly] [-c "Work" -c "Urgent"] [--list LIST_ID]`
+- Update task: `olk todo update <TASK_ID> [--title X] [--due DATE] [--start DATE] [--importance low|normal|high] [--body TEXT] [--reminder DATETIME] [--recurrence PATTERN] [-c CATEGORY] [--list LIST_ID]`
 - Complete task: `olk todo complete <TASK_ID> [--list LIST_ID]`
 - Delete task: `olk todo delete <TASK_ID> --force [--list LIST_ID]`
+
+Checklist Items
+
+- List checklist items: `olk todo checklist list <TASK_ID> [--list LIST_ID]`
+- Create checklist item: `olk todo checklist create <TASK_ID> -n "Step 1" [--list LIST_ID]`
+- Toggle checked/unchecked: `olk todo checklist toggle <TASK_ID> <ITEM_ID> [--list LIST_ID]`
+- Update checklist item: `olk todo checklist update <TASK_ID> <ITEM_ID> -n "New name" [--list LIST_ID]`
+- Delete checklist item: `olk todo checklist delete <TASK_ID> <ITEM_ID> --force [--list LIST_ID]`
+
+Task Attachments
+
+- List attachments: `olk todo attach list <TASK_ID> [--list LIST_ID]`
+- Upload attachment: `olk todo attach upload <TASK_ID> <FILE> [--list LIST_ID]`
+- Download attachment: `olk todo attach download <TASK_ID> <ATTACHMENT_ID> [--out DIR] [--list LIST_ID]`
+- Delete attachment: `olk todo attach delete <TASK_ID> <ATTACHMENT_ID> --force [--list LIST_ID]`
+
+Linked Resources
+
+- List linked resources: `olk todo links list <TASK_ID> [--list LIST_ID]`
+- Create linked resource: `olk todo links create <TASK_ID> -n "Resource name" [--url URL] [--app-name APP] [--external-id ID] [--list LIST_ID]`
+- Delete linked resource: `olk todo links delete <TASK_ID> <RESOURCE_ID> --force [--list LIST_ID]`
 
 If `--list` is omitted, the default (first) task list is used automatically.
 

--- a/internal/cmd/todo.go
+++ b/internal/cmd/todo.go
@@ -9,13 +9,16 @@ import (
 
 // TodoCmd is the top-level command group for Microsoft To Do tasks.
 type TodoCmd struct {
-	Lists    TodoListsCmd    `cmd:"" help:"Task list operations"`
-	List     TodoListCmd     `cmd:"" help:"List tasks in a list"`
-	Get      TodoGetCmd      `cmd:"" help:"Get task details"`
-	Create   TodoCreateCmd   `cmd:"" help:"Create a task"`
-	Complete TodoCompleteCmd `cmd:"" help:"Mark a task as complete"`
-	Update   TodoUpdateCmd   `cmd:"" help:"Update a task"`
-	Delete   TodoDeleteCmd   `cmd:"" help:"Delete a task"`
+	Lists     TodoListsCmd     `cmd:"" help:"Task list operations"`
+	List      TodoListCmd      `cmd:"" help:"List tasks in a list"`
+	Get       TodoGetCmd       `cmd:"" help:"Get task details"`
+	Create    TodoCreateCmd    `cmd:"" help:"Create a task"`
+	Complete  TodoCompleteCmd  `cmd:"" help:"Mark a task as complete"`
+	Update    TodoUpdateCmd    `cmd:"" help:"Update a task"`
+	Delete    TodoDeleteCmd    `cmd:"" help:"Delete a task"`
+	Checklist TodoChecklistCmd `cmd:"" help:"Checklist item operations"`
+	Attach    TodoAttachCmd    `cmd:"" help:"Task attachment operations"`
+	Links     TodoLinksCmd     `cmd:"" help:"Linked resource operations"`
 }
 
 // resolveListID returns the provided listID, or auto-detects the default task list.
@@ -71,7 +74,7 @@ func (c *TodoListsListCmd) Run(ctx *RunContext) error {
 			owner = "Y"
 		}
 		rows = append(rows, []string{
-			outfmt.Truncate(l.ID, 15),
+			outfmt.Truncate(outfmt.Sanitize(l.ID), 15),
 			outfmt.Sanitize(l.DisplayName),
 			owner,
 		})
@@ -171,11 +174,11 @@ func (c *TodoListCmd) Run(ctx *RunContext) error {
 	for i := range tasks {
 		t := &tasks[i]
 		rows = append(rows, []string{
-			outfmt.Truncate(t.ID, 15),
+			outfmt.Truncate(outfmt.Sanitize(t.ID), 15),
 			outfmt.Truncate(outfmt.Sanitize(t.Title), 50),
-			t.Status,
-			t.Importance,
-			outfmt.Truncate(t.DueDate, 16),
+			outfmt.Sanitize(t.Status),
+			outfmt.Sanitize(t.Importance),
+			outfmt.Truncate(outfmt.Sanitize(t.DueDate), 16),
 		})
 	}
 
@@ -217,8 +220,23 @@ func (c *TodoGetCmd) Run(ctx *RunContext) error {
 	if task.DueDate != "" {
 		fmt.Printf("Due:         %s\n", outfmt.Sanitize(task.DueDate))
 	}
+	if task.StartDate != "" {
+		fmt.Printf("Start:       %s\n", outfmt.Sanitize(task.StartDate))
+	}
+	if task.IsReminderOn {
+		fmt.Printf("Reminder:    %s\n", outfmt.Sanitize(task.ReminderDate))
+	}
+	if task.Recurrence != "" {
+		fmt.Printf("Recurrence:  %s\n", outfmt.Sanitize(task.Recurrence))
+	}
+	if len(task.Categories) > 0 {
+		fmt.Printf("Categories:  %s\n", outfmt.Sanitize(strings.Join(task.Categories, ", ")))
+	}
 	if task.CompletedAt != "" {
 		fmt.Printf("Completed:   %s\n", outfmt.Sanitize(task.CompletedAt))
+	}
+	if task.HasAttachments {
+		fmt.Printf("Attachments: Yes\n")
 	}
 	if task.Body != "" {
 		fmt.Println(strings.Repeat("-", 60))
@@ -230,11 +248,15 @@ func (c *TodoGetCmd) Run(ctx *RunContext) error {
 
 // TodoCreateCmd creates a new task.
 type TodoCreateCmd struct {
-	List       string `help:"Task list ID" env:"OLK_TODO_LIST"`
-	Title      string `help:"Task title" required:"" short:"t"`
-	Due        string `help:"Due date (ISO 8601, e.g. 2024-12-31)" short:"d"`
-	Importance string `help:"Importance level" enum:"low,normal,high," default:""`
-	Body       string `help:"Task body text" short:"b"`
+	List       string   `help:"Task list ID" env:"OLK_TODO_LIST"`
+	Title      string   `help:"Task title" required:"" short:"t"`
+	Due        string   `help:"Due date (ISO 8601, e.g. 2024-12-31)" short:"d"`
+	Start      string   `help:"Start date (ISO 8601)" short:"s"`
+	Reminder   string   `help:"Reminder date/time (ISO 8601)"`
+	Recurrence string   `help:"Recurrence pattern" enum:"daily,weekdays,weekly,monthly,yearly," default:""`
+	Importance string   `help:"Importance level" enum:"low,normal,high," default:""`
+	Body       string   `help:"Task body text" short:"b"`
+	Categories []string `help:"Categories to assign" short:"c"`
 }
 
 func (c *TodoCreateCmd) Run(ctx *RunContext) error {
@@ -248,11 +270,23 @@ func (c *TodoCreateCmd) Run(ctx *RunContext) error {
 		if c.Due != "" {
 			fmt.Printf("  Due: %s\n", outfmt.Sanitize(c.Due))
 		}
+		if c.Start != "" {
+			fmt.Printf("  Start: %s\n", outfmt.Sanitize(c.Start))
+		}
+		if c.Reminder != "" {
+			fmt.Printf("  Reminder: %s\n", outfmt.Sanitize(c.Reminder))
+		}
+		if c.Recurrence != "" {
+			fmt.Printf("  Recurrence: %s\n", outfmt.Sanitize(c.Recurrence))
+		}
 		if c.Importance != "" {
 			fmt.Printf("  Importance: %s\n", outfmt.Sanitize(c.Importance))
 		}
 		if c.Body != "" {
 			fmt.Printf("  Body: %s\n", outfmt.Sanitize(c.Body))
+		}
+		if len(c.Categories) > 0 {
+			fmt.Printf("  Categories: %s\n", outfmt.Sanitize(strings.Join(c.Categories, ", ")))
 		}
 		return nil
 	}
@@ -262,7 +296,7 @@ func (c *TodoCreateCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	task, err := client.CreateTodoTask(ctx.Ctx, listID, c.Title, c.Due, c.Importance, c.Body)
+	task, err := client.CreateTodoTask(ctx.Ctx, listID, c.Title, c.Due, c.Importance, c.Body, c.Start, c.Reminder, c.Recurrence, c.Categories)
 	if err != nil {
 		return err
 	}
@@ -304,12 +338,16 @@ func (c *TodoCompleteCmd) Run(ctx *RunContext) error {
 
 // TodoUpdateCmd updates a task's properties.
 type TodoUpdateCmd struct {
-	ID         string `arg:"" help:"Task ID"`
-	List       string `help:"Task list ID" env:"OLK_TODO_LIST"`
-	Title      string `help:"New title" short:"t"`
-	Due        string `help:"New due date (ISO 8601, empty string to clear)" short:"d"`
-	Importance string `help:"New importance level" enum:"low,normal,high," default:""`
-	Body       string `help:"New body text" short:"b"`
+	ID         string   `arg:"" help:"Task ID"`
+	List       string   `help:"Task list ID" env:"OLK_TODO_LIST"`
+	Title      string   `help:"New title" short:"t"`
+	Due        string   `help:"New due date (ISO 8601, empty string to clear)" short:"d"`
+	Start      string   `help:"New start date (ISO 8601, empty string to clear)" short:"s"`
+	Reminder   string   `help:"New reminder date/time (ISO 8601, empty string to clear)"`
+	Recurrence string   `help:"New recurrence pattern (empty string to clear)" enum:"daily,weekdays,weekly,monthly,yearly," default:""`
+	Importance string   `help:"New importance level" enum:"low,normal,high," default:""`
+	Body       string   `help:"New body text" short:"b"`
+	Categories []string `help:"New categories (use -c none to clear)" short:"c"`
 }
 
 func (c *TodoUpdateCmd) Run(ctx *RunContext) error {
@@ -319,7 +357,8 @@ func (c *TodoUpdateCmd) Run(ctx *RunContext) error {
 	}
 
 	// Build optional params - only set what was provided
-	var title, due, importance, body *string
+	var title, due, importance, body, start, reminder, recurrence *string
+	var categories *[]string
 	if c.Title != "" {
 		title = &c.Title
 	}
@@ -332,9 +371,26 @@ func (c *TodoUpdateCmd) Run(ctx *RunContext) error {
 	if c.Body != "" {
 		body = &c.Body
 	}
+	if c.Start != "" {
+		start = &c.Start
+	}
+	if c.Reminder != "" {
+		reminder = &c.Reminder
+	}
+	if c.Recurrence != "" {
+		recurrence = &c.Recurrence
+	}
+	if len(c.Categories) > 0 {
+		if len(c.Categories) == 1 && c.Categories[0] == "none" {
+			empty := []string{}
+			categories = &empty
+		} else {
+			categories = &c.Categories
+		}
+	}
 
-	if title == nil && due == nil && importance == nil && body == nil {
-		return fmt.Errorf("nothing to update; provide at least one of --title, --due, --importance, --body")
+	if title == nil && due == nil && importance == nil && body == nil && start == nil && reminder == nil && recurrence == nil && categories == nil {
+		return fmt.Errorf("nothing to update; provide at least one of --title, --due, --start, --reminder, --recurrence, --importance, --body, --categories")
 	}
 
 	if ctx.Flags.DryRun {
@@ -347,7 +403,7 @@ func (c *TodoUpdateCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	task, err := client.UpdateTodoTask(ctx.Ctx, listID, c.ID, title, due, importance, body)
+	task, err := client.UpdateTodoTask(ctx.Ctx, listID, c.ID, title, due, importance, body, start, reminder, recurrence, categories)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/todo_attachments.go
+++ b/internal/cmd/todo_attachments.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// TodoAttachCmd manages file attachments on tasks.
+type TodoAttachCmd struct {
+	List     TodoAttachListCmd     `cmd:"" help:"List task attachments"`
+	Upload   TodoAttachUploadCmd   `cmd:"" help:"Upload a file attachment"`
+	Download TodoAttachDownloadCmd `cmd:"" help:"Download an attachment"`
+	Delete   TodoAttachDeleteCmd   `cmd:"" help:"Delete an attachment"`
+}
+
+// TodoAttachListCmd lists attachments on a task.
+type TodoAttachListCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoAttachListCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	attachments, err := client.ListTodoAttachments(ctx.Ctx, listID, c.TaskID)
+	if err != nil {
+		return err
+	}
+
+	if len(attachments) == 0 {
+		fmt.Println("No attachments.")
+		return nil
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(attachments, len(attachments), "")
+	}
+
+	headers := []string{"ID", "NAME", "TYPE", "SIZE"}
+	var rows [][]string
+	for _, a := range attachments {
+		rows = append(rows, []string{
+			outfmt.Sanitize(a.ID),
+			outfmt.Sanitize(a.Name),
+			outfmt.Sanitize(a.ContentType),
+			fmt.Sprintf("%d", a.Size),
+		})
+	}
+
+	return printer.Print(headers, rows, attachments, len(attachments), "")
+}
+
+// TodoAttachUploadCmd uploads a file attachment to a task.
+type TodoAttachUploadCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	File   string `arg:"" help:"File to upload" type:"existingfile"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoAttachUploadCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(c.File)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+	if info.Size() > maxDownloadSize {
+		return fmt.Errorf("file is %d bytes, exceeds 50MB upload limit", info.Size())
+	}
+
+	content, err := os.ReadFile(c.File)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	filename := filepath.Base(c.File)
+	contentType := mime.TypeByExtension(filepath.Ext(c.File))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would upload %s to task %s\n", outfmt.Sanitize(filename), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	att, err := client.UploadTodoAttachment(ctx.Ctx, listID, c.TaskID, filename, contentType, content)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Uploaded: %s (ID: %s)\n", outfmt.Sanitize(att.Name), outfmt.Sanitize(att.ID))
+	return nil
+}
+
+// TodoAttachDownloadCmd downloads an attachment from a task.
+type TodoAttachDownloadCmd struct {
+	TaskID       string `arg:"" help:"Task ID"`
+	AttachmentID string `arg:"" help:"Attachment ID"`
+	Out          string `help:"Output directory for download" default:"." type:"path"`
+	List         string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoAttachDownloadCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	name, _, content, err := client.DownloadTodoAttachment(ctx.Ctx, listID, c.TaskID, c.AttachmentID)
+	if err != nil {
+		return err
+	}
+
+	if len(content) > maxDownloadSize {
+		return fmt.Errorf("attachment is %d bytes, exceeds 50MB download limit", len(content))
+	}
+
+	if err := validateOutDir(c.Out); err != nil {
+		return err
+	}
+
+	filename := sanitizeFilename(name)
+	outPath := filepath.Join(c.Out, filename)
+	saved, err := safeWriteFile(outPath, content)
+	if err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+
+	fmt.Printf("Saved: %s\n", saved)
+	return nil
+}
+
+// TodoAttachDeleteCmd deletes an attachment from a task.
+type TodoAttachDeleteCmd struct {
+	TaskID       string `arg:"" help:"Task ID"`
+	AttachmentID string `arg:"" help:"Attachment ID"`
+	List         string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoAttachDeleteCmd) Run(ctx *RunContext) error {
+	if !ctx.Flags.Force {
+		return fmt.Errorf("delete attachment %s: use --force to confirm deletion", outfmt.Sanitize(c.AttachmentID))
+	}
+
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would delete attachment %s from task %s\n", outfmt.Sanitize(c.AttachmentID), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteTodoAttachment(ctx.Ctx, listID, c.TaskID, c.AttachmentID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Attachment deleted.")
+	return nil
+}

--- a/internal/cmd/todo_checklist.go
+++ b/internal/cmd/todo_checklist.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// TodoChecklistCmd manages checklist items within a task.
+type TodoChecklistCmd struct {
+	List   TodoChecklistListCmd   `cmd:"" help:"List checklist items"`
+	Create TodoChecklistCreateCmd `cmd:"" help:"Create a checklist item"`
+	Toggle TodoChecklistToggleCmd `cmd:"" help:"Toggle a checklist item checked/unchecked"`
+	Update TodoChecklistUpdateCmd `cmd:"" help:"Update a checklist item"`
+	Delete TodoChecklistDeleteCmd `cmd:"" help:"Delete a checklist item"`
+}
+
+// TodoChecklistListCmd lists checklist items in a task.
+type TodoChecklistListCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoChecklistListCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	items, err := client.ListChecklistItems(ctx.Ctx, listID, c.TaskID)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(items, len(items), "")
+	}
+
+	headers := []string{"ID", "NAME", "CHECKED"}
+	var rows [][]string
+	for _, item := range items {
+		checked := " "
+		if item.IsChecked {
+			checked = "Y"
+		}
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(item.ID), 15),
+			outfmt.Truncate(outfmt.Sanitize(item.DisplayName), 50),
+			checked,
+		})
+	}
+
+	return printer.Print(headers, rows, items, len(items), "")
+}
+
+// TodoChecklistCreateCmd creates a new checklist item.
+type TodoChecklistCreateCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	Name   string `help:"Checklist item name" required:"" short:"n"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoChecklistCreateCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would create checklist item %q in task %s\n", outfmt.Sanitize(c.Name), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	item, err := client.CreateChecklistItem(ctx.Ctx, listID, c.TaskID, c.Name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Checklist item created: %s (ID: %s)\n", outfmt.Sanitize(item.DisplayName), outfmt.Sanitize(item.ID))
+	return nil
+}
+
+// TodoChecklistToggleCmd toggles a checklist item checked/unchecked.
+type TodoChecklistToggleCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	ItemID string `arg:"" help:"Checklist item ID"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoChecklistToggleCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would toggle checklist item %s in task %s\n", outfmt.Sanitize(c.ItemID), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	item, err := client.ToggleChecklistItem(ctx.Ctx, listID, c.TaskID, c.ItemID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Checklist item toggled: %s (checked: %t)\n", outfmt.Sanitize(item.DisplayName), item.IsChecked)
+	return nil
+}
+
+// TodoChecklistUpdateCmd updates a checklist item.
+type TodoChecklistUpdateCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	ItemID string `arg:"" help:"Checklist item ID"`
+	Name   string `help:"New name" short:"n"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoChecklistUpdateCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	var name *string
+	if c.Name != "" {
+		name = &c.Name
+	}
+
+	if name == nil {
+		return fmt.Errorf("nothing to update; provide at least --name")
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would update checklist item %s in task %s\n", outfmt.Sanitize(c.ItemID), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	item, err := client.UpdateChecklistItem(ctx.Ctx, listID, c.TaskID, c.ItemID, name, nil)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Checklist item updated: %s\n", outfmt.Sanitize(item.DisplayName))
+	return nil
+}
+
+// TodoChecklistDeleteCmd deletes a checklist item.
+type TodoChecklistDeleteCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	ItemID string `arg:"" help:"Checklist item ID"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoChecklistDeleteCmd) Run(ctx *RunContext) error {
+	if !ctx.Flags.Force {
+		return fmt.Errorf("delete checklist item %s: use --force to confirm deletion", outfmt.Sanitize(outfmt.Truncate(c.ItemID, 30)))
+	}
+
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would delete checklist item %s in task %s\n", outfmt.Sanitize(c.ItemID), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteChecklistItem(ctx.Ctx, listID, c.TaskID, c.ItemID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Checklist item deleted.")
+	return nil
+}

--- a/internal/cmd/todo_links.go
+++ b/internal/cmd/todo_links.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// TodoLinksCmd manages linked resources on tasks.
+type TodoLinksCmd struct {
+	List   TodoLinksListCmd   `cmd:"" help:"List linked resources"`
+	Create TodoLinksCreateCmd `cmd:"" help:"Create a linked resource"`
+	Delete TodoLinksDeleteCmd `cmd:"" help:"Delete a linked resource"`
+}
+
+// TodoLinksListCmd lists linked resources for a task.
+type TodoLinksListCmd struct {
+	TaskID string `arg:"" help:"Task ID"`
+	List   string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoLinksListCmd) Run(ctx *RunContext) error {
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	links, err := client.ListLinkedResources(ctx.Ctx, listID, c.TaskID)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(links, len(links), "")
+	}
+
+	headers := []string{"ID", "NAME", "APP", "URL"}
+	var rows [][]string
+	for _, l := range links {
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(l.ID), 15),
+			outfmt.Truncate(outfmt.Sanitize(l.DisplayName), 30),
+			outfmt.Sanitize(l.ApplicationName),
+			outfmt.Truncate(outfmt.Sanitize(l.WebURL), 50),
+		})
+	}
+
+	return printer.Print(headers, rows, links, len(links), "")
+}
+
+// TodoLinksCreateCmd creates a linked resource on a task.
+type TodoLinksCreateCmd struct {
+	TaskID     string `arg:"" help:"Task ID"`
+	Name       string `help:"Display name" required:"" short:"n"`
+	URL        string `help:"Web URL"`
+	AppName    string `help:"Application name" default:"olk"`
+	ExternalID string `help:"External ID"`
+	List       string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoLinksCreateCmd) Run(ctx *RunContext) error {
+	if c.URL != "" && !strings.HasPrefix(c.URL, "http://") && !strings.HasPrefix(c.URL, "https://") {
+		return fmt.Errorf("URL must use http:// or https:// scheme")
+	}
+
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would create linked resource %q on task %s\n", outfmt.Sanitize(c.Name), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	link, err := client.CreateLinkedResource(ctx.Ctx, listID, c.TaskID, c.Name, c.AppName, c.ExternalID, c.URL)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Linked resource created: %s (ID: %s)\n", outfmt.Sanitize(link.DisplayName), outfmt.Sanitize(link.ID))
+	return nil
+}
+
+// TodoLinksDeleteCmd deletes a linked resource from a task.
+type TodoLinksDeleteCmd struct {
+	TaskID     string `arg:"" help:"Task ID"`
+	ResourceID string `arg:"" help:"Linked resource ID"`
+	List       string `help:"Task list ID" env:"OLK_TODO_LIST"`
+}
+
+func (c *TodoLinksDeleteCmd) Run(ctx *RunContext) error {
+	if !ctx.Flags.Force {
+		return fmt.Errorf("delete linked resource %s: use --force to confirm deletion", outfmt.Sanitize(outfmt.Truncate(c.ResourceID, 30)))
+	}
+
+	listID, err := resolveListID(ctx, c.List)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would delete linked resource %s from task %s\n", outfmt.Sanitize(c.ResourceID), outfmt.Sanitize(c.TaskID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteLinkedResource(ctx.Ctx, listID, c.TaskID, c.ResourceID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Linked resource deleted.")
+	return nil
+}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -471,7 +471,7 @@ func sanitizeKQL(query string) string {
 func (c *Client) SearchMessages(ctx context.Context, query string, top int32) ([]MailMessage, error) {
 	return c.ListMessages(ctx, &ListMessagesOptions{
 		Top:    top,
-		Search: fmt.Sprintf(`"%s"`, sanitizeKQL(query)),
+		Search: `"` + sanitizeKQL(query) + `"`,
 	})
 }
 

--- a/internal/graphapi/todo.go
+++ b/internal/graphapi/todo.go
@@ -27,14 +27,45 @@ type TodoList struct {
 
 // TodoTask is a simplified task for output
 type TodoTask struct {
+	ID             string   `json:"id"`
+	Title          string   `json:"title"`
+	Status         string   `json:"status"`
+	Importance     string   `json:"importance"`
+	DueDate        string   `json:"dueDateTime,omitempty"`
+	CreatedAt      string   `json:"createdDateTime"`
+	CompletedAt    string   `json:"completedDateTime,omitempty"`
+	Body           string   `json:"body,omitempty"`
+	StartDate      string   `json:"startDateTime,omitempty"`
+	IsReminderOn   bool     `json:"isReminderOn"`
+	ReminderDate   string   `json:"reminderDateTime,omitempty"`
+	Recurrence     string   `json:"recurrence,omitempty"`
+	Categories     []string `json:"categories,omitempty"`
+	HasAttachments bool     `json:"hasAttachments"`
+}
+
+// TodoChecklistItem is a simplified checklist item for output
+type TodoChecklistItem struct {
 	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Status      string `json:"status"`
-	Importance  string `json:"importance"`
-	DueDate     string `json:"dueDateTime,omitempty"`
-	CreatedAt   string `json:"createdDateTime"`
-	CompletedAt string `json:"completedDateTime,omitempty"`
-	Body        string `json:"body,omitempty"`
+	DisplayName string `json:"displayName"`
+	IsChecked   bool   `json:"isChecked"`
+	CreatedAt   string `json:"createdDateTime,omitempty"`
+}
+
+// TodoAttachment is a simplified attachment for output
+type TodoAttachment struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	ContentType string `json:"contentType"`
+	Size        int32  `json:"size"`
+}
+
+// TodoLinkedResource is a simplified linked resource for output
+type TodoLinkedResource struct {
+	ID              string `json:"id"`
+	DisplayName     string `json:"displayName"`
+	ApplicationName string `json:"applicationName"`
+	ExternalID      string `json:"externalId"`
+	WebURL          string `json:"webUrl"`
 }
 
 // ListTodoLists returns all task lists for the current user.
@@ -154,7 +185,7 @@ func (c *Client) GetTodoTask(ctx context.Context, listID, taskID string) (*TodoT
 }
 
 // CreateTodoTask creates a new task in the given list.
-func (c *Client) CreateTodoTask(ctx context.Context, listID, title, dueDate, importance, body string) (*TodoTask, error) {
+func (c *Client) CreateTodoTask(ctx context.Context, listID, title, dueDate, importance, body, startDate, reminderDate, recurrence string, categories []string) (*TodoTask, error) {
 	if err := validateID(listID, "list ID"); err != nil {
 		return nil, err
 	}
@@ -199,6 +230,55 @@ func (c *Client) CreateTodoTask(ctx context.Context, listID, title, dueDate, imp
 		task.SetBody(b)
 	}
 
+	if startDate != "" {
+		parsed, err := parseDate(startDate)
+		if err != nil {
+			return nil, fmt.Errorf("invalid start date %q: use ISO 8601 format (e.g. 2025-06-15 or 2025-06-15T09:00:00Z): %w", startDate, err)
+		}
+		canonical := parsed.UTC().Format("2006-01-02T15:04:05")
+		dt := models.NewDateTimeTimeZone()
+		dt.SetDateTime(&canonical)
+		tz := graphTimeZoneUTC
+		dt.SetTimeZone(&tz)
+		task.SetStartDateTime(dt)
+	}
+
+	if reminderDate != "" {
+		parsed, err := parseDate(reminderDate)
+		if err != nil {
+			return nil, fmt.Errorf("invalid reminder date %q: use ISO 8601 format (e.g. 2025-06-15 or 2025-06-15T09:00:00Z): %w", reminderDate, err)
+		}
+		canonical := parsed.UTC().Format("2006-01-02T15:04:05")
+		dt := models.NewDateTimeTimeZone()
+		dt.SetDateTime(&canonical)
+		tz := graphTimeZoneUTC
+		dt.SetTimeZone(&tz)
+		task.SetReminderDateTime(dt)
+		isOn := true
+		task.SetIsReminderOn(&isOn)
+	}
+
+	if recurrence != "" {
+		var start time.Time
+		switch {
+		case startDate != "":
+			start, _ = parseDate(startDate)
+		case dueDate != "":
+			start, _ = parseDate(dueDate)
+		default:
+			start = time.Now()
+		}
+		rec, err := buildRecurrence(recurrence, start)
+		if err != nil {
+			return nil, err
+		}
+		task.SetRecurrence(rec)
+	}
+
+	if len(categories) > 0 {
+		task.SetCategories(categories)
+	}
+
 	resp, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().Post(ctx, task, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating todo task: %w", err)
@@ -229,7 +309,7 @@ func (c *Client) CompleteTodoTask(ctx context.Context, listID, taskID string) er
 }
 
 // UpdateTodoTask updates a task's properties.
-func (c *Client) UpdateTodoTask(ctx context.Context, listID, taskID string, title, dueDate, importance, body *string) (*TodoTask, error) {
+func (c *Client) UpdateTodoTask(ctx context.Context, listID, taskID string, title, dueDate, importance, body, startDate, reminderDate, recurrence *string, categories *[]string) (*TodoTask, error) {
 	if err := validateID(listID, "list ID"); err != nil {
 		return nil, err
 	}
@@ -284,6 +364,69 @@ func (c *Client) UpdateTodoTask(ctx context.Context, listID, taskID string, titl
 		task.SetBody(b)
 	}
 
+	if startDate != nil {
+		if *startDate == "" {
+			task.SetStartDateTime(nil)
+		} else {
+			parsed, err := parseDate(*startDate)
+			if err != nil {
+				return nil, fmt.Errorf("invalid start date %q: use ISO 8601 format (e.g. 2025-06-15): %w", *startDate, err)
+			}
+			canonical := parsed.UTC().Format("2006-01-02T15:04:05")
+			dt := models.NewDateTimeTimeZone()
+			dt.SetDateTime(&canonical)
+			tz := graphTimeZoneUTC
+			dt.SetTimeZone(&tz)
+			task.SetStartDateTime(dt)
+		}
+	}
+
+	if reminderDate != nil {
+		if *reminderDate == "" {
+			task.SetReminderDateTime(nil)
+			isOff := false
+			task.SetIsReminderOn(&isOff)
+		} else {
+			parsed, err := parseDate(*reminderDate)
+			if err != nil {
+				return nil, fmt.Errorf("invalid reminder date %q: use ISO 8601 format (e.g. 2025-06-15): %w", *reminderDate, err)
+			}
+			canonical := parsed.UTC().Format("2006-01-02T15:04:05")
+			dt := models.NewDateTimeTimeZone()
+			dt.SetDateTime(&canonical)
+			tz := graphTimeZoneUTC
+			dt.SetTimeZone(&tz)
+			task.SetReminderDateTime(dt)
+			isOn := true
+			task.SetIsReminderOn(&isOn)
+		}
+	}
+
+	if recurrence != nil {
+		if *recurrence == "" {
+			task.SetRecurrence(nil)
+		} else {
+			var start time.Time
+			switch {
+			case startDate != nil && *startDate != "":
+				start, _ = parseDate(*startDate)
+			case dueDate != nil && *dueDate != "":
+				start, _ = parseDate(*dueDate)
+			default:
+				start = time.Now()
+			}
+			rec, err := buildRecurrence(*recurrence, start)
+			if err != nil {
+				return nil, err
+			}
+			task.SetRecurrence(rec)
+		}
+	}
+
+	if categories != nil {
+		task.SetCategories(*categories)
+	}
+
 	resp, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).Patch(ctx, task, nil)
 	if err != nil {
 		return nil, fmt.Errorf("updating todo task: %w", err)
@@ -335,5 +478,375 @@ func convertTodoTask(t models.TodoTaskable) TodoTask {
 	if t.GetBody() != nil && t.GetBody().GetContent() != nil {
 		task.Body = *t.GetBody().GetContent()
 	}
+	if t.GetStartDateTime() != nil && t.GetStartDateTime().GetDateTime() != nil {
+		task.StartDate = *t.GetStartDateTime().GetDateTime()
+	}
+	if t.GetIsReminderOn() != nil {
+		task.IsReminderOn = *t.GetIsReminderOn()
+	}
+	if t.GetReminderDateTime() != nil && t.GetReminderDateTime().GetDateTime() != nil {
+		task.ReminderDate = *t.GetReminderDateTime().GetDateTime()
+	}
+	if t.GetRecurrence() != nil {
+		task.Recurrence = formatRecurrence(t.GetRecurrence())
+	}
+	if t.GetCategories() != nil {
+		task.Categories = t.GetCategories()
+	}
+	if t.GetHasAttachments() != nil {
+		task.HasAttachments = *t.GetHasAttachments()
+	}
 	return task
+}
+
+// --- Checklist Item methods ---
+
+// ListChecklistItems returns all checklist items for a task.
+func (c *Client) ListChecklistItems(ctx context.Context, listID, taskID string) ([]TodoChecklistItem, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems().Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing checklist items: %w", err)
+	}
+
+	var result []TodoChecklistItem
+	for _, item := range resp.GetValue() {
+		result = append(result, convertChecklistItem(item))
+	}
+	return result, nil
+}
+
+// CreateChecklistItem creates a new checklist item on a task.
+func (c *Client) CreateChecklistItem(ctx context.Context, listID, taskID, displayName string) (*TodoChecklistItem, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+
+	item := models.NewChecklistItem()
+	item.SetDisplayName(&displayName)
+
+	created, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems().Post(ctx, item, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating checklist item: %w", err)
+	}
+
+	result := convertChecklistItem(created)
+	return &result, nil
+}
+
+// UpdateChecklistItem updates a checklist item's properties.
+func (c *Client) UpdateChecklistItem(ctx context.Context, listID, taskID, itemID string, displayName *string, isChecked *bool) (*TodoChecklistItem, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "checklist item ID"); err != nil {
+		return nil, err
+	}
+
+	item := models.NewChecklistItem()
+	if displayName != nil {
+		item.SetDisplayName(displayName)
+	}
+	if isChecked != nil {
+		item.SetIsChecked(isChecked)
+	}
+
+	updated, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems().ByChecklistItemId(itemID).Patch(ctx, item, nil)
+	if err != nil {
+		return nil, fmt.Errorf("updating checklist item: %w", err)
+	}
+
+	result := convertChecklistItem(updated)
+	return &result, nil
+}
+
+// DeleteChecklistItem deletes a checklist item.
+func (c *Client) DeleteChecklistItem(ctx context.Context, listID, taskID, itemID string) error {
+	if err := validateID(listID, "list ID"); err != nil {
+		return err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return err
+	}
+	if err := validateID(itemID, "checklist item ID"); err != nil {
+		return err
+	}
+
+	err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems().ByChecklistItemId(itemID).Delete(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("deleting checklist item: %w", err)
+	}
+	return nil
+}
+
+// ToggleChecklistItem toggles the IsChecked state of a checklist item.
+func (c *Client) ToggleChecklistItem(ctx context.Context, listID, taskID, itemID string) (*TodoChecklistItem, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "checklist item ID"); err != nil {
+		return nil, err
+	}
+
+	// Get current state
+	current, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems().ByChecklistItemId(itemID).Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting checklist item: %w", err)
+	}
+
+	// Flip the IsChecked value
+	newChecked := current.GetIsChecked() == nil || !*current.GetIsChecked()
+
+	patch := models.NewChecklistItem()
+	patch.SetIsChecked(&newChecked)
+
+	updated, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems().ByChecklistItemId(itemID).Patch(ctx, patch, nil)
+	if err != nil {
+		return nil, fmt.Errorf("toggling checklist item: %w", err)
+	}
+
+	result := convertChecklistItem(updated)
+	return &result, nil
+}
+
+func convertChecklistItem(item models.ChecklistItemable) TodoChecklistItem {
+	ci := TodoChecklistItem{}
+	if item.GetId() != nil {
+		ci.ID = *item.GetId()
+	}
+	if item.GetDisplayName() != nil {
+		ci.DisplayName = *item.GetDisplayName()
+	}
+	if item.GetIsChecked() != nil {
+		ci.IsChecked = *item.GetIsChecked()
+	}
+	if item.GetCreatedDateTime() != nil {
+		ci.CreatedAt = item.GetCreatedDateTime().Format("2006-01-02T15:04:05Z")
+	}
+	return ci
+}
+
+// --- Attachment methods ---
+
+// ListTodoAttachments returns all attachments for a task.
+func (c *Client) ListTodoAttachments(ctx context.Context, listID, taskID string) ([]TodoAttachment, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).Attachments().Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing todo attachments: %w", err)
+	}
+
+	var result []TodoAttachment
+	for _, a := range resp.GetValue() {
+		att := TodoAttachment{}
+		if a.GetId() != nil {
+			att.ID = *a.GetId()
+		}
+		if a.GetName() != nil {
+			att.Name = *a.GetName()
+		}
+		if a.GetContentType() != nil {
+			att.ContentType = *a.GetContentType()
+		}
+		if a.GetSize() != nil {
+			att.Size = *a.GetSize()
+		}
+		result = append(result, att)
+	}
+	return result, nil
+}
+
+// UploadTodoAttachment uploads a file attachment to a task.
+func (c *Client) UploadTodoAttachment(ctx context.Context, listID, taskID, name, contentType string, content []byte) (*TodoAttachment, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+
+	att := models.NewTaskFileAttachment()
+	odataType := "#microsoft.graph.taskFileAttachment"
+	att.SetOdataType(&odataType)
+	att.SetName(&name)
+	att.SetContentType(&contentType)
+	att.SetContentBytes(content)
+
+	created, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).Attachments().Post(ctx, att, nil)
+	if err != nil {
+		return nil, fmt.Errorf("uploading todo attachment: %w", err)
+	}
+
+	result := TodoAttachment{}
+	if created.GetId() != nil {
+		result.ID = *created.GetId()
+	}
+	if created.GetName() != nil {
+		result.Name = *created.GetName()
+	}
+	if created.GetContentType() != nil {
+		result.ContentType = *created.GetContentType()
+	}
+	if created.GetSize() != nil {
+		result.Size = *created.GetSize()
+	}
+	return &result, nil
+}
+
+// DownloadTodoAttachment downloads a task attachment's content.
+func (c *Client) DownloadTodoAttachment(ctx context.Context, listID, taskID, attachmentID string) (name, contentType string, content []byte, err error) {
+	if e := validateID(listID, "list ID"); e != nil {
+		return "", "", nil, e
+	}
+	if e := validateID(taskID, "task ID"); e != nil {
+		return "", "", nil, e
+	}
+	if e := validateID(attachmentID, "attachment ID"); e != nil {
+		return "", "", nil, e
+	}
+
+	att, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).Attachments().ByAttachmentBaseId(attachmentID).Get(ctx, nil)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("downloading todo attachment: %w", err)
+	}
+
+	if att.GetName() != nil {
+		name = *att.GetName()
+	}
+	if att.GetContentType() != nil {
+		contentType = *att.GetContentType()
+	}
+
+	// Type-assert to TaskFileAttachmentable to access ContentBytes
+	if fileAtt, ok := att.(models.TaskFileAttachmentable); ok {
+		content = fileAtt.GetContentBytes()
+	}
+
+	return name, contentType, content, nil
+}
+
+// DeleteTodoAttachment deletes a task attachment.
+func (c *Client) DeleteTodoAttachment(ctx context.Context, listID, taskID, attachmentID string) error {
+	if err := validateID(listID, "list ID"); err != nil {
+		return err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return err
+	}
+	if err := validateID(attachmentID, "attachment ID"); err != nil {
+		return err
+	}
+
+	err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).Attachments().ByAttachmentBaseId(attachmentID).Delete(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("deleting todo attachment: %w", err)
+	}
+	return nil
+}
+
+// --- Linked Resource methods ---
+
+// ListLinkedResources returns all linked resources for a task.
+func (c *Client) ListLinkedResources(ctx context.Context, listID, taskID string) ([]TodoLinkedResource, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).LinkedResources().Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing linked resources: %w", err)
+	}
+
+	var result []TodoLinkedResource
+	for _, r := range resp.GetValue() {
+		result = append(result, convertLinkedResource(r))
+	}
+	return result, nil
+}
+
+// CreateLinkedResource creates a new linked resource on a task.
+func (c *Client) CreateLinkedResource(ctx context.Context, listID, taskID, displayName, appName, externalID, webURL string) (*TodoLinkedResource, error) {
+	if err := validateID(listID, "list ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return nil, err
+	}
+
+	lr := models.NewLinkedResource()
+	lr.SetDisplayName(&displayName)
+	lr.SetApplicationName(&appName)
+	lr.SetExternalId(&externalID)
+	lr.SetWebUrl(&webURL)
+
+	created, err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).LinkedResources().Post(ctx, lr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating linked resource: %w", err)
+	}
+
+	result := convertLinkedResource(created)
+	return &result, nil
+}
+
+// DeleteLinkedResource deletes a linked resource from a task.
+func (c *Client) DeleteLinkedResource(ctx context.Context, listID, taskID, resourceID string) error {
+	if err := validateID(listID, "list ID"); err != nil {
+		return err
+	}
+	if err := validateID(taskID, "task ID"); err != nil {
+		return err
+	}
+	if err := validateID(resourceID, "linked resource ID"); err != nil {
+		return err
+	}
+
+	err := c.inner.Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).LinkedResources().ByLinkedResourceId(resourceID).Delete(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("deleting linked resource: %w", err)
+	}
+	return nil
+}
+
+func convertLinkedResource(r models.LinkedResourceable) TodoLinkedResource {
+	lr := TodoLinkedResource{}
+	if r.GetId() != nil {
+		lr.ID = *r.GetId()
+	}
+	if r.GetDisplayName() != nil {
+		lr.DisplayName = *r.GetDisplayName()
+	}
+	if r.GetApplicationName() != nil {
+		lr.ApplicationName = *r.GetApplicationName()
+	}
+	if r.GetExternalId() != nil {
+		lr.ExternalID = *r.GetExternalId()
+	}
+	if r.GetWebUrl() != nil {
+		lr.WebURL = *r.GetWebUrl()
+	}
+	return lr
 }


### PR DESCRIPTION
## Summary
- **Checklist items**: list, create, toggle, update, delete sub-commands (`todo checklist`)
- **File attachments**: list, upload, download, delete sub-commands (`todo attach`) with upload/download size limits
- **Linked resources**: list, create, delete sub-commands (`todo links`) with URL scheme validation
- **Extended task fields**: start date, reminder, recurrence, categories on create/update/get
- **Security hardening**: pre-check file size before read, sanitize all IDs/enums in table output, download size validation
- **Lint fix**: KQL search quoting in mail.go

## Test plan
- [x] All 20 todo tests pass on consumer account (rramesan@outlook.com)
- [x] All 20 todo tests pass on enterprise account (roshinlal@nextgenchannels.onmicrosoft.com)
- [x] Mail search verified on both accounts after KQL quoting change
- [x] `go build`, `go vet`, `make lint` all clean (0 issues)
- [x] Security audit completed — 3 medium findings fixed, 1 low fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)