### PR TITLE
fix(security): orphaned tokens, permission hardening, attachment limits, output sanitization

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rlrghb/olkcli/internal/config"
 	"github.com/rlrghb/olkcli/internal/msauth"
 	"github.com/rlrghb/olkcli/internal/outfmt"
+	"github.com/rlrghb/olkcli/internal/secrets"
 )
 
 type AuthCmd struct {
@@ -155,22 +156,42 @@ func (c *AuthCleanCmd) Run(ctx *RunContext) error {
 		clientCfg := cfg.GetClient(acct.Email)
 		a, err := ctx.Authenticator(clientCfg.ClientID, clientCfg.TenantID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", outfmt.Sanitize(acct.Email), err)
+			fmt.Fprintf(os.Stderr, "warning: skipping %s: %s\n", outfmt.Sanitize(acct.Email), outfmt.Sanitize(err.Error()))
 			continue
 		}
 		if err := a.Logout(acct.Email); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not remove %s: %v\n", outfmt.Sanitize(acct.Email), err)
+			fmt.Fprintf(os.Stderr, "warning: could not remove %s: %s\n", outfmt.Sanitize(acct.Email), outfmt.Sanitize(err.Error()))
 			continue
 		}
 		cfg.RemoveAccount(acct.Email)
 		removed++
 	}
 
+	// Clean up orphaned keyring tokens that no longer have account files.
+	// This catches tokens left behind if an account file was deleted manually
+	// or if a previous logout partially failed.
+	orphaned := 0
+	if keys, err := auth.Store.Keys(); err == nil {
+		for _, key := range keys {
+			if secrets.IsTokenKey(key) {
+				if err := auth.Store.Delete(key); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: could not remove orphaned token %s: %s\n", outfmt.Sanitize(key), outfmt.Sanitize(err.Error()))
+				} else {
+					orphaned++
+				}
+			}
+		}
+	}
+
 	if err := cfg.Save(); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
 
-	fmt.Printf("Removed %d account(s) and their tokens.\n", removed)
+	msg := fmt.Sprintf("Removed %d account(s) and their tokens.", removed)
+	if orphaned > 0 {
+		msg += fmt.Sprintf(" Cleaned up %d orphaned token(s).", orphaned)
+	}
+	fmt.Println(msg)
 	return nil
 }
 

--- a/internal/cmd/mail_attachments.go
+++ b/internal/cmd/mail_attachments.go
@@ -101,9 +101,7 @@ func (c *MailAttachmentsCmd) Run(ctx *RunContext) error {
 		if err != nil {
 			return err
 		}
-		if len(att.Content) > maxDownloadSize {
-			return fmt.Errorf("attachment %q content is %d bytes, exceeds 50MB download limit", att.Name, len(att.Content))
-		}
+		// Size is validated in the API layer (graphapi/mail.go).
 
 		outDir := c.Out
 		if err := validateOutDir(outDir); err != nil {
@@ -144,9 +142,6 @@ func (c *MailAttachmentsCmd) Run(ctx *RunContext) error {
 			att, err := client.DownloadAttachment(ctx.Ctx, c.ID, a.ID)
 			if err != nil {
 				return fmt.Errorf("downloading %q: %w", a.Name, err)
-			}
-			if len(att.Content) > maxDownloadSize {
-				return fmt.Errorf("attachment %q content is %d bytes, exceeds 50MB download limit", a.Name, len(att.Content))
 			}
 
 			filename := sanitizeFilename(att.Name)

--- a/internal/cmd/todo_attachments.go
+++ b/internal/cmd/todo_attachments.go
@@ -137,10 +137,7 @@ func (c *TodoAttachDownloadCmd) Run(ctx *RunContext) error {
 	if err != nil {
 		return err
 	}
-
-	if len(content) > maxDownloadSize {
-		return fmt.Errorf("attachment is %d bytes, exceeds 50MB download limit", len(content))
-	}
+	// Size is validated in the API layer (graphapi/todo.go).
 
 	if err := validateOutDir(c.Out); err != nil {
 		return err

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -33,6 +33,11 @@ func EnsureConfigDir() error {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
+		// Enforce restrictive permissions even if directory already existed
+		// with weaker permissions (e.g. created by another tool or umask).
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -26,6 +26,10 @@ var allowedOrderBy = map[string]bool{
 // safeEmailPattern validates basic email format.
 var safeEmailPattern = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
 
+// maxAttachmentBytes is the hard limit for attachment downloads (50 MB).
+// Applied in the API layer so oversized content is rejected before reaching callers.
+const maxAttachmentBytes = 50 << 20
+
 // allowedSelectFields is the set of valid $select field names for messages.
 var allowedSelectFields = map[string]bool{
 	"id": true, "subject": true, "from": true, "toRecipients": true,
@@ -498,6 +502,10 @@ func (c *Client) DownloadAttachment(ctx context.Context, messageID, attachmentID
 		att.Content = fileAtt.GetContentBytes()
 	} else {
 		return nil, fmt.Errorf("attachment %q is not a file attachment", att.Name)
+	}
+
+	if len(att.Content) > maxAttachmentBytes {
+		return nil, fmt.Errorf("attachment %q is %d bytes, exceeds %d byte limit", att.Name, len(att.Content), maxAttachmentBytes)
 	}
 
 	return att, nil

--- a/internal/graphapi/todo.go
+++ b/internal/graphapi/todo.go
@@ -743,6 +743,10 @@ func (c *Client) DownloadTodoAttachment(ctx context.Context, listID, taskID, att
 		content = fileAtt.GetContentBytes()
 	}
 
+	if len(content) > maxAttachmentBytes {
+		return "", "", nil, fmt.Errorf("attachment %q is %d bytes, exceeds %d byte limit", name, len(content), maxAttachmentBytes)
+	}
+
 	return name, contentType, content, nil
 }
 

--- a/internal/msauth/auth.go
+++ b/internal/msauth/auth.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -212,21 +213,37 @@ func (a *Authenticator) ListAccounts() ([]AccountInfo, error) {
 		return nil, fmt.Errorf("reading accounts directory: %w", err)
 	}
 
+	// Harden directory permissions on every read — fixes drift from
+	// umask changes or manual edits.
+	if runtime.GOOS != "windows" {
+		_ = os.Chmod(acctDir, 0o700)
+	}
+
 	var accounts []AccountInfo
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 			continue
 		}
 
-		data, err := os.ReadFile(filepath.Join(acctDir, entry.Name()))
+		filePath := filepath.Join(acctDir, entry.Name())
+
+		// Harden file permissions if too open.
+		if runtime.GOOS != "windows" {
+			if info, err := entry.Info(); err == nil && info.Mode().Perm()&0o077 != 0 {
+				fmt.Fprintf(os.Stderr, "warning: fixing permissions on %q (was %o)\n", entry.Name(), info.Mode().Perm())
+				_ = os.Chmod(filePath, 0o600)
+			}
+		}
+
+		data, err := os.ReadFile(filePath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: skipping account file %s: %v\n", entry.Name(), err)
+			fmt.Fprintf(os.Stderr, "warning: skipping account file %q: %v\n", entry.Name(), err)
 			continue
 		}
 
 		var info AccountInfo
 		if err := json.Unmarshal(data, &info); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: skipping account file %s: invalid JSON: %v\n", entry.Name(), err)
+			fmt.Fprintf(os.Stderr, "warning: skipping account file %q: invalid JSON: %v\n", entry.Name(), err)
 			continue
 		}
 		accounts = append(accounts, info)

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -116,3 +116,8 @@ func (s *KeyringStore) Keys() ([]string, error) {
 func TokenKey(email string) string {
 	return tokenPrefix + strings.ToLower(email)
 }
+
+// IsTokenKey reports whether a keyring key is an olk token entry.
+func IsTokenKey(key string) bool {
+	return strings.HasPrefix(key, tokenPrefix)
+}


### PR DESCRIPTION
## Summary

Four security/privacy gaps from full repo audit:

- **Orphaned token cleanup** (Medium): `auth clean` only deleted keyring tokens for accounts with matching JSON files. Now enumerates all `olk:token:*` keyring entries and removes any remaining orphans after account-based cleanup.
- **Permission hardening** (Medium): `EnsureConfigDir` now enforces `0700` on config/accounts dirs on every call (not just creation). `ListAccounts` auto-fixes account files with permissions more open than `0600`.
- **Attachment size limit in API layer** (Low-Medium): Moved the 50MB size check from the cmd layer into `graphapi/mail.go` and `graphapi/todo.go` so oversized content is rejected before reaching callers.
- **Output sanitization** (Low): Warning messages in `ListAccounts` changed from `%s` to `%q` for filenames, preventing terminal escape injection from crafted filesystem entries.

## Files changed

| File | Change |
|------|--------|
| `internal/cmd/auth.go` | Orphaned token cleanup after account-based removal |
| `internal/config/paths.go` | Chmod 0700 enforcement on existing dirs |
| `internal/msauth/auth.go` | Auto-fix account file permissions, `%q` for filenames |
| `internal/secrets/store.go` | Added `IsTokenKey()` helper |
| `internal/graphapi/mail.go` | `maxAttachmentBytes` constant, size check in `DownloadAttachment` |
| `internal/graphapi/todo.go` | Size check in `DownloadTodoAttachment` |

## Test plan

- [x] `make build && make lint` — 0 issues
- [x] `make test` — passes
- [x] `auth list` works
- [x] Code review: all four findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)