### PR TITLE
fix(mail): always quote $search parameter for KQL compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,5 +57,5 @@
 - Config dir (`~/.config/olk/`) uses 0700 permissions; token files use 0600.
 - Device code flow uses PKCE (RFC 7636) — `code_challenge` sent with device code request, `code_verifier` sent during token polling.
 - Token refresh is serialized per-email via `sync.Map` of mutexes in `internal/msauth/auth.go` to prevent race conditions.
-- KQL search queries support property restrictions (`from:`, `subject:`, etc.) and boolean operators. Only literal double-quote characters are stripped to prevent syntax injection. Plain keyword queries are auto-wrapped in double quotes; queries containing KQL operators are passed through as-is. See `internal/graphapi/mail.go`.
+- KQL search queries are always wrapped in double quotes (Graph `$search` parameter requirement). Property restrictions (`from:`, `subject:`, etc.) and boolean operators work inside the quotes. Literal double-quote characters are stripped from user input to prevent breaking the wrapper. See `internal/graphapi/mail.go`.
 - See `SECURITY.md` for vulnerability disclosure policy.

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -442,34 +442,12 @@ func (c *Client) DeleteMailFolder(ctx context.Context, folderID string) error {
 	return nil
 }
 
-// isKQLQuery returns true when query contains KQL syntax — either punctuation
-// operators (:, (, ), &, |, !, *) or keyword operators (AND, OR, NOT).
-func isKQLQuery(query string) bool {
-	if strings.ContainsAny(query, ":()&|!*") {
-		return true
-	}
-	for _, word := range strings.Fields(query) {
-		switch word {
-		case "AND", "OR", "NOT":
-			return true
-		}
-	}
-	return false
-}
-
 func (c *Client) SearchMessages(ctx context.Context, query string, top int32) ([]MailMessage, error) {
-	var search string
-	if isKQLQuery(query) {
-		// KQL query — pass through as-is so property restrictions, boolean
-		// operators, and quoted phrases (e.g. subject:"quarterly report")
-		// all work. This is the user's own mailbox, so the impact of any
-		// query manipulation is limited to their own search results.
-		search = query
-	} else {
-		// Plain keyword search — wrap in quotes for phrase matching.
-		// Strip any literal double quotes to prevent breaking the wrapper.
-		search = `"` + strings.ReplaceAll(query, `"`, "") + `"`
-	}
+	// The $search parameter value must be wrapped in double quotes per
+	// Graph API requirements. KQL property restrictions (from:, subject:, etc.)
+	// and boolean operators (AND, OR, NOT) work inside the quoted string.
+	// Strip literal double quotes from user input to prevent breaking the wrapper.
+	search := `"` + strings.ReplaceAll(query, `"`, "") + `"`
 	return c.ListMessages(ctx, &ListMessagesOptions{
 		Top:    top,
 		Search: search,


### PR DESCRIPTION
## Summary

- **Fix KQL search regression** from PR #11 — property restrictions (`from:`, `subject:`, `hasAttachment:`, etc.) were broken on both consumer and enterprise accounts
- The `$search` parameter in Microsoft Graph requires the query value to be wrapped in double quotes. PR #11's `isKQLQuery()` passed KQL queries through without quoting, causing `Syntax error: character ':' is not valid` errors
- Fix: always wrap the search value in double quotes, strip literal double quotes from input. KQL operators work inside the quoted string.
- Removed the unnecessary `isKQLQuery()` function — simpler is correct

## Test plan

- [x] `make build && make lint` — 0 issues
- [x] Plain keyword search works on both accounts
- [x] KQL `from:` property restriction works on both accounts  
- [x] All other functionality sanity-tested (mail list/get, calendar, todo CRUD, contacts, people, desire paths, auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)