### PR TITLE
feat: add user-configurable timezone support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - `internal/graphapi/`: Microsoft Graph API wrapper — mail, calendar, contacts, todo (tasks, checklist items, attachments, linked resources), availability, mailbox settings, mail rules, people.
 - `internal/config/`: Configuration and XDG paths (`~/.config/olk/`).
 - `internal/secrets/`: OS keyring integration via `99designs/keyring`.
-- `internal/outfmt/`: Output formatting — JSON envelope, aligned tables, TSV.
+- `internal/outfmt/`: Output formatting — JSON envelope, aligned tables, TSV, timezone conversion via `ConvertTime()`.
 - `internal/errfmt/`: Graph API error mapping to actionable user messages.
 - `SKILL.md`: [Agent Skills](https://agentskills.io) standard file — teaches AI assistants (Claude Code, OpenClaw, etc.) how to use `olk` commands.
 - `bin/`: build outputs (gitignored).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ go mod tidy         # After changing dependencies
 - **API**: Official `msgraph-sdk-go` wrapped in `internal/graphapi/` for ergonomic access
 - **Secrets**: OS keyring via `github.com/99designs/keyring` (macOS Keychain, Linux Secret Service, Windows WinCred)
 - **Output**: JSON envelope (`--json`), aligned table (default), TSV (`--plain`)
+- **Timezone**: Display-layer conversion via `outfmt.ConvertTime()`. Resolved once per command via `RunContext.Timezone()` (flag > env > config > Local). JSON output keeps raw UTC; envelope includes `timezone` field. IANA db embedded via `import _ "time/tzdata"`
 
 ## Key Patterns
 
@@ -55,6 +56,11 @@ go mod tidy         # After changing dependencies
 
 ### Adding a new flag to all commands
 Add it to `RootFlags` in `internal/cmd/root.go` with `env:"OLK_*"` tag.
+
+### Adding timezone conversion to a new command
+1. Get the location: `loc, _ := ctx.Timezone()`
+2. Wrap time fields: `outfmt.ConvertTime(field, loc)`
+3. Only convert for table/plain output — JSON keeps raw UTC strings
 
 ### Changing Graph API calls
 Edit files in `internal/graphapi/` — these wrap the verbose SDK calls into simple methods returning plain structs.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ For common workflows, `olk` provides top-level shortcuts:
 | `--color auto\|never\|always` | `OLK_COLOR` | Color mode |
 | `--select FIELDS` | `OLK_SELECT` | Field projection |
 | `--results-only` | `OLK_RESULTS_ONLY` | Unwrap JSON envelope |
+| `--tz TIMEZONE` | `OLK_TIMEZONE` | IANA time zone for display (e.g. `America/New_York`) |
 
 ## Commands Reference
 
@@ -342,6 +343,13 @@ olk todo links create <TASK_ID> -n "Name" --url "URL" [--list ID]   Create a lin
 olk todo links delete <TASK_ID> <RESOURCE_ID> --force [--list ID]   Delete a linked resource
 ```
 
+### Configuration
+
+```
+olk config set timezone America/New_York             Set display timezone
+olk config get timezone                              Get current timezone setting
+```
+
 ### User Profile
 
 ```
@@ -360,6 +368,23 @@ Config is stored at `~/.config/olk/`:
 ```
 
 Override the config directory with `OLK_CONFIG_DIR`.
+
+### Timezone
+
+By default, times are displayed in your system's local timezone. You can override this:
+
+```bash
+# Per-command
+olk calendar events --tz America/New_York
+
+# Via environment variable
+export OLK_TIMEZONE=Europe/London
+
+# Persistent (saved to config)
+olk config set timezone America/Chicago
+```
+
+Precedence: `--tz` flag > `OLK_TIMEZONE` env var > config file > system local timezone. JSON output always contains raw UTC strings; the `timezone` field in the envelope indicates the display timezone.
 
 ## Scripting Examples
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -173,6 +173,13 @@ Linked Resources
 
 If `--list` is omitted, the default (first) task list is used automatically.
 
+Configuration
+
+- Set timezone: `olk config set timezone America/New_York`
+- Get timezone: `olk config get timezone`
+- Timezone precedence: `--tz` flag > `OLK_TIMEZONE` env > config file > system local
+- JSON output keeps raw UTC times; envelope includes `"timezone"` field
+
 User Profile
 
 - `olk whoami` — display current user's name, email, job title, department, office, phone
@@ -206,6 +213,7 @@ Global Flags
 - `-v, --verbose` — verbose output (env: `OLK_VERBOSE`)
 - `--color auto|never|always` — color mode (env: `OLK_COLOR`)
 - `--timeout SECONDS` — request timeout, default 60 (env: `OLK_TIMEOUT`)
+- `--tz TIMEZONE` — IANA time zone for display, e.g. `America/New_York`, `UTC`, `Local` (env: `OLK_TIMEZONE`)
 
 Scripting Examples
 
@@ -226,6 +234,7 @@ Scripting Examples
 
 Notes
 
+- Set `OLK_TIMEZONE=America/New_York` to display times in your timezone.
 - Set `OLK_ACCOUNT=you@example.com` to avoid repeating `--account`.
 - Set `OLK_TODO_LIST=<list-id>` to avoid repeating `--list` for todo commands.
 - For scripting, prefer `--json --results-only` plus `jq`.

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -76,14 +76,15 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(events, len(events), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "SUBJECT", "START", "END", "LOCATION", "STATUS", "RECURRENCE"}
 	var rows [][]string
 	for i := range events {
 		e := &events[i]
 		id := outfmt.Truncate(e.ID, 15)
 		subject := outfmt.Truncate(e.Subject, 40)
-		startStr := outfmt.Truncate(e.Start, 16)
-		endStr := outfmt.Truncate(e.End, 16)
+		startStr := outfmt.Truncate(outfmt.ConvertTime(e.Start, loc), 16)
+		endStr := outfmt.Truncate(outfmt.ConvertTime(e.End, loc), 16)
 		rows = append(rows, []string{id, subject, startStr, endStr, e.Location, e.Status, e.Recurrence})
 	}
 
@@ -110,9 +111,10 @@ func (c *CalendarGetCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(event, 1, "")
 	}
 
+	loc, _ := ctx.Timezone()
 	fmt.Printf("Subject:   %s\n", outfmt.Sanitize(event.Subject))
-	fmt.Printf("Start:     %s\n", outfmt.Sanitize(event.Start))
-	fmt.Printf("End:       %s\n", outfmt.Sanitize(event.End))
+	fmt.Printf("Start:     %s\n", outfmt.Sanitize(outfmt.ConvertTime(event.Start, loc)))
+	fmt.Printf("End:       %s\n", outfmt.Sanitize(outfmt.ConvertTime(event.End, loc)))
 	fmt.Printf("Location:  %s\n", outfmt.Sanitize(event.Location))
 	fmt.Printf("Organizer: %s\n", outfmt.Sanitize(event.Organizer))
 	fmt.Printf("Status:    %s\n", outfmt.Sanitize(event.Status))

--- a/internal/cmd/calendar_availability.go
+++ b/internal/cmd/calendar_availability.go
@@ -62,6 +62,7 @@ func (c *CalendarAvailabilityCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(schedules, len(schedules), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"EMAIL", "STATUS", "START", "END", "SUBJECT"}
 	var rows [][]string
 	for _, sched := range schedules {
@@ -73,8 +74,8 @@ func (c *CalendarAvailabilityCmd) Run(ctx *RunContext) error {
 			rows = append(rows, []string{
 				sched.Email,
 				item.Status,
-				outfmt.Truncate(item.Start, 16),
-				outfmt.Truncate(item.End, 16),
+				outfmt.Truncate(outfmt.ConvertTime(item.Start, loc), 16),
+				outfmt.Truncate(outfmt.ConvertTime(item.End, loc), 16),
 				outfmt.Truncate(item.Subject, 40),
 			})
 		}

--- a/internal/cmd/calendar_find_times.go
+++ b/internal/cmd/calendar_find_times.go
@@ -57,6 +57,7 @@ func (c *CalendarFindTimesCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(suggestions, len(suggestions), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"START", "END", "CONFIDENCE", "ATTENDEE AVAILABILITY"}
 	var rows [][]string
 	for _, s := range suggestions {
@@ -65,8 +66,8 @@ func (c *CalendarFindTimesCmd) Run(ctx *RunContext) error {
 			avails = append(avails, fmt.Sprintf("%s:%s", a.Email, a.Availability))
 		}
 		rows = append(rows, []string{
-			outfmt.Truncate(s.Start, 16),
-			outfmt.Truncate(s.End, 16),
+			outfmt.Truncate(outfmt.ConvertTime(s.Start, loc), 16),
+			outfmt.Truncate(outfmt.ConvertTime(s.End, loc), 16),
 			fmt.Sprintf("%.0f%%", s.Confidence*100),
 			strings.Join(avails, ", "),
 		})

--- a/internal/cmd/calendar_view.go
+++ b/internal/cmd/calendar_view.go
@@ -56,14 +56,15 @@ func (c *CalendarViewCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(events, len(events), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "SUBJECT", "START", "END", "LOCATION", "STATUS", "RECURRENCE"}
 	var rows [][]string
 	for i := range events {
 		e := &events[i]
 		id := outfmt.Truncate(e.ID, 15)
 		subject := outfmt.Truncate(e.Subject, 40)
-		startStr := outfmt.Truncate(e.Start, 16)
-		endStr := outfmt.Truncate(e.End, 16)
+		startStr := outfmt.Truncate(outfmt.ConvertTime(e.Start, loc), 16)
+		endStr := outfmt.Truncate(outfmt.ConvertTime(e.End, loc), 16)
 		rows = append(rows, []string{id, subject, startStr, endStr, outfmt.Sanitize(e.Location), e.Status, e.Recurrence})
 	}
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// ConfigCmd manages persistent configuration settings.
+type ConfigCmd struct {
+	Set ConfigSetCmd `cmd:"" help:"Set a configuration value"`
+	Get ConfigGetCmd `cmd:"" help:"Get a configuration value"`
+}
+
+// ConfigSetCmd sets a configuration key.
+type ConfigSetCmd struct {
+	Key   string `arg:"" help:"Configuration key (e.g. timezone)" enum:"timezone"`
+	Value string `arg:"" help:"Value to set"`
+}
+
+func (c *ConfigSetCmd) Run(ctx *RunContext) error {
+	cfg, err := ctx.Config()
+	if err != nil {
+		return err
+	}
+
+	switch c.Key {
+	case "timezone":
+		if _, err := time.LoadLocation(c.Value); err != nil {
+			return fmt.Errorf("invalid timezone %q: %w", c.Value, err)
+		}
+		cfg.SetTimezone(c.Value)
+	default:
+		return fmt.Errorf("unknown config key: %s", c.Key)
+	}
+
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+
+	fmt.Printf("%s = %s\n", c.Key, outfmt.Sanitize(c.Value))
+	return nil
+}
+
+// ConfigGetCmd reads a configuration key.
+type ConfigGetCmd struct {
+	Key string `arg:"" help:"Configuration key (e.g. timezone)" enum:"timezone"`
+}
+
+func (c *ConfigGetCmd) Run(ctx *RunContext) error {
+	cfg, err := ctx.Config()
+	if err != nil {
+		return err
+	}
+
+	switch c.Key {
+	case "timezone":
+		v := cfg.GetTimezone()
+		if v == "" {
+			v = "Local (not set)"
+		}
+		fmt.Println(outfmt.Sanitize(v))
+	default:
+		return fmt.Errorf("unknown config key: %s", c.Key)
+	}
+
+	return nil
+}

--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -39,13 +39,14 @@ func (c *MailDraftsListCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(drafts, len(drafts), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "SUBJECT", "TO", "CREATED"}
 	var rows [][]string
 	for _, d := range drafts {
 		id := outfmt.Truncate(d.ID, 15)
 		subject := outfmt.Truncate(d.Subject, 60)
 		to := outfmt.Truncate(strings.Join(d.To, ", "), 40)
-		created := outfmt.Truncate(d.Created, 16)
+		created := outfmt.Truncate(outfmt.ConvertTime(d.Created, loc), 16)
 		rows = append(rows, []string{id, subject, to, created})
 	}
 

--- a/internal/cmd/mail_get.go
+++ b/internal/cmd/mail_get.go
@@ -28,10 +28,11 @@ func (c *MailGetCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(msg, 1, "")
 	}
 
+	loc, _ := ctx.Timezone()
 	fmt.Printf("From:    %s\n", outfmt.Sanitize(msg.From))
 	fmt.Printf("To:      %s\n", outfmt.Sanitize(strings.Join(msg.To, ", ")))
 	fmt.Printf("Subject: %s\n", outfmt.Sanitize(msg.Subject))
-	fmt.Printf("Date:    %s\n", outfmt.Sanitize(msg.ReceivedAt))
+	fmt.Printf("Date:    %s\n", outfmt.Sanitize(outfmt.ConvertTime(msg.ReceivedAt, loc)))
 	fmt.Printf("Read:    %v\n", msg.IsRead)
 	fmt.Println(strings.Repeat("-", 60))
 

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -61,6 +61,7 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(messages, len(messages), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "FROM", "SUBJECT", "DATE", "READ", "ATTACH"}
 	var rows [][]string
 	for i := range messages {
@@ -74,7 +75,7 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 			attach = "Y"
 		}
 		subject := outfmt.Truncate(m.Subject, 60)
-		date := outfmt.Truncate(m.ReceivedAt, 16)
+		date := outfmt.Truncate(outfmt.ConvertTime(m.ReceivedAt, loc), 16)
 		id := outfmt.Truncate(m.ID, 15)
 		rows = append(rows, []string{id, m.From, subject, date, read, attach})
 	}

--- a/internal/cmd/mail_ooo.go
+++ b/internal/cmd/mail_ooo.go
@@ -35,6 +35,7 @@ func (c *MailOOOGetCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(settings, 1, "")
 	}
 
+	loc, _ := ctx.Timezone()
 	fmt.Printf("Status:            %s\n", outfmt.Sanitize(settings.Status))
 	fmt.Printf("External Audience: %s\n", outfmt.Sanitize(settings.ExternalAudience))
 	if settings.InternalMessage != "" {
@@ -44,10 +45,10 @@ func (c *MailOOOGetCmd) Run(ctx *RunContext) error {
 		fmt.Printf("External Message:  %s\n", outfmt.Sanitize(settings.ExternalMessage))
 	}
 	if settings.StartTime != "" {
-		fmt.Printf("Start:             %s\n", outfmt.Sanitize(settings.StartTime))
+		fmt.Printf("Start:             %s\n", outfmt.Sanitize(outfmt.ConvertTime(settings.StartTime, loc)))
 	}
 	if settings.EndTime != "" {
-		fmt.Printf("End:               %s\n", outfmt.Sanitize(settings.EndTime))
+		fmt.Printf("End:               %s\n", outfmt.Sanitize(outfmt.ConvertTime(settings.EndTime, loc)))
 	}
 
 	return nil

--- a/internal/cmd/mail_search.go
+++ b/internal/cmd/mail_search.go
@@ -23,12 +23,13 @@ func (c *MailSearchCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(messages, len(messages), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "FROM", "SUBJECT", "DATE"}
 	var rows [][]string
 	for i := range messages {
 		m := &messages[i]
 		id := outfmt.Truncate(m.ID, 15)
-		date := outfmt.Truncate(m.ReceivedAt, 16)
+		date := outfmt.Truncate(outfmt.ConvertTime(m.ReceivedAt, loc), 16)
 		subject := outfmt.Truncate(m.Subject, 60)
 		rows = append(rows, []string{id, m.From, subject, date})
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/alecthomas/kong"
 
@@ -32,6 +33,7 @@ type RootFlags struct {
 	Select      string `help:"Comma-separated fields to output" env:"OLK_SELECT"`
 	ResultsOnly bool   `help:"Output only the results array (no envelope)" env:"OLK_RESULTS_ONLY"`
 	Timeout     int    `help:"Request timeout in seconds" default:"60" env:"OLK_TIMEOUT"`
+	TimeZone    string `help:"IANA time zone for display (e.g. America/New_York, Local, UTC)" name:"tz" env:"OLK_TIMEZONE"`
 }
 
 type RunContext struct {
@@ -126,9 +128,28 @@ func (r *RunContext) GraphClient() (*graphapi.Client, error) {
 	return client, nil
 }
 
+// Timezone returns the resolved time.Location for display.
+// Precedence: --tz flag > OLK_TIMEZONE env > config file > Local.
+func (r *RunContext) Timezone() (*time.Location, error) {
+	tz := r.Flags.TimeZone
+	if tz == "" {
+		if cfg, err := r.Config(); err == nil {
+			tz = cfg.GetTimezone()
+		}
+	}
+	if tz == "" {
+		tz = "Local"
+	}
+	return time.LoadLocation(tz)
+}
+
 // Printer returns an output printer based on flags
 func (r *RunContext) Printer() *outfmt.Printer {
-	return outfmt.NewPrinter(r.Flags.JSON, r.Flags.Plain, r.Flags.ResultsOnly, r.Flags.Select)
+	tzName := "Local"
+	if loc, err := r.Timezone(); err == nil {
+		tzName = loc.String()
+	}
+	return outfmt.NewPrinter(r.Flags.JSON, r.Flags.Plain, r.Flags.ResultsOnly, r.Flags.Select, tzName)
 }
 
 type CLI struct {
@@ -140,6 +161,7 @@ type CLI struct {
 	Contacts ContactsCmd `cmd:"" help:"Contacts commands"`
 	Todo     TodoCmd     `cmd:"" help:"Microsoft To Do tasks"`
 	People   PeopleCmd   `cmd:"" help:"People directory search"`
+	Config   ConfigCmd   `cmd:"" help:"Configuration management"`
 	Version  VersionCmd  `cmd:"" help:"Show version information"`
 	Whoami   WhoamiCmd   `cmd:"" help:"Show current user profile"`
 

--- a/internal/cmd/todo.go
+++ b/internal/cmd/todo.go
@@ -169,6 +169,7 @@ func (c *TodoListCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(tasks, len(tasks), "")
 	}
 
+	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "TITLE", "STATUS", "IMPORTANCE", "DUE"}
 	var rows [][]string
 	for i := range tasks {
@@ -178,7 +179,7 @@ func (c *TodoListCmd) Run(ctx *RunContext) error {
 			outfmt.Truncate(outfmt.Sanitize(t.Title), 50),
 			outfmt.Sanitize(t.Status),
 			outfmt.Sanitize(t.Importance),
-			outfmt.Truncate(outfmt.Sanitize(t.DueDate), 16),
+			outfmt.Truncate(outfmt.Sanitize(outfmt.ConvertTime(t.DueDate, loc)), 16),
 		})
 	}
 
@@ -212,19 +213,20 @@ func (c *TodoGetCmd) Run(ctx *RunContext) error {
 		return printer.PrintJSON(task, 1, "")
 	}
 
+	loc, _ := ctx.Timezone()
 	fmt.Printf("ID:          %s\n", outfmt.Sanitize(task.ID))
 	fmt.Printf("Title:       %s\n", outfmt.Sanitize(task.Title))
 	fmt.Printf("Status:      %s\n", outfmt.Sanitize(task.Status))
 	fmt.Printf("Importance:  %s\n", outfmt.Sanitize(task.Importance))
-	fmt.Printf("Created:     %s\n", outfmt.Sanitize(task.CreatedAt))
+	fmt.Printf("Created:     %s\n", outfmt.Sanitize(outfmt.ConvertTime(task.CreatedAt, loc)))
 	if task.DueDate != "" {
-		fmt.Printf("Due:         %s\n", outfmt.Sanitize(task.DueDate))
+		fmt.Printf("Due:         %s\n", outfmt.Sanitize(outfmt.ConvertTime(task.DueDate, loc)))
 	}
 	if task.StartDate != "" {
-		fmt.Printf("Start:       %s\n", outfmt.Sanitize(task.StartDate))
+		fmt.Printf("Start:       %s\n", outfmt.Sanitize(outfmt.ConvertTime(task.StartDate, loc)))
 	}
 	if task.IsReminderOn {
-		fmt.Printf("Reminder:    %s\n", outfmt.Sanitize(task.ReminderDate))
+		fmt.Printf("Reminder:    %s\n", outfmt.Sanitize(outfmt.ConvertTime(task.ReminderDate, loc)))
 	}
 	if task.Recurrence != "" {
 		fmt.Printf("Recurrence:  %s\n", outfmt.Sanitize(task.Recurrence))
@@ -233,7 +235,7 @@ func (c *TodoGetCmd) Run(ctx *RunContext) error {
 		fmt.Printf("Categories:  %s\n", outfmt.Sanitize(strings.Join(task.Categories, ", ")))
 	}
 	if task.CompletedAt != "" {
-		fmt.Printf("Completed:   %s\n", outfmt.Sanitize(task.CompletedAt))
+		fmt.Printf("Completed:   %s\n", outfmt.Sanitize(outfmt.ConvertTime(task.CompletedAt, loc)))
 	}
 	if task.HasAttachments {
 		fmt.Printf("Attachments: Yes\n")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	DefaultAccount string            `json:"default_account,omitempty"`
 	Clients        map[string]Client `json:"clients,omitempty"`
+	Timezone       string            `json:"timezone,omitempty"`
 	mu             sync.RWMutex
 }
 
@@ -154,6 +155,20 @@ func (c *Config) GetClient(email string) Client {
 		ClientID: DefaultClientID,
 		TenantID: DefaultTenantID,
 	}
+}
+
+// SetTimezone sets the display timezone
+func (c *Config) SetTimezone(tz string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Timezone = tz
+}
+
+// GetTimezone returns the configured display timezone
+func (c *Config) GetTimezone() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Timezone
 }
 
 // RemoveAccount removes an account from config

--- a/internal/outfmt/outfmt.go
+++ b/internal/outfmt/outfmt.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 	"unicode"
 )
 
@@ -23,6 +24,7 @@ type Envelope struct {
 	Results  interface{} `json:"results"`
 	Count    int         `json:"count"`
 	NextLink string      `json:"nextLink,omitempty"`
+	Timezone string      `json:"timezone,omitempty"`
 }
 
 // Printer handles output formatting
@@ -31,10 +33,11 @@ type Printer struct {
 	Writer      io.Writer
 	Select      string // comma-separated field names
 	ResultsOnly bool
+	Timezone    string // IANA timezone name for JSON envelope metadata
 }
 
 // NewPrinter creates a printer from flags
-func NewPrinter(jsonFlag, plainFlag, resultsOnly bool, selectFields string) *Printer {
+func NewPrinter(jsonFlag, plainFlag, resultsOnly bool, selectFields, timezone string) *Printer {
 	f := FormatTable
 	if jsonFlag {
 		f = FormatJSON
@@ -46,6 +49,7 @@ func NewPrinter(jsonFlag, plainFlag, resultsOnly bool, selectFields string) *Pri
 		Writer:      os.Stdout,
 		Select:      selectFields,
 		ResultsOnly: resultsOnly,
+		Timezone:    timezone,
 	}
 }
 
@@ -60,6 +64,7 @@ func (p *Printer) PrintJSON(results interface{}, count int, nextLink string) err
 		Results:  results,
 		Count:    count,
 		NextLink: nextLink,
+		Timezone: p.Timezone,
 	})
 }
 
@@ -191,4 +196,38 @@ func SanitizeMultiline(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// ConvertTime parses a UTC time string and converts it to the given location.
+// For date-only inputs, returns "2006-01-02". For datetime inputs, returns
+// "2006-01-02 15:04". Returns the original string unchanged if loc is nil or
+// parsing fails.
+func ConvertTime(utcStr string, loc *time.Location) string {
+	if loc == nil || utcStr == "" {
+		return utcStr
+	}
+
+	formats := []struct {
+		layout   string
+		dateOnly bool
+	}{
+		{time.RFC3339, false},
+		{"2006-01-02T15:04:05.0000000", false},
+		{"2006-01-02T15:04:05", false},
+		{"2006-01-02T15:04", false},
+		{"2006-01-02", true},
+	}
+
+	for _, f := range formats {
+		t, err := time.Parse(f.layout, utcStr)
+		if err != nil {
+			continue
+		}
+		if f.dateOnly {
+			return t.In(loc).Format("2006-01-02")
+		}
+		return t.In(loc).Format("2006-01-02 15:04")
+	}
+
+	return utcStr
 }


### PR DESCRIPTION
## Summary

- Add `--tz` global flag, `OLK_TIMEZONE` env var, and `olk config set timezone` for persistent timezone configuration
- Convert all time fields in table/plain output to the user's preferred timezone (precedence: flag > env > config > system local)
- JSON output preserves raw UTC strings; envelope includes `"timezone"` metadata field
- New `olk config set/get` command for managing persistent settings
- Embeds IANA timezone database (`time/tzdata`) for portability on minimal systems

## Changed files

| File | Change |
|------|--------|
| `internal/config/config.go` | `Timezone` field + `Get/SetTimezone()` accessors |
| `internal/cmd/root.go` | `--tz` flag, `Timezone()` resolver, `import _ "time/tzdata"`, updated `Printer()` |
| `internal/outfmt/outfmt.go` | `ConvertTime()` utility, `Timezone` in `Printer`/`Envelope`, updated `NewPrinter` |
| `internal/cmd/config.go` | **New** — `config set timezone` / `config get timezone` with validation + sanitized output |
| `internal/cmd/calendar.go` | Convert Start/End in events list + get detail |
| `internal/cmd/calendar_view.go` | Convert Start/End |
| `internal/cmd/calendar_availability.go` | Convert Start/End |
| `internal/cmd/calendar_find_times.go` | Convert Start/End |
| `internal/cmd/mail_list.go` | Convert ReceivedAt |
| `internal/cmd/mail_search.go` | Convert ReceivedAt |
| `internal/cmd/mail_get.go` | Convert ReceivedAt |
| `internal/cmd/mail_drafts.go` | Convert Created |
| `internal/cmd/mail_ooo.go` | Convert StartTime/EndTime |
| `internal/cmd/todo.go` | Convert DueDate (list), CreatedAt/DueDate/CompletedAt (detail) |
| `README.md` | Document `--tz`, `OLK_TIMEZONE`, `config set timezone`, timezone section |
| `SKILL.md` | Add `--tz` flag, config section, timezone notes |
| `CLAUDE.md` | Architecture + Common Tasks timezone notes |
| `AGENTS.md` | Updated outfmt description |

## Security audit

- `config set` and `config get` output sanitized via `outfmt.Sanitize()` (terminal escape injection)
- `time.LoadLocation()` validates all timezone input — rejects path traversal and invalid names
- `ConvertTime()` gracefully returns original string on parse failure; all callers sanitize before terminal output
- JSON envelope timezone field always comes from validated `LoadLocation` output or `"Local"` literal

## Test plan

Tested manually on both personal (`rramesan@outlook.com`) and enterprise (`roshinlal@nextgenchannels.onmicrosoft.com`) accounts:

- [x] `olk mail list --tz America/New_York` — times shift to ET
- [x] `olk mail list --tz UTC` — times stay UTC
- [x] `olk mail get --tz` — Date field converts
- [x] `olk mail search --tz` — Date field converts
- [x] `olk mail drafts list --tz` — Created field converts
- [x] `olk mail ooo get --tz` — Start/End convert
- [x] `olk calendar events --tz` — Start/End convert (verified UTC vs ET vs IST)
- [x] `olk calendar get --tz` — Start/End convert
- [x] `olk calendar view --tz` — Start/End convert
- [x] `olk calendar availability --tz` — Start/End convert
- [x] `olk calendar find-times --tz` — Start/End convert
- [x] `olk todo list --tz` — DueDate converts
- [x] `olk todo get --tz` — Created/Due/Completed convert
- [x] `olk config set timezone America/New_York` — saves, validates
- [x] `olk config get timezone` — reads saved value
- [x] `olk config set timezone Fake/Zone` — rejected with error
- [x] Config auto-use (no flag) — uses saved timezone
- [x] `OLK_TIMEZONE=Europe/London` env var — overrides config
- [x] `--tz UTC` overrides `OLK_TIMEZONE=Europe/London` — flag wins
- [x] `--json` output — raw UTC preserved, `"timezone"` in envelope
- [x] Path traversal (`../../etc/passwd`) — rejected by `LoadLocation`
- [x] `make build` — passes
- [x] `make test` — passes
- [x] `make lint` — passes (pre-existing issue in `graphapi/mail.go` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)