### PR TITLE
fix(calendar): find-times confidence display and enterprise error

### DIFF
--- a/internal/cmd/calendar_find_times.go
+++ b/internal/cmd/calendar_find_times.go
@@ -68,7 +68,7 @@ func (c *CalendarFindTimesCmd) Run(ctx *RunContext) error {
 		rows = append(rows, []string{
 			outfmt.Truncate(outfmt.ConvertTime(s.Start, loc), 16),
 			outfmt.Truncate(outfmt.ConvertTime(s.End, loc), 16),
-			fmt.Sprintf("%.0f%%", s.Confidence*100),
+			fmt.Sprintf("%.0f%%", s.Confidence),
 			strings.Join(avails, ", "),
 		})
 	}

--- a/internal/graphapi/validate.go
+++ b/internal/graphapi/validate.go
@@ -126,10 +126,14 @@ func graphErrorMessage(err error) string {
 }
 
 // enterpriseError wraps a Graph API error with a hint that the feature
-// may require a work/school account, if the error is access-denied.
+// may require a work/school account, if the error indicates access issues.
 func enterpriseError(action string, err error) error {
 	msg := graphErrorMessage(err)
-	if strings.Contains(strings.ToLower(msg), "access") && strings.Contains(strings.ToLower(msg), "denied") {
+	lower := strings.ToLower(msg)
+	needsEnterprise := (strings.Contains(lower, "access") && strings.Contains(lower, "denied")) ||
+		lower == "unknownerror" ||
+		strings.Contains(lower, "mailboxnotenabledforrestapi")
+	if needsEnterprise {
 		return fmt.Errorf("%s: %s\n  Note: this feature requires a work/school (Microsoft 365) account and is not available for personal Microsoft accounts (Outlook.com, Hotmail, Live.com)", action, msg)
 	}
 	return fmt.Errorf("%s: %s", action, msg)


### PR DESCRIPTION
## Summary

- **Confidence 10000% bug**: Graph API returns confidence as 0–100 (already a percentage), but the formatter multiplied by 100 again. Removed the multiplication — now correctly displays `100%`.
- **UnknownError on personal accounts**: `enterpriseError()` only matched "access denied". FindMeetingTimes returns "UnknownError" on personal accounts. Expanded matching to also catch "UnknownError" and "MailboxNotEnabledForRESTAPI", showing the helpful enterprise-only note.

## Test plan

- [x] `make build && make lint` — 0 issues
- [x] Personal account: `olk calendar find-times -a rramesan@outlook.com` → shows enterprise-only note
- [x] Enterprise account: `olk calendar find-times -a roshinlal@...` → shows `100%` not `10000%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)