### PR TITLE
fix: address audit findings — KQL, todo clearing, warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,5 +57,5 @@
 - Config dir (`~/.config/olk/`) uses 0700 permissions; token files use 0600.
 - Device code flow uses PKCE (RFC 7636) — `code_challenge` sent with device code request, `code_verifier` sent during token polling.
 - Token refresh is serialized per-email via `sync.Map` of mutexes in `internal/msauth/auth.go` to prevent race conditions.
-- KQL search queries are sanitized by stripping special characters (`"`, `:`, `(`, `)`, `&`, `|`, `!`, `*`, `\`) in `internal/graphapi/mail.go`.
+- KQL search queries support property restrictions (`from:`, `subject:`, etc.) and boolean operators. Only literal double-quote characters are stripped to prevent syntax injection. Plain keyword queries are auto-wrapped in double quotes; queries containing KQL operators are passed through as-is. See `internal/graphapi/mail.go`.
 - See `SECURITY.md` for vulnerability disclosure policy.

--- a/internal/cmd/desire_paths.go
+++ b/internal/cmd/desire_paths.go
@@ -9,6 +9,7 @@ type SendCmd struct {
 	BCC         []string `help:"BCC recipients"`
 	HTML        bool     `help:"Send body as HTML"`
 	Attach      []string `help:"File paths to attach" type:"path"`
+	Importance  string   `help:"Message importance: low|normal|high" enum:",low,normal,high" default:""`
 	ReadReceipt bool     `help:"Request a read receipt"`
 }
 
@@ -21,6 +22,7 @@ func (c *SendCmd) Run(ctx *RunContext) error {
 		BCC:         c.BCC,
 		HTML:        c.HTML,
 		Attach:      c.Attach,
+		Importance:  c.Importance,
 		ReadReceipt: c.ReadReceipt,
 	}
 	return inner.Run(ctx)

--- a/internal/cmd/mail_categorize.go
+++ b/internal/cmd/mail_categorize.go
@@ -14,7 +14,7 @@ type MailCategorizeCmd struct {
 
 func (c *MailCategorizeCmd) Run(ctx *RunContext) error {
 	// Allow clearing categories with --categories none or --categories ""
-	clearCats := len(c.Categories) == 1 && (c.Categories[0] == "none" || c.Categories[0] == "")
+	clearCats := len(c.Categories) == 1 && (c.Categories[0] == clearSentinel || c.Categories[0] == "")
 	if clearCats {
 		c.Categories = []string{}
 	} else {

--- a/internal/cmd/mail_search.go
+++ b/internal/cmd/mail_search.go
@@ -3,7 +3,7 @@ package cmd
 import "github.com/rlrghb/olkcli/internal/outfmt"
 
 type MailSearchCmd struct {
-	Query string `arg:"" help:"Search query (KQL syntax)"`
+	Query string `arg:"" help:"Search query — supports KQL operators (from:, subject:, hasAttachment:, etc.)"`
 	Top   int32  `help:"Number of results" default:"25" short:"n"`
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -194,6 +194,7 @@ func Execute() int {
 		timeout = 60
 	}
 	if timeout > 600 {
+		fmt.Fprintf(os.Stderr, "warning: --timeout %d exceeds maximum, clamping to 600s\n", timeout)
 		timeout = 600
 	}
 	var cancel context.CancelFunc

--- a/internal/cmd/todo.go
+++ b/internal/cmd/todo.go
@@ -21,6 +21,9 @@ type TodoCmd struct {
 	Links     TodoLinksCmd     `cmd:"" help:"Linked resource operations"`
 }
 
+// clearSentinel is the value users pass to clear optional fields (e.g. --due none).
+const clearSentinel = "none"
+
 // resolveListID returns the provided listID, or auto-detects the default task list.
 func resolveListID(ctx *RunContext, listID string) (string, error) {
 	if listID != "" {
@@ -343,10 +346,10 @@ type TodoUpdateCmd struct {
 	ID         string   `arg:"" help:"Task ID"`
 	List       string   `help:"Task list ID" env:"OLK_TODO_LIST"`
 	Title      string   `help:"New title" short:"t"`
-	Due        string   `help:"New due date (ISO 8601, empty string to clear)" short:"d"`
-	Start      string   `help:"New start date (ISO 8601, empty string to clear)" short:"s"`
-	Reminder   string   `help:"New reminder date/time (ISO 8601, empty string to clear)"`
-	Recurrence string   `help:"New recurrence pattern (empty string to clear)" enum:"daily,weekdays,weekly,monthly,yearly," default:""`
+	Due        string   `help:"New due date (ISO 8601, or 'none' to clear)" short:"d"`
+	Start      string   `help:"New start date (ISO 8601, or 'none' to clear)" short:"s"`
+	Reminder   string   `help:"New reminder date/time (ISO 8601, or 'none' to clear)"`
+	Recurrence string   `help:"New recurrence pattern, or 'none' to clear" enum:"daily,weekdays,weekly,monthly,yearly,none," default:""`
 	Importance string   `help:"New importance level" enum:"low,normal,high," default:""`
 	Body       string   `help:"New body text" short:"b"`
 	Categories []string `help:"New categories (use -c none to clear)" short:"c"`
@@ -365,7 +368,12 @@ func (c *TodoUpdateCmd) Run(ctx *RunContext) error {
 		title = &c.Title
 	}
 	if c.Due != "" {
-		due = &c.Due
+		if c.Due == clearSentinel {
+			empty := ""
+			due = &empty
+		} else {
+			due = &c.Due
+		}
 	}
 	if c.Importance != "" {
 		importance = &c.Importance
@@ -374,16 +382,31 @@ func (c *TodoUpdateCmd) Run(ctx *RunContext) error {
 		body = &c.Body
 	}
 	if c.Start != "" {
-		start = &c.Start
+		if c.Start == clearSentinel {
+			empty := ""
+			start = &empty
+		} else {
+			start = &c.Start
+		}
 	}
 	if c.Reminder != "" {
-		reminder = &c.Reminder
+		if c.Reminder == clearSentinel {
+			empty := ""
+			reminder = &empty
+		} else {
+			reminder = &c.Reminder
+		}
 	}
 	if c.Recurrence != "" {
-		recurrence = &c.Recurrence
+		if c.Recurrence == clearSentinel {
+			empty := ""
+			recurrence = &empty
+		} else {
+			recurrence = &c.Recurrence
+		}
 	}
 	if len(c.Categories) > 0 {
-		if len(c.Categories) == 1 && c.Categories[0] == "none" {
+		if len(c.Categories) == 1 && c.Categories[0] == clearSentinel {
 			empty := []string{}
 			categories = &empty
 		} else {

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -442,36 +442,37 @@ func (c *Client) DeleteMailFolder(ctx context.Context, folderID string) error {
 	return nil
 }
 
-// sanitizeKQL strips characters that have special meaning in Microsoft Graph
-// KQL $search expressions. The query is wrapped in double quotes by the caller,
-// so we must remove literal double quotes and also strip KQL operators/syntax
-// characters to prevent query injection. This is the user's own mailbox, so
-// the impact is low, but defense-in-depth is worthwhile.
-func sanitizeKQL(query string) string {
-	// Remove characters with special KQL semantics:
-	//   "  — would break out of the quoted string
-	//   :  — property restriction operator (e.g., from:, subject:)
-	//   (  — grouping
-	//   )  — grouping
-	//   &  — AND operator
-	//   |  — OR operator
-	//   !  — NOT operator
-	//   *  — wildcard
-	//   \  — escape character
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case '"', ':', '(', ')', '&', '|', '!', '*', '\\':
-			return -1 // drop
-		default:
-			return r
+// isKQLQuery returns true when query contains KQL syntax — either punctuation
+// operators (:, (, ), &, |, !, *) or keyword operators (AND, OR, NOT).
+func isKQLQuery(query string) bool {
+	if strings.ContainsAny(query, ":()&|!*") {
+		return true
+	}
+	for _, word := range strings.Fields(query) {
+		switch word {
+		case "AND", "OR", "NOT":
+			return true
 		}
-	}, query)
+	}
+	return false
 }
 
 func (c *Client) SearchMessages(ctx context.Context, query string, top int32) ([]MailMessage, error) {
+	var search string
+	if isKQLQuery(query) {
+		// KQL query — pass through as-is so property restrictions, boolean
+		// operators, and quoted phrases (e.g. subject:"quarterly report")
+		// all work. This is the user's own mailbox, so the impact of any
+		// query manipulation is limited to their own search results.
+		search = query
+	} else {
+		// Plain keyword search — wrap in quotes for phrase matching.
+		// Strip any literal double quotes to prevent breaking the wrapper.
+		search = `"` + strings.ReplaceAll(query, `"`, "") + `"`
+	}
 	return c.ListMessages(ctx, &ListMessagesOptions{
 		Top:    top,
-		Search: `"` + sanitizeKQL(query) + `"`,
+		Search: search,
 	})
 }
 

--- a/internal/msauth/auth.go
+++ b/internal/msauth/auth.go
@@ -220,11 +220,13 @@ func (a *Authenticator) ListAccounts() ([]AccountInfo, error) {
 
 		data, err := os.ReadFile(filepath.Join(acctDir, entry.Name()))
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping account file %s: %v\n", entry.Name(), err)
 			continue
 		}
 
 		var info AccountInfo
 		if err := json.Unmarshal(data, &info); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping account file %s: invalid JSON: %v\n", entry.Name(), err)
 			continue
 		}
 		accounts = append(accounts, info)


### PR DESCRIPTION
## Summary

- **KQL search support**: Replace blanket operator stripping with proper KQL detection. Property restrictions (`from:`, `subject:`), boolean keywords (`AND`, `OR`, `NOT`), and quoted phrases (`subject:"quarterly report"`) now pass through to Graph API. Plain keyword queries are still auto-wrapped in double quotes for phrase matching.
- **Todo field clearing**: `--due none`, `--start none`, `--reminder none`, `--recurrence none` now correctly clear fields via the Graph API. Previously the empty-string clear paths documented in help text were unreachable because the CLI gated on `!= ""`.
- **Desire path parity**: Add `--importance` flag to `olk send` shortcut, matching `olk mail send`.
- **Account list warnings**: Emit stderr warnings when account JSON files are unreadable or corrupt instead of silently skipping them.
- **Timeout clamp warning**: Warn on stderr when `--timeout` value exceeds 600s maximum.
- **Docs/lint**: Update AGENTS.md and help text for new KQL behavior; extract `clearSentinel` constant to satisfy goconst.

## Test plan

- [ ] `olk mail search "from:boss@co.com subject:urgent"` — returns filtered results (not degraded keyword match)
- [ ] `olk mail search "foo AND bar"` — boolean search, not phrase search for "foo AND bar"
- [ ] `olk mail search 'subject:"quarterly report"'` — quoted phrase within property restriction works
- [ ] `olk mail search "hello world"` — plain keyword still works (auto-wrapped)
- [ ] `olk todo update <id> --due none` — clears due date
- [ ] `olk todo update <id> --start none --reminder none --recurrence none` — clears all fields
- [ ] `olk send --to a@b.com --subject test --body test --importance high` — importance flag works
- [ ] Corrupt a JSON file in `~/.config/olk/accounts/`, run `olk auth list` — warning on stderr
- [ ] `olk --timeout 1200 mail list` — warns about clamping to 600s
- [ ] `make build && make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)