### PR TITLE
feat(drive): add OneDrive file operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides context for Claude Code when working on the olk project.
 
 ## What is this project?
 
-`olk` is a CLI tool for Microsoft Outlook via the Microsoft Graph API. It provides terminal access to email, calendar, contacts, and tasks for both personal Microsoft accounts and enterprise Azure AD/Entra ID accounts.
+`olk` is a CLI tool for Microsoft Outlook and OneDrive via the Microsoft Graph API. It provides terminal access to email, calendar, contacts, tasks, and OneDrive files for both personal Microsoft accounts and enterprise Azure AD/Entra ID accounts.
 
 ## Quick Reference
 
@@ -54,6 +54,11 @@ go mod tidy         # After changing dependencies
 2. Add the struct to `TodoCmd` in `internal/cmd/todo.go`
 3. If needed, add the API method to `internal/graphapi/todo.go`
 
+### Adding a new drive subcommand
+1. Create `internal/cmd/drive_<name>.go` with the command struct and `Run` method
+2. Add the struct to `DriveCmd` in `internal/cmd/drive.go`
+3. If needed, add the API method to `internal/graphapi/drive.go`
+
 ### Adding a new flag to all commands
 Add it to `RootFlags` in `internal/cmd/root.go` with `env:"OLK_*"` tag.
 
@@ -83,3 +88,7 @@ The project uses `msgraph-sdk-go` v1.96.0 which has some naming quirks:
 - Todo checklist items: `Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).ChecklistItems()`
 - Todo attachments: `TaskFileAttachment` type for upload; `ByAttachmentBaseId()` for get/delete
 - Todo linked resources: `Me().Todo().Lists().ByTodoTaskListId(listID).Tasks().ByTodoTaskId(taskID).LinkedResources()`
+- Drive: `Me().Drive()` for default drive, `Me().Drives()` for all drives, `Drives().ByDriveId(id)` for specific drive
+- DriveItems: `Drives().ByDriveId(id).Items().ByDriveItemId(itemID)` for item operations; `.Children()` for folder contents; `.Content()` for file download/upload
+- Drive path-based access requires raw URL builders: `drives.NewItemItemsDriveItemItemRequestBuilder(rawURL, c.inner.GetAdapter())` with URL pattern `/drives/{id}/root:/{path}:`
+- Drive sharing: `CreateLink().Post()` body uses `SetTypeEscaped()` not `SetType()` (same Go keyword collision as Attendee)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # olk — Microsoft Outlook in Your Terminal
 
-A fast, scriptable CLI for Microsoft Outlook via the Microsoft Graph API. Manage email, calendar, contacts, and tasks from the command line.
+A fast, scriptable CLI for Microsoft Outlook and OneDrive via the Microsoft Graph API. Manage email, calendar, contacts, tasks, and OneDrive files from the command line.
 
 Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Entra ID)** accounts. Zero-config setup with device-code authentication — just run `olk auth login` and go. For enterprise accounts, use `olk auth login --enterprise` to enable additional features like out-of-office, inbox rules, and directory search.
 
@@ -43,6 +43,15 @@ Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Ent
 - **Checklists**: list, create, toggle, update, and delete checklist items within tasks
 - **Attachments**: list, upload, download, and delete task file attachments
 - **Linked resources**: list, create, and delete linked resources on tasks
+
+### OneDrive
+- **Browse** files and folders with `drive ls [path]`
+- **Search** files by name or content
+- **Download** and **upload** files (simple and resumable for large files)
+- **Create folders**, **copy**, **move**, and **delete** items
+- **Share** files with view or edit links
+- **Version history** for files
+- **Drive info** including quota usage
 
 ### People / Directory
 - **Search** people by name — returns name, email, job title, department, company. Personal accounts search known contacts; enterprise accounts also search the organization directory
@@ -161,6 +170,8 @@ olk auth login --enterprise
 
 Uses an embedded public client ID with device-code flow. The `--enterprise` flag requests additional scopes (`User.ReadBasic.All`, `MailboxSettings.ReadWrite`) needed for enterprise-only features. Personal accounts should not use `--enterprise` as these scopes are not supported.
 
+> **Note:** If you upgrade to a version that adds new features (e.g. OneDrive support), you may need to re-run `olk auth login` to grant the new permissions. If you see "access denied" errors, re-login to refresh your token scopes.
+
 ### Custom App Registration
 
 If your organization blocks the default client ID, or your admin requires apps to be registered under your tenant, you'll need to create your own app registration:
@@ -168,7 +179,7 @@ If your organization blocks the default client ID, or your admin requires apps t
 1. Go to [Azure Portal > App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) and click **New registration**
 2. Set **Supported account types** to match your needs (single tenant or multi-tenant)
 3. Under **Authentication > Advanced settings**, set **Allow public client flows** to **Yes** (required for device-code flow)
-4. Under **API permissions**, add **Microsoft Graph** delegated permissions: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`, `People.Read`, `User.Read`, `User.ReadBasic.All`, `MailboxSettings.ReadWrite`, `offline_access`
+4. Under **API permissions**, add **Microsoft Graph** delegated permissions: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`, `Files.ReadWrite`, `People.Read`, `User.Read`, `User.ReadBasic.All`, `MailboxSettings.ReadWrite`, `offline_access` (use `Files.Read` instead of `Files.ReadWrite` for read-only access)
 5. Copy the **Application (client) ID** and **Directory (tenant) ID** from the app's Overview page
 
 Then use them:
@@ -465,6 +476,7 @@ Most features work with both personal and enterprise accounts. A few features re
 | Focused Inbox | Yes | Yes |
 | Availability / free-busy | Yes | Yes |
 | Find meeting times | No | Yes |
+| OneDrive (browse, upload, download, share) | Yes | Yes |
 | Directory search (fallback) | No | Yes |
 
 ## Privacy & Security

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: olk
-description: Microsoft Outlook CLI for email, calendar, contacts, and tasks via Microsoft Graph API.
+description: Microsoft Outlook and OneDrive CLI for email, calendar, contacts, tasks, and files via Microsoft Graph API.
 homepage: https://github.com/rlrghb/olkcli
 metadata:
   {
@@ -24,7 +24,7 @@ metadata:
 
 # olk
 
-Use `olk` for Outlook Mail/Calendar/Contacts/Tasks. Works with personal Microsoft accounts and enterprise Azure AD/Entra ID.
+Use `olk` for Outlook Mail/Calendar/Contacts/Tasks and OneDrive files. Works with personal Microsoft accounts and enterprise Azure AD/Entra ID.
 
 Setup (once)
 
@@ -173,6 +173,26 @@ Linked Resources
 
 If `--list` is omitted, the default (first) task list is used automatically.
 
+OneDrive
+
+- List drives: `olk drive list`
+- Drive info: `olk drive info [--drive-id ID]`
+- List folder: `olk drive ls [PATH] [--drive-id ID] [-n 50]`
+- Get item details: `olk drive get <ID> [--drive-id ID]`
+- Search: `olk drive search <QUERY> [--drive-id ID] [-n 25]`
+- Recent files: `olk drive recent [--drive-id ID]`
+- Shared with me: `olk drive shared [--drive-id ID]`
+- Download: `olk drive download <ID> [--out DIR] [--drive-id ID]`
+- Upload: `olk drive upload <LOCAL_PATH> <REMOTE_PATH> [--drive-id ID] [--replace]`
+- Create folder: `olk drive mkdir <PATH> [--drive-id ID]`
+- Copy: `olk drive cp <ID> <DEST_PATH> [--name NEW_NAME] [--drive-id ID]`
+- Move/rename: `olk drive mv <ID> <DEST_PATH> [--drive-id ID]`
+- Delete: `olk drive rm <ID> --force [--drive-id ID]`
+- Share: `olk drive share <ID> [--type view|edit] [--scope anonymous|organization] [--drive-id ID]`
+- Version history: `olk drive versions <ID> [--drive-id ID]`
+
+If `--drive-id` is omitted, the user's primary drive is used automatically.
+
 Configuration
 
 - Set timezone: `olk config set timezone America/New_York`
@@ -231,12 +251,15 @@ Scripting Examples
 - Find meeting times: `olk calendar find-times --attendees a@b.com --attendees c@d.com --json --results-only | jq '.[0]'`
 - Search people: `olk people search "engineering" --json --results-only | jq -r '.[].email'`
 - Focused inbox unread: `olk mail list --focused --unread --json --results-only | jq length`
+- List large files: `olk drive ls /Documents --json --results-only | jq '[.[] | select(.size > 10000000)] | sort_by(.size) | reverse'`
+- Check quota: `olk drive info --json --results-only | jq '{used: .quotaUsed, total: .quotaTotal}'`
 
 Notes
 
 - Set `OLK_TIMEZONE=America/New_York` to display times in your timezone.
 - Set `OLK_ACCOUNT=you@example.com` to avoid repeating `--account`.
 - Set `OLK_TODO_LIST=<list-id>` to avoid repeating `--list` for todo commands.
+- Set `OLK_DRIVE_ID=<drive-id>` to avoid repeating `--drive-id` for drive commands.
 - For scripting, prefer `--json --results-only` plus `jq`.
 - IDs are opaque Microsoft Graph strings. Always get them from `list` or `search` first — never guess.
 - Dates are ISO 8601: `2025-06-15` or `2025-06-15T09:00`.
@@ -246,3 +269,4 @@ Notes
 - Confirm before sending mail or creating/deleting events.
 - If a command fails with an auth error, check `olk auth status` first.
 - Some features are enterprise-only (work/school accounts): out-of-office, inbox rules, find meeting times, and directory search. These require `olk auth login --enterprise`.
+- OneDrive commands require re-login (`olk auth login`) if you authenticated before OneDrive support was added.

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// allowedDownloadHostSuffixes are trusted host suffixes for pre-authenticated URLs
+// returned by Microsoft Graph. Requests to other hosts are rejected.
+// allowedDownloadHostSuffixes are trusted host suffixes for pre-authenticated URLs
+// returned by Microsoft Graph. Requests to other hosts are rejected.
+//
+// Sources:
+//   - https://learn.microsoft.com/en-us/sharepoint/required-urls-and-ports
+//   - https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges
+var allowedDownloadHostSuffixes = []string{
+	".sharepoint.com",               // SharePoint Online / OneDrive for Business
+	".microsoftpersonalcontent.com", // Personal OneDrive content
+	".microsoft.com",                // graph.microsoft.com and other Microsoft services
+	".live.com",                     // *.storage.live.com, *.onedrive.live.com
+	".live.net",                     // *.docs.live.net, *.apis.live.net
+	".1drv.com",                     // *.files.1drv.com, *.up.1drv.com
+	".1drv.ms",                      // OneDrive short URLs
+	".svc.ms",                       // Microsoft service endpoints
+}
+
+// validateGraphURL checks that a pre-authenticated URL from Graph API is safe to use:
+// must be HTTPS, must be a known Microsoft host, must not resolve to loopback/private IPs.
+func validateGraphURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("refusing non-HTTPS URL")
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	// Reject literal IP targets that are loopback/private
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() {
+			return fmt.Errorf("refusing request to private/loopback address")
+		}
+	}
+	// Check host against allowlist
+	allowed := false
+	for _, suffix := range allowedDownloadHostSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("refusing request to untrusted host %q", host)
+	}
+	// Resolve hostname and reject if any resolved IP is loopback/private (SSRF protection)
+	if net.ParseIP(host) == nil {
+		addrs, err := net.LookupHost(host)
+		if err != nil {
+			return fmt.Errorf("cannot resolve host %q", host)
+		}
+		for _, addr := range addrs {
+			ip := net.ParseIP(addr)
+			if ip == nil {
+				continue
+			}
+			if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() {
+				return fmt.Errorf("host %q resolves to private/loopback address", host)
+			}
+		}
+	}
+	return nil
+}
+
+// DriveCmd is the top-level command group for OneDrive file operations.
+type DriveCmd struct {
+	List     DriveListCmd     `cmd:"" help:"List all drives"`
+	Info     DriveInfoCmd     `cmd:"" help:"Show drive details and quota"`
+	Ls       DriveLsCmd       `cmd:"" help:"List folder contents"`
+	Get      DriveGetCmd      `cmd:"" help:"Get item details"`
+	Search   DriveSearchCmd   `cmd:"" help:"Search files"`
+	Recent   DriveRecentCmd   `cmd:"" help:"Recently accessed files"`
+	Shared   DriveSharedCmd   `cmd:"" help:"Files shared with me"`
+	Download DriveDownloadCmd `cmd:"" help:"Download a file"`
+	Upload   DriveUploadCmd   `cmd:"" help:"Upload a file"`
+	Mkdir    DriveMkdirCmd    `cmd:"" help:"Create a folder"`
+	Cp       DriveCpCmd       `cmd:"" help:"Copy a file or folder"`
+	Mv       DriveMvCmd       `cmd:"" help:"Move or rename a file or folder"`
+	Rm       DriveRmCmd       `cmd:"" help:"Delete a file or folder"`
+	Share    DriveShareCmd    `cmd:"" help:"Create a sharing link"`
+	Versions DriveVersionsCmd `cmd:"" help:"List file version history"`
+}
+
+// resolveDriveID returns the provided driveID, or auto-detects the default drive.
+func resolveDriveID(ctx *RunContext, driveID string) (string, error) {
+	if driveID != "" {
+		return driveID, nil
+	}
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return "", err
+	}
+	drive, err := client.GetDrive(ctx.Ctx, "")
+	if err != nil {
+		return "", fmt.Errorf("auto-detecting drive: %w", err)
+	}
+	return drive.ID, nil
+}
+
+// formatBytes returns a human-readable byte size string.
+func formatBytes(n int64) string {
+	if n < 0 {
+		return ""
+	}
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case n < kb:
+		return fmt.Sprintf("%d B", n)
+	case n < mb:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(kb))
+	case n < gb:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(mb))
+	default:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(gb))
+	}
+}
+
+// looksLikePath returns true if the string appears to be a path rather than an ID.
+func looksLikePath(s string) bool {
+	return s != "" && s[0] == '/'
+}
+
+// driveItemType constants for consistent comparison.
+const (
+	driveItemTypeFile   = "file"
+	driveItemTypeFolder = "folder"
+)
+
+// printDriveItems prints a list of drive items in the standard table format.
+func printDriveItems(ctx *RunContext, items []graphapi.DriveItem) error {
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(items, len(items), "")
+	}
+
+	loc, _ := ctx.Timezone()
+	headers := []string{"NAME", "TYPE", "SIZE", "MODIFIED", "ID"}
+	var rows [][]string
+	for i := range items {
+		item := &items[i]
+		size := ""
+		if item.ItemType == driveItemTypeFile {
+			size = formatBytes(item.Size)
+		}
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(item.Name), 50),
+			outfmt.Sanitize(item.ItemType),
+			size,
+			outfmt.Truncate(outfmt.Sanitize(outfmt.ConvertTime(item.ModifiedAt, loc)), 16),
+			outfmt.Truncate(outfmt.Sanitize(item.ID), 15),
+		})
+	}
+	return printer.Print(headers, rows, items, len(items), "")
+}

--- a/internal/cmd/drive_cp.go
+++ b/internal/cmd/drive_cp.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveCpCmd copies a file or folder.
+type DriveCpCmd struct {
+	ItemID  string `arg:"" help:"Source item ID"`
+	Dest    string `arg:"" help:"Destination folder path"`
+	Name    string `help:"New name for the copy" short:"n"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveCpCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ItemID) {
+		return fmt.Errorf("first argument looks like a path; use 'olk drive ls %s' to find item IDs", c.ItemID)
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		name := c.Name
+		if name == "" {
+			name = "(same name)"
+		}
+		fmt.Printf("Would copy %s to %s as %s\n",
+			outfmt.Sanitize(c.ItemID), outfmt.Sanitize(c.Dest), outfmt.Sanitize(name))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	// Resolve destination path to item ID
+	dest, err := client.ResolveItemByPath(ctx.Ctx, driveID, c.Dest)
+	if err != nil {
+		return fmt.Errorf("resolving destination path: %w", err)
+	}
+
+	err = client.CopyDriveItem(ctx.Ctx, driveID, c.ItemID, dest.ID, c.Name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Copy initiated.")
+	return nil
+}

--- a/internal/cmd/drive_download.go
+++ b/internal/cmd/drive_download.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+const (
+	// maxSmallDownload is the threshold for in-memory download (50 MB).
+	maxSmallDownload = 50 << 20
+	// maxDriveDownload is the hard limit for CLI downloads (2 GB).
+	maxDriveDownload = 2 << 30
+)
+
+// DriveDownloadCmd downloads a file.
+type DriveDownloadCmd struct {
+	ID      string `arg:"" help:"Item ID"`
+	Output  string `help:"Output directory" short:"o" default:"." type:"path"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveDownloadCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ID) {
+		return fmt.Errorf("argument looks like a path; use 'olk drive ls %s' to find item IDs", c.ID)
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	// Get metadata first
+	item, err := client.GetDriveItem(ctx.Ctx, driveID, c.ID)
+	if err != nil {
+		return err
+	}
+
+	if item.ItemType == driveItemTypeFolder {
+		return fmt.Errorf("cannot download a folder; use a file item ID")
+	}
+
+	if item.Size > maxDriveDownload {
+		return fmt.Errorf("file too large: %s (max %s)", formatBytes(item.Size), formatBytes(maxDriveDownload))
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would download %s (%s) to %s\n",
+			outfmt.Sanitize(item.Name), formatBytes(item.Size), outfmt.Sanitize(c.Output))
+		return nil
+	}
+
+	if err := validateOutDir(c.Output); err != nil {
+		return err
+	}
+
+	filename := sanitizeFilename(item.Name)
+	destPath := filepath.Join(c.Output, filename)
+
+	if item.Size <= maxSmallDownload {
+		// Small file: in-memory download
+		content, err := client.DownloadDriveItem(ctx.Ctx, driveID, c.ID)
+		if err != nil {
+			return err
+		}
+		written, err := safeWriteFile(destPath, content)
+		if err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+		fmt.Printf("Downloaded %s (%s)\n", outfmt.Sanitize(filepath.Base(written)), formatBytes(item.Size))
+		return nil
+	}
+
+	// Large file: streaming download via download URL
+	if item.DownloadURL == "" {
+		return fmt.Errorf("no download URL available for this item; try a smaller file or use the web interface")
+	}
+	if err := validateGraphURL(item.DownloadURL); err != nil {
+		return fmt.Errorf("download URL rejected: %w", err)
+	}
+
+	f, finalPath, err := safeCreateFile(destPath)
+	if err != nil {
+		return fmt.Errorf("creating output file: %w", err)
+	}
+
+	cleanupFile := func() {
+		f.Close()
+		os.Remove(finalPath)
+	}
+
+	req, err := http.NewRequestWithContext(ctx.Ctx, http.MethodGet, item.DownloadURL, http.NoBody)
+	if err != nil {
+		cleanupFile()
+		return fmt.Errorf("creating download request failed")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cleanupFile()
+		return fmt.Errorf("downloading file failed (check network connectivity)")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		cleanupFile()
+		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+
+	// Limit read to declared file size + 1 byte to detect server sending more than expected.
+	limitedReader := io.LimitReader(resp.Body, item.Size+1)
+	written, err := io.Copy(f, limitedReader)
+	if err != nil {
+		cleanupFile()
+		return fmt.Errorf("writing file: %w", err)
+	}
+	if written > item.Size {
+		cleanupFile()
+		return fmt.Errorf("server sent more data than expected (%s declared), aborting", formatBytes(item.Size))
+	}
+
+	f.Close()
+	fmt.Printf("Downloaded %s (%s)\n", outfmt.Sanitize(filepath.Base(finalPath)), formatBytes(item.Size))
+	return nil
+}
+
+// safeCreateFile opens a file for writing with O_EXCL to prevent overwriting.
+// If the file exists, it tries numeric suffixes like file(1).pdf.
+// Returns the open file handle and the final path used.
+func safeCreateFile(path string) (*os.File, string, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		return f, path, nil
+	}
+	if !os.IsExist(err) {
+		return nil, "", err
+	}
+
+	ext := filepath.Ext(path)
+	base := path[:len(path)-len(ext)]
+	for i := 1; i < 1000; i++ {
+		candidate := fmt.Sprintf("%s(%d)%s", base, i, ext)
+		f, err = os.OpenFile(candidate, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return f, candidate, nil
+		}
+		if !os.IsExist(err) {
+			return nil, "", err
+		}
+	}
+	return nil, "", fmt.Errorf("could not find available filename for %s after 1000 attempts", filepath.Base(path))
+}

--- a/internal/cmd/drive_get.go
+++ b/internal/cmd/drive_get.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveGetCmd gets item details.
+type DriveGetCmd struct {
+	ID      string `arg:"" help:"Item ID"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveGetCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ID) {
+		return fmt.Errorf("argument looks like a path; use 'olk drive ls %s' to find item IDs", c.ID)
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	item, err := client.GetDriveItem(ctx.Ctx, driveID, c.ID)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(item, 1, "")
+	}
+
+	loc, _ := ctx.Timezone()
+	fmt.Printf("ID:       %s\n", outfmt.Sanitize(item.ID))
+	fmt.Printf("Name:     %s\n", outfmt.Sanitize(item.Name))
+	fmt.Printf("Type:     %s\n", outfmt.Sanitize(item.ItemType))
+	if item.ItemType == driveItemTypeFile {
+		fmt.Printf("Size:     %s\n", formatBytes(item.Size))
+		if item.MimeType != "" {
+			fmt.Printf("MIME:     %s\n", outfmt.Sanitize(item.MimeType))
+		}
+	}
+	if item.ItemType == driveItemTypeFolder && item.ChildCount > 0 {
+		fmt.Printf("Children: %d\n", item.ChildCount)
+	}
+	fmt.Printf("Created:  %s\n", outfmt.Sanitize(outfmt.ConvertTime(item.CreatedAt, loc)))
+	fmt.Printf("Modified: %s\n", outfmt.Sanitize(outfmt.ConvertTime(item.ModifiedAt, loc)))
+	if item.CreatedBy != "" {
+		fmt.Printf("Created by:  %s\n", outfmt.Sanitize(item.CreatedBy))
+	}
+	if item.ModifiedBy != "" {
+		fmt.Printf("Modified by: %s\n", outfmt.Sanitize(item.ModifiedBy))
+	}
+	if item.ParentPath != "" {
+		fmt.Printf("Parent:   %s\n", outfmt.Sanitize(item.ParentPath))
+	}
+	if item.WebURL != "" {
+		fmt.Printf("URL:      %s\n", outfmt.Sanitize(item.WebURL))
+	}
+	return nil
+}

--- a/internal/cmd/drive_info.go
+++ b/internal/cmd/drive_info.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveInfoCmd shows drive details and quota.
+type DriveInfoCmd struct {
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveInfoCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	drive, err := client.GetDrive(ctx.Ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(drive, 1, "")
+	}
+
+	fmt.Printf("ID:        %s\n", outfmt.Sanitize(drive.ID))
+	fmt.Printf("Name:      %s\n", outfmt.Sanitize(drive.Name))
+	fmt.Printf("Type:      %s\n", outfmt.Sanitize(drive.DriveType))
+	if drive.OwnerName != "" {
+		fmt.Printf("Owner:     %s\n", outfmt.Sanitize(drive.OwnerName))
+	}
+	if drive.OwnerEmail != "" {
+		fmt.Printf("Email:     %s\n", outfmt.Sanitize(drive.OwnerEmail))
+	}
+	fmt.Printf("Used:      %s\n", formatBytes(drive.QuotaUsed))
+	fmt.Printf("Total:     %s\n", formatBytes(drive.QuotaTotal))
+	fmt.Printf("Remaining: %s\n", formatBytes(drive.QuotaRemaining))
+	fmt.Printf("State:     %s\n", outfmt.Sanitize(drive.QuotaState))
+	if drive.WebURL != "" {
+		fmt.Printf("URL:       %s\n", outfmt.Sanitize(drive.WebURL))
+	}
+	return nil
+}

--- a/internal/cmd/drive_list.go
+++ b/internal/cmd/drive_list.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveListCmd lists all drives for the current user.
+type DriveListCmd struct{}
+
+func (c *DriveListCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	drives, err := client.ListDrives(ctx.Ctx)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(drives, len(drives), "")
+	}
+
+	headers := []string{"ID", "NAME", "TYPE", "USED", "TOTAL"}
+	var rows [][]string
+	for i := range drives {
+		d := &drives[i]
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(d.ID), 15),
+			outfmt.Sanitize(d.Name),
+			outfmt.Sanitize(d.DriveType),
+			formatBytes(d.QuotaUsed),
+			formatBytes(d.QuotaTotal),
+		})
+	}
+	return printer.Print(headers, rows, drives, len(drives), "")
+}

--- a/internal/cmd/drive_ls.go
+++ b/internal/cmd/drive_ls.go
@@ -1,0 +1,27 @@
+package cmd
+
+// DriveLsCmd lists folder contents.
+type DriveLsCmd struct {
+	Path    string `arg:"" optional:"" help:"Folder path (default: root)" default:"/"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+	Top     int32  `help:"Number of items to return" default:"50" short:"n"`
+}
+
+func (c *DriveLsCmd) Run(ctx *RunContext) error {
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	items, err := client.ListDriveChildrenByPath(ctx.Ctx, driveID, c.Path, c.Top)
+	if err != nil {
+		return err
+	}
+
+	return printDriveItems(ctx, items)
+}

--- a/internal/cmd/drive_mkdir.go
+++ b/internal/cmd/drive_mkdir.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveMkdirCmd creates a folder.
+type DriveMkdirCmd struct {
+	Path    string `arg:"" help:"Folder path to create (e.g. /Documents/NewFolder)"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveMkdirCmd) Run(ctx *RunContext) error {
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	// Split path into parent and folder name
+	parentPath := path.Dir(c.Path)
+	folderName := path.Base(c.Path)
+	if folderName == "" || folderName == "/" || folderName == "." {
+		return fmt.Errorf("invalid folder path: %s", c.Path)
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would create folder %q in %s\n", outfmt.Sanitize(folderName), outfmt.Sanitize(parentPath))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	// Resolve parent to item ID
+	parentID := "root"
+	if parentPath != "/" && parentPath != "." {
+		parent, err := client.ResolveItemByPath(ctx.Ctx, driveID, parentPath)
+		if err != nil {
+			return fmt.Errorf("resolving parent path: %w", err)
+		}
+		parentID = parent.ID
+	}
+
+	folder, err := client.CreateFolder(ctx.Ctx, driveID, parentID, folderName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Folder created: %s (ID: %s)\n", outfmt.Sanitize(folder.Name), outfmt.Sanitize(folder.ID))
+	return nil
+}

--- a/internal/cmd/drive_mv.go
+++ b/internal/cmd/drive_mv.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveMvCmd moves or renames a file or folder.
+type DriveMvCmd struct {
+	ItemID  string `arg:"" help:"Item ID to move or rename"`
+	Dest    string `arg:"" help:"Destination folder path or new name"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveMvCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ItemID) {
+		return fmt.Errorf("first argument looks like a path; use 'olk drive ls' to find item IDs")
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would move %s to %s\n", outfmt.Sanitize(c.ItemID), outfmt.Sanitize(c.Dest))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	// Determine if Dest is a path (move) or a plain name (rename)
+	var destParentID, newName string
+	if looksLikePath(c.Dest) {
+		// Move to a new folder
+		dest, err := client.ResolveItemByPath(ctx.Ctx, driveID, c.Dest)
+		if err != nil {
+			return fmt.Errorf("resolving destination path: %w", err)
+		}
+		destParentID = dest.ID
+	} else {
+		// Rename
+		newName = c.Dest
+	}
+
+	item, err := client.MoveDriveItem(ctx.Ctx, driveID, c.ItemID, destParentID, newName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Moved: %s (ID: %s)\n", outfmt.Sanitize(item.Name), outfmt.Sanitize(item.ID))
+	return nil
+}

--- a/internal/cmd/drive_recent.go
+++ b/internal/cmd/drive_recent.go
@@ -1,0 +1,25 @@
+package cmd
+
+// DriveRecentCmd lists recently accessed files.
+type DriveRecentCmd struct {
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveRecentCmd) Run(ctx *RunContext) error {
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	items, err := client.RecentDriveItems(ctx.Ctx, driveID)
+	if err != nil {
+		return err
+	}
+
+	return printDriveItems(ctx, items)
+}

--- a/internal/cmd/drive_rm.go
+++ b/internal/cmd/drive_rm.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveRmCmd deletes a file or folder.
+type DriveRmCmd struct {
+	ID      string `arg:"" help:"Item ID to delete"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveRmCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ID) {
+		return fmt.Errorf("argument looks like a path; use 'olk drive ls %s' to find item IDs", c.ID)
+	}
+
+	if !ctx.Flags.Force {
+		return fmt.Errorf("delete item %s: use --force to confirm deletion", outfmt.Sanitize(outfmt.Truncate(c.ID, 30)))
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would delete item %s\n", outfmt.Sanitize(c.ID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteDriveItem(ctx.Ctx, driveID, c.ID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Item deleted.")
+	return nil
+}

--- a/internal/cmd/drive_search.go
+++ b/internal/cmd/drive_search.go
@@ -1,0 +1,27 @@
+package cmd
+
+// DriveSearchCmd searches files by name or content.
+type DriveSearchCmd struct {
+	Query   string `arg:"" help:"Search query"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+	Top     int32  `help:"Number of results" default:"25" short:"n"`
+}
+
+func (c *DriveSearchCmd) Run(ctx *RunContext) error {
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	items, err := client.SearchDrive(ctx.Ctx, driveID, c.Query, c.Top)
+	if err != nil {
+		return err
+	}
+
+	return printDriveItems(ctx, items)
+}

--- a/internal/cmd/drive_share.go
+++ b/internal/cmd/drive_share.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveShareCmd creates a sharing link for an item.
+type DriveShareCmd struct {
+	ID      string `arg:"" help:"Item ID"`
+	Type    string `help:"Link type" enum:"view,edit" default:"view" short:"t"`
+	Scope   string `help:"Link scope" enum:"anonymous,organization" default:"anonymous" short:"s"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveShareCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ID) {
+		return fmt.Errorf("argument looks like a path; use 'olk drive ls %s' to find item IDs", c.ID)
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would create %s sharing link (%s) for %s\n",
+			outfmt.Sanitize(c.Type), outfmt.Sanitize(c.Scope), outfmt.Sanitize(c.ID))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	link, err := client.CreateShareLink(ctx.Ctx, driveID, c.ID, c.Type, c.Scope)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(link, 1, "")
+	}
+
+	fmt.Println(outfmt.Sanitize(link.URL))
+	return nil
+}

--- a/internal/cmd/drive_shared.go
+++ b/internal/cmd/drive_shared.go
@@ -1,0 +1,25 @@
+package cmd
+
+// DriveSharedCmd lists files shared with the current user.
+type DriveSharedCmd struct {
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveSharedCmd) Run(ctx *RunContext) error {
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	items, err := client.SharedWithMeItems(ctx.Ctx, driveID)
+	if err != nil {
+		return err
+	}
+
+	return printDriveItems(ctx, items)
+}

--- a/internal/cmd/drive_upload.go
+++ b/internal/cmd/drive_upload.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+const (
+	// maxSimpleUpload is the threshold for simple PUT upload (4 MB).
+	maxSimpleUpload = 4 << 20
+	// uploadChunkSize is the chunk size for resumable uploads (10 MB, multiple of 320 KB).
+	uploadChunkSize = 10 * 1024 * 1024
+)
+
+// DriveUploadCmd uploads a file.
+type DriveUploadCmd struct {
+	LocalPath  string `arg:"" help:"Local file path" type:"existingfile"`
+	RemotePath string `arg:"" help:"Remote path (e.g. /Documents/report.pdf)"`
+	DriveID    string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+	Replace    bool   `help:"Replace existing file" default:"false"`
+}
+
+func (c *DriveUploadCmd) Run(ctx *RunContext) error {
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(c.LocalPath)
+	if err != nil {
+		return fmt.Errorf("reading local file: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("cannot upload a directory")
+	}
+
+	if ctx.Flags.DryRun {
+		fmt.Printf("Would upload %s (%s) to %s\n",
+			outfmt.Sanitize(filepath.Base(c.LocalPath)),
+			formatBytes(info.Size()),
+			outfmt.Sanitize(c.RemotePath))
+		return nil
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	if info.Size() < maxSimpleUpload {
+		// Simple upload
+		content, err := os.ReadFile(c.LocalPath)
+		if err != nil {
+			return fmt.Errorf("reading file: %w", err)
+		}
+		item, err := client.UploadSmallFile(ctx.Ctx, driveID, c.RemotePath, content, c.Replace)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Uploaded %s (%s) ID: %s\n",
+			outfmt.Sanitize(item.Name), formatBytes(item.Size), outfmt.Sanitize(item.ID))
+		return nil
+	}
+
+	// Resumable upload for large files
+	uploadURL, err := client.CreateUploadSession(ctx.Ctx, driveID, c.RemotePath, c.Replace)
+	if err != nil {
+		return err
+	}
+	if err := validateGraphURL(uploadURL); err != nil {
+		return fmt.Errorf("upload URL rejected: %w", err)
+	}
+
+	f, err := os.Open(c.LocalPath)
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+	defer f.Close()
+
+	totalSize := info.Size()
+	buf := make([]byte, uploadChunkSize)
+	var offset int64
+
+	for offset < totalSize {
+		n, err := f.Read(buf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("reading file chunk: %w", err)
+		}
+		if n == 0 {
+			break
+		}
+
+		end := offset + int64(n) - 1
+		contentRange := fmt.Sprintf("bytes %d-%d/%d", offset, end, totalSize)
+
+		req, err := http.NewRequestWithContext(ctx.Ctx, http.MethodPut, uploadURL, bytes.NewReader(buf[:n]))
+		if err != nil {
+			return fmt.Errorf("creating upload request failed")
+		}
+		req.Header.Set("Content-Range", contentRange)
+		req.ContentLength = int64(n)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("uploading chunk: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			resp.Body.Close()
+			return fmt.Errorf("upload chunk failed: HTTP %d: %s", resp.StatusCode, string(body))
+		}
+		// Drain and close body for connection reuse
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck // drain body for connection reuse
+		resp.Body.Close()
+
+		offset += int64(n)
+		pct := int(float64(offset) / float64(totalSize) * 100)
+		fmt.Fprintf(os.Stderr, "\rUploading... %d%%", pct)
+	}
+	fmt.Fprintln(os.Stderr)
+
+	fmt.Printf("Uploaded %s (%s)\n",
+		outfmt.Sanitize(filepath.Base(c.LocalPath)), formatBytes(totalSize))
+	return nil
+}

--- a/internal/cmd/drive_versions.go
+++ b/internal/cmd/drive_versions.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// DriveVersionsCmd lists version history for a file.
+type DriveVersionsCmd struct {
+	ID      string `arg:"" help:"Item ID"`
+	DriveID string `help:"Drive ID (default: primary drive)" name:"drive-id" env:"OLK_DRIVE_ID"`
+}
+
+func (c *DriveVersionsCmd) Run(ctx *RunContext) error {
+	if looksLikePath(c.ID) {
+		return fmt.Errorf("argument looks like a path; use 'olk drive ls %s' to find item IDs", c.ID)
+	}
+
+	driveID, err := resolveDriveID(ctx, c.DriveID)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+
+	versions, err := client.ListDriveItemVersions(ctx.Ctx, driveID, c.ID)
+	if err != nil {
+		return err
+	}
+
+	if len(versions) == 0 {
+		fmt.Println("No versions.")
+		return nil
+	}
+
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(versions, len(versions), "")
+	}
+
+	loc, _ := ctx.Timezone()
+	headers := []string{"VERSION", "MODIFIED", "SIZE", "MODIFIED BY"}
+	var rows [][]string
+	for _, v := range versions {
+		rows = append(rows, []string{
+			outfmt.Sanitize(v.ID),
+			outfmt.Truncate(outfmt.Sanitize(outfmt.ConvertTime(v.ModifiedAt, loc)), 16),
+			formatBytes(v.Size),
+			outfmt.Sanitize(v.ModifiedBy),
+		})
+	}
+	return printer.Print(headers, rows, versions, len(versions), "")
+}

--- a/internal/cmd/mail_attachments.go
+++ b/internal/cmd/mail_attachments.go
@@ -73,7 +73,8 @@ func safeWriteFile(path string, content []byte) (string, error) {
 	return "", fmt.Errorf("could not find available filename for %s after 1000 attempts", filepath.Base(path))
 }
 
-// sanitizeFilename removes path separators and leading dots to prevent path traversal.
+// sanitizeFilename removes path separators, control characters, and leading dots
+// to prevent path traversal and filename-based attacks.
 func sanitizeFilename(name string) string {
 	// Strip any directory components
 	name = filepath.Base(name)
@@ -81,6 +82,13 @@ func sanitizeFilename(name string) string {
 	name = strings.ReplaceAll(name, string(os.PathSeparator), "_")
 	name = strings.ReplaceAll(name, "/", "_")
 	name = strings.ReplaceAll(name, "\\", "_")
+	// Remove null bytes and control characters (U+0000–U+001F, U+007F)
+	name = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7F {
+			return -1
+		}
+		return r
+	}, name)
 	// Remove leading dots to prevent hidden files or traversal
 	name = strings.TrimLeft(name, ".")
 	if name == "" {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -161,6 +161,7 @@ type CLI struct {
 	Contacts ContactsCmd `cmd:"" help:"Contacts commands"`
 	Todo     TodoCmd     `cmd:"" help:"Microsoft To Do tasks"`
 	People   PeopleCmd   `cmd:"" help:"People directory search"`
+	Drive    DriveCmd    `cmd:"" help:"OneDrive file operations"`
 	Config   ConfigCmd   `cmd:"" help:"Configuration management"`
 	Version  VersionCmd  `cmd:"" help:"Show version information"`
 	Whoami   WhoamiCmd   `cmd:"" help:"Show current user profile"`

--- a/internal/graphapi/drive.go
+++ b/internal/graphapi/drive.go
@@ -1,0 +1,659 @@
+package graphapi
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/drives"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+// safeDriveSearchQuery matches alphanumeric, Unicode letters, spaces, @, dots, hyphens, underscores.
+// SECURITY: this whitelist prevents KQL injection in drive search queries.
+var safeDriveSearchQuery = regexp.MustCompile(`^[\p{L}\p{N} @._-]+$`)
+
+// DriveInfo is a simplified drive for output.
+type DriveInfo struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	DriveType      string `json:"driveType"`
+	QuotaTotal     int64  `json:"quotaTotal"`
+	QuotaUsed      int64  `json:"quotaUsed"`
+	QuotaRemaining int64  `json:"quotaRemaining"`
+	QuotaState     string `json:"quotaState"`
+	OwnerName      string `json:"ownerName,omitempty"`
+	OwnerEmail     string `json:"ownerEmail,omitempty"`
+	WebURL         string `json:"webUrl"`
+}
+
+// DriveItem is a simplified drive item for output.
+type DriveItem struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	ItemType    string `json:"itemType"`
+	MimeType    string `json:"mimeType,omitempty"`
+	CreatedAt   string `json:"createdDateTime"`
+	ModifiedAt  string `json:"lastModifiedDateTime"`
+	WebURL      string `json:"webUrl"`
+	DownloadURL string `json:"-"` // pre-authenticated URL with embedded token; excluded from JSON for security
+	ParentPath  string `json:"parentPath,omitempty"`
+	ChildCount  int32  `json:"childCount,omitempty"`
+	CreatedBy   string `json:"createdBy,omitempty"`
+	ModifiedBy  string `json:"modifiedBy,omitempty"`
+}
+
+// DriveItemVersion is a simplified version entry for output.
+type DriveItemVersion struct {
+	ID         string `json:"id"`
+	ModifiedAt string `json:"lastModifiedDateTime"`
+	Size       int64  `json:"size"`
+	ModifiedBy string `json:"lastModifiedBy,omitempty"`
+}
+
+// ShareLink is a simplified sharing link for output.
+type ShareLink struct {
+	ID       string `json:"id"`
+	LinkType string `json:"type"`
+	URL      string `json:"webUrl"`
+	Scope    string `json:"scope"`
+}
+
+func convertDrive(d models.Driveable) DriveInfo {
+	info := DriveInfo{
+		WebURL: derefStr(d.GetWebUrl()),
+	}
+	if d.GetId() != nil {
+		info.ID = *d.GetId()
+	}
+	if d.GetName() != nil {
+		info.Name = *d.GetName()
+	}
+	if d.GetDriveType() != nil {
+		info.DriveType = *d.GetDriveType()
+	}
+	if q := d.GetQuota(); q != nil {
+		if q.GetTotal() != nil {
+			info.QuotaTotal = *q.GetTotal()
+		}
+		if q.GetUsed() != nil {
+			info.QuotaUsed = *q.GetUsed()
+		}
+		if q.GetRemaining() != nil {
+			info.QuotaRemaining = *q.GetRemaining()
+		}
+		if q.GetState() != nil {
+			info.QuotaState = *q.GetState()
+		}
+	}
+	if o := d.GetOwner(); o != nil {
+		if u := o.GetUser(); u != nil {
+			info.OwnerName = derefStr(u.GetDisplayName())
+			// User identity doesn't expose email directly; use additionalData.
+			// Kiota may deserialize as string or *string depending on version.
+			if email, ok := u.GetAdditionalData()["email"]; ok {
+				switch v := email.(type) {
+				case string:
+					info.OwnerEmail = v
+				case *string:
+					if v != nil {
+						info.OwnerEmail = *v
+					}
+				}
+			}
+		}
+	}
+	return info
+}
+
+func convertDriveItem(d models.DriveItemable) DriveItem {
+	item := DriveItem{
+		WebURL: derefStr(d.GetWebUrl()),
+	}
+	if d.GetId() != nil {
+		item.ID = *d.GetId()
+	}
+	if d.GetName() != nil {
+		item.Name = *d.GetName()
+	}
+	if d.GetSize() != nil {
+		item.Size = *d.GetSize()
+	}
+	if d.GetFolder() != nil {
+		item.ItemType = "folder"
+		if d.GetFolder().GetChildCount() != nil {
+			item.ChildCount = *d.GetFolder().GetChildCount()
+		}
+	} else if d.GetFile() != nil {
+		item.ItemType = "file"
+		if d.GetFile().GetMimeType() != nil {
+			item.MimeType = *d.GetFile().GetMimeType()
+		}
+	}
+	if ct := d.GetCreatedDateTime(); ct != nil {
+		item.CreatedAt = ct.UTC().Format(time.RFC3339)
+	}
+	if mt := d.GetLastModifiedDateTime(); mt != nil {
+		item.ModifiedAt = mt.UTC().Format(time.RFC3339)
+	}
+	if ref := d.GetParentReference(); ref != nil {
+		item.ParentPath = derefStr(ref.GetPath())
+	}
+	if cb := d.GetCreatedBy(); cb != nil {
+		if u := cb.GetUser(); u != nil {
+			item.CreatedBy = derefStr(u.GetDisplayName())
+		}
+	}
+	if mb := d.GetLastModifiedBy(); mb != nil {
+		if u := mb.GetUser(); u != nil {
+			item.ModifiedBy = derefStr(u.GetDisplayName())
+		}
+	}
+	// Extract download URL from additional data.
+	// Kiota may deserialize this as string or *string depending on version.
+	if dlURL, ok := d.GetAdditionalData()["@microsoft.graph.downloadUrl"]; ok {
+		switch v := dlURL.(type) {
+		case string:
+			item.DownloadURL = v
+		case *string:
+			if v != nil {
+				item.DownloadURL = *v
+			}
+		}
+	}
+	return item
+}
+
+func convertDriveItemVersion(v models.DriveItemVersionable) DriveItemVersion {
+	ver := DriveItemVersion{}
+	if v.GetId() != nil {
+		ver.ID = *v.GetId()
+	}
+	if mt := v.GetLastModifiedDateTime(); mt != nil {
+		ver.ModifiedAt = mt.UTC().Format(time.RFC3339)
+	}
+	if v.GetSize() != nil {
+		ver.Size = *v.GetSize()
+	}
+	if mb := v.GetLastModifiedBy(); mb != nil {
+		if u := mb.GetUser(); u != nil {
+			ver.ModifiedBy = derefStr(u.GetDisplayName())
+		}
+	}
+	return ver
+}
+
+// validateDrivePath validates a OneDrive path for safety.
+func validateDrivePath(path string) error {
+	if strings.ContainsRune(path, '\x00') {
+		return fmt.Errorf("path contains null byte")
+	}
+	if len(path) > 400 {
+		return fmt.Errorf("path too long: %d characters (max 400)", len(path))
+	}
+	clean := strings.Trim(path, "/")
+	if clean == "" {
+		return nil
+	}
+	for _, seg := range strings.Split(clean, "/") {
+		if seg == "" {
+			return fmt.Errorf("path contains empty segment")
+		}
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("path contains unsafe segment %q", seg)
+		}
+	}
+	return nil
+}
+
+// encodePathSegments URL-encodes each path segment individually.
+func encodePathSegments(path string) string {
+	clean := strings.Trim(path, "/")
+	if clean == "" {
+		return ""
+	}
+	parts := strings.Split(clean, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// ListDrives returns all drives for the current user.
+func (c *Client) ListDrives(ctx context.Context) ([]DriveInfo, error) {
+	resp, err := c.inner.Me().Drives().Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("listing drives", err)
+	}
+	var result []DriveInfo
+	for _, d := range resp.GetValue() {
+		result = append(result, convertDrive(d))
+	}
+	return result, nil
+}
+
+// GetDrive returns details for a specific drive, or the default drive if driveID is empty.
+func (c *Client) GetDrive(ctx context.Context, driveID string) (*DriveInfo, error) {
+	var d models.Driveable
+	var err error
+	if driveID == "" {
+		d, err = c.inner.Me().Drive().Get(ctx, nil)
+	} else {
+		if e := validateID(driveID, "drive ID"); e != nil {
+			return nil, e
+		}
+		d, err = c.inner.Drives().ByDriveId(driveID).Get(ctx, nil)
+	}
+	if err != nil {
+		return nil, scopeUpgradeError("getting drive", err)
+	}
+	info := convertDrive(d)
+	return &info, nil
+}
+
+// ListDriveChildren returns items in a folder by item ID.
+func (c *Client) ListDriveChildren(ctx context.Context, driveID, itemID string, top int32) ([]DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if itemID == "" {
+		itemID = "root"
+	}
+	top = clampTop(top)
+	topVal := top
+	orderBy := "name asc"
+	config := &drives.ItemItemsItemChildrenRequestBuilderGetRequestConfiguration{
+		QueryParameters: &drives.ItemItemsItemChildrenRequestBuilderGetQueryParameters{
+			Top:     &topVal,
+			Orderby: []string{orderBy},
+		},
+	}
+	resp, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Children().Get(ctx, config)
+	if err != nil {
+		return nil, scopeUpgradeError("listing folder contents", err)
+	}
+	var result []DriveItem
+	for _, d := range resp.GetValue() {
+		result = append(result, convertDriveItem(d))
+	}
+	return result, nil
+}
+
+// ListDriveChildrenByPath returns items in a folder by path.
+func (c *Client) ListDriveChildrenByPath(ctx context.Context, driveID, path string, top int32) ([]DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateDrivePath(path); err != nil {
+		return nil, err
+	}
+	clean := strings.Trim(path, "/")
+	if clean == "" {
+		return c.ListDriveChildren(ctx, driveID, "root", top)
+	}
+	top = clampTop(top)
+	topVal := top
+	orderBy := "name asc"
+	encoded := encodePathSegments(clean)
+	rawURL := fmt.Sprintf("https://graph.microsoft.com/v1.0/drives/%s/root:/%s:/children",
+		url.PathEscape(driveID), encoded)
+	builder := drives.NewItemItemsItemChildrenRequestBuilder(rawURL, c.inner.GetAdapter())
+	config := &drives.ItemItemsItemChildrenRequestBuilderGetRequestConfiguration{
+		QueryParameters: &drives.ItemItemsItemChildrenRequestBuilderGetQueryParameters{
+			Top:     &topVal,
+			Orderby: []string{orderBy},
+		},
+	}
+	resp, err := builder.Get(ctx, config)
+	if err != nil {
+		return nil, scopeUpgradeError("listing folder contents", err)
+	}
+	var result []DriveItem
+	for _, d := range resp.GetValue() {
+		result = append(result, convertDriveItem(d))
+	}
+	return result, nil
+}
+
+// GetDriveItem returns metadata for a specific item.
+func (c *Client) GetDriveItem(ctx context.Context, driveID, itemID string) (*DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return nil, err
+	}
+	resp, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("getting item", err)
+	}
+	item := convertDriveItem(resp)
+	return &item, nil
+}
+
+// SearchDrive searches for items matching a query.
+func (c *Client) SearchDrive(ctx context.Context, driveID, query string, top int32) ([]DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if query == "" {
+		return nil, fmt.Errorf("search query cannot be empty")
+	}
+	if len(query) > 1024 {
+		return nil, fmt.Errorf("search query too long: %d characters (max 1024)", len(query))
+	}
+	if !safeDriveSearchQuery.MatchString(query) {
+		return nil, fmt.Errorf("search query contains invalid characters")
+	}
+	top = clampTop(top)
+	resp, err := c.inner.Drives().ByDriveId(driveID).SearchWithQ(&query).Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("searching drive", err)
+	}
+	var result []DriveItem
+	for _, d := range resp.GetValue() {
+		result = append(result, convertDriveItem(d))
+	}
+	// Limit results to top
+	if int32(len(result)) > top {
+		result = result[:top]
+	}
+	return result, nil
+}
+
+// RecentDriveItems returns recently accessed items.
+func (c *Client) RecentDriveItems(ctx context.Context, driveID string) ([]DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	resp, err := c.inner.Drives().ByDriveId(driveID).Recent().Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("getting recent items", err)
+	}
+	var result []DriveItem
+	for _, d := range resp.GetValue() {
+		result = append(result, convertDriveItem(d))
+	}
+	return result, nil
+}
+
+// SharedWithMeItems returns items shared with the current user.
+func (c *Client) SharedWithMeItems(ctx context.Context, driveID string) ([]DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	resp, err := c.inner.Drives().ByDriveId(driveID).SharedWithMe().Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("getting shared items", err)
+	}
+	var result []DriveItem
+	for _, d := range resp.GetValue() {
+		result = append(result, convertDriveItem(d))
+	}
+	return result, nil
+}
+
+// DownloadDriveItem downloads file content by item ID.
+// For large files, use GetDriveItem to get the DownloadURL and stream directly.
+func (c *Client) DownloadDriveItem(ctx context.Context, driveID, itemID string) ([]byte, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return nil, err
+	}
+	content, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Content().Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("downloading item", err)
+	}
+	return content, nil
+}
+
+// UploadSmallFile uploads a file under 4MB via simple PUT.
+func (c *Client) UploadSmallFile(ctx context.Context, driveID, remotePath string, content []byte, replace bool) (*DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateDrivePath(remotePath); err != nil {
+		return nil, err
+	}
+	encoded := encodePathSegments(strings.Trim(remotePath, "/"))
+	conflict := "fail"
+	if replace {
+		conflict = "replace"
+	}
+	rawURL := fmt.Sprintf("https://graph.microsoft.com/v1.0/drives/%s/root:/%s:/content?@microsoft.graph.conflictBehavior=%s",
+		url.PathEscape(driveID), encoded, conflict)
+	builder := drives.NewItemItemsItemContentRequestBuilder(rawURL, c.inner.GetAdapter())
+	resp, err := builder.Put(ctx, content, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("uploading file", err)
+	}
+	item := convertDriveItem(resp)
+	return &item, nil
+}
+
+// CreateUploadSession creates a resumable upload session for large files (>= 4MB).
+func (c *Client) CreateUploadSession(ctx context.Context, driveID, remotePath string, replace bool) (string, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return "", err
+	}
+	if err := validateDrivePath(remotePath); err != nil {
+		return "", err
+	}
+	encoded := encodePathSegments(strings.Trim(remotePath, "/"))
+	rawURL := fmt.Sprintf("https://graph.microsoft.com/v1.0/drives/%s/root:/%s:/createUploadSession",
+		url.PathEscape(driveID), encoded)
+
+	// Build request body with conflict behavior
+	body := drives.NewItemItemsItemCreateUploadSessionPostRequestBody()
+	props := models.NewDriveItemUploadableProperties()
+	conflict := "fail"
+	if replace {
+		conflict = "replace"
+	}
+	props.SetAdditionalData(map[string]interface{}{
+		"@microsoft.graph.conflictBehavior": conflict,
+	})
+	body.SetItem(props)
+
+	builder := drives.NewItemItemsItemCreateUploadSessionRequestBuilder(rawURL, c.inner.GetAdapter())
+	session, err := builder.Post(ctx, body, nil)
+	if err != nil {
+		return "", scopeUpgradeError("creating upload session", err)
+	}
+	if session.GetUploadUrl() == nil {
+		return "", fmt.Errorf("upload session created but no upload URL returned")
+	}
+	return *session.GetUploadUrl(), nil
+}
+
+// CreateFolder creates a new folder under the given parent item ID.
+func (c *Client) CreateFolder(ctx context.Context, driveID, parentItemID, folderName string) (*DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if parentItemID == "" {
+		parentItemID = "root"
+	}
+	if folderName == "" {
+		return nil, fmt.Errorf("folder name cannot be empty")
+	}
+	newItem := models.NewDriveItem()
+	newItem.SetName(&folderName)
+	folder := models.NewFolder()
+	newItem.SetFolder(folder)
+	// Set conflict behavior to fail
+	newItem.SetAdditionalData(map[string]interface{}{
+		"@microsoft.graph.conflictBehavior": "fail",
+	})
+
+	resp, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(parentItemID).Children().Post(ctx, newItem, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("creating folder", err)
+	}
+	item := convertDriveItem(resp)
+	return &item, nil
+}
+
+// CopyDriveItem initiates an async copy of an item to a new parent.
+func (c *Client) CopyDriveItem(ctx context.Context, driveID, itemID, destParentID, newName string) error {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return err
+	}
+	if err := validateID(destParentID, "destination parent ID"); err != nil {
+		return err
+	}
+
+	body := drives.NewItemItemsItemCopyPostRequestBody()
+	parentRef := models.NewItemReference()
+	parentRef.SetDriveId(&driveID)
+	parentRef.SetId(&destParentID)
+	body.SetParentReference(parentRef)
+	if newName != "" {
+		body.SetName(&newName)
+	}
+
+	_, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Copy().Post(ctx, body, nil)
+	if err != nil {
+		return scopeUpgradeError("copying item", err)
+	}
+	return nil
+}
+
+// MoveDriveItem moves or renames an item.
+func (c *Client) MoveDriveItem(ctx context.Context, driveID, itemID, destParentID, newName string) (*DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return nil, err
+	}
+
+	patch := models.NewDriveItem()
+	if destParentID != "" {
+		if err := validateID(destParentID, "destination parent ID"); err != nil {
+			return nil, err
+		}
+		parentRef := models.NewItemReference()
+		parentRef.SetId(&destParentID)
+		patch.SetParentReference(parentRef)
+	}
+	if newName != "" {
+		patch.SetName(&newName)
+	}
+
+	resp, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Patch(ctx, patch, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("moving item", err)
+	}
+	item := convertDriveItem(resp)
+	return &item, nil
+}
+
+// DeleteDriveItem deletes an item.
+func (c *Client) DeleteDriveItem(ctx context.Context, driveID, itemID string) error {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return err
+	}
+	err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Delete(ctx, nil)
+	if err != nil {
+		return scopeUpgradeError("deleting item", err)
+	}
+	return nil
+}
+
+// CreateShareLink creates a sharing link for an item.
+func (c *Client) CreateShareLink(ctx context.Context, driveID, itemID, linkType, scope string) (*ShareLink, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return nil, err
+	}
+
+	body := drives.NewItemItemsItemCreateLinkPostRequestBody()
+	body.SetTypeEscaped(&linkType)
+	body.SetScope(&scope)
+
+	perm, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).CreateLink().Post(ctx, body, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("creating share link", err)
+	}
+
+	link := &ShareLink{}
+	if perm.GetId() != nil {
+		link.ID = *perm.GetId()
+	}
+	if l := perm.GetLink(); l != nil {
+		if l.GetTypeEscaped() != nil {
+			link.LinkType = *l.GetTypeEscaped()
+		}
+		if l.GetWebUrl() != nil {
+			link.URL = *l.GetWebUrl()
+		}
+		if l.GetScope() != nil {
+			link.Scope = *l.GetScope()
+		}
+	}
+	return link, nil
+}
+
+// ListDriveItemVersions returns version history for an item.
+func (c *Client) ListDriveItemVersions(ctx context.Context, driveID, itemID string) ([]DriveItemVersion, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateID(itemID, "item ID"); err != nil {
+		return nil, err
+	}
+	resp, err := c.inner.Drives().ByDriveId(driveID).Items().ByDriveItemId(itemID).Versions().Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("listing versions", err)
+	}
+	var result []DriveItemVersion
+	for _, v := range resp.GetValue() {
+		result = append(result, convertDriveItemVersion(v))
+	}
+	return result, nil
+}
+
+// ResolveItemByPath resolves a path to a DriveItem using the Graph API path syntax.
+func (c *Client) ResolveItemByPath(ctx context.Context, driveID, path string) (*DriveItem, error) {
+	if err := validateID(driveID, "drive ID"); err != nil {
+		return nil, err
+	}
+	if err := validateDrivePath(path); err != nil {
+		return nil, err
+	}
+	clean := strings.Trim(path, "/")
+	if clean == "" {
+		// Root item
+		resp, err := c.inner.Drives().ByDriveId(driveID).Root().Get(ctx, nil)
+		if err != nil {
+			return nil, scopeUpgradeError("resolving path", err)
+		}
+		item := convertDriveItem(resp)
+		return &item, nil
+	}
+	encoded := encodePathSegments(clean)
+	rawURL := fmt.Sprintf("https://graph.microsoft.com/v1.0/drives/%s/root:/%s:",
+		url.PathEscape(driveID), encoded)
+	builder := drives.NewItemItemsDriveItemItemRequestBuilder(rawURL, c.inner.GetAdapter())
+	resp, err := builder.Get(ctx, nil)
+	if err != nil {
+		return nil, scopeUpgradeError("resolving path", err)
+	}
+	item := convertDriveItem(resp)
+	return &item, nil
+}

--- a/internal/graphapi/validate.go
+++ b/internal/graphapi/validate.go
@@ -13,8 +13,8 @@ import (
 // graphTimeZoneUTC is the time zone string Microsoft Graph expects on dateTimeTimeZone values.
 const graphTimeZoneUTC = "UTC"
 
-// safeIDPattern matches typical Microsoft Graph IDs (alphanumeric, hyphens, underscores, equals, plus, slash for base64).
-var safeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_=+/-]+$`)
+// safeIDPattern matches typical Microsoft Graph IDs (alphanumeric, hyphens, underscores, equals, plus, slash for base64, exclamation for OneDrive).
+var safeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_=+/!-]+$`)
 
 // validateID checks that an ID parameter contains only safe characters.
 func validateID(id, label string) error {
@@ -135,6 +135,21 @@ func enterpriseError(action string, err error) error {
 		strings.Contains(lower, "mailboxnotenabledforrestapi")
 	if needsEnterprise {
 		return fmt.Errorf("%s: %s\n  Note: this feature requires a work/school (Microsoft 365) account and is not available for personal Microsoft accounts (Outlook.com, Hotmail, Live.com)", action, msg)
+	}
+	return fmt.Errorf("%s: %s", action, msg)
+}
+
+// scopeUpgradeError wraps a Graph API error with a hint to re-login
+// when the error indicates missing permissions (e.g. token lacks a newly added scope).
+func scopeUpgradeError(action string, err error) error {
+	msg := graphErrorMessage(err)
+	lower := strings.ToLower(msg)
+	needsReauth := strings.Contains(lower, "accessdenied") ||
+		strings.Contains(lower, "insufficient") ||
+		(strings.Contains(lower, "access") && strings.Contains(lower, "denied")) ||
+		strings.Contains(lower, "authorization_requestdenied")
+	if needsReauth {
+		return fmt.Errorf("%s: %s\n  Hint: you may need to re-login to grant new permissions: olk auth login", action, msg)
 	}
 	return fmt.Errorf("%s: %s", action, msg)
 }

--- a/internal/msauth/auth.go
+++ b/internal/msauth/auth.go
@@ -27,8 +27,9 @@ var (
 )
 
 // emailMutex returns a per-email mutex for serializing token refresh operations.
+// Email is lowercased to match the canonical key used in TokenKey().
 func emailMutex(email string) *sync.Mutex {
-	val, _ := refreshMuMap.LoadOrStore(email, &sync.Mutex{})
+	val, _ := refreshMuMap.LoadOrStore(strings.ToLower(email), &sync.Mutex{})
 	return val.(*sync.Mutex)
 }
 

--- a/internal/msauth/scopes.go
+++ b/internal/msauth/scopes.go
@@ -7,6 +7,7 @@ const (
 	ScopeCalendar        = "Calendars.ReadWrite"
 	ScopeContacts        = "Contacts.ReadWrite"
 	ScopeTasks           = "Tasks.ReadWrite"
+	ScopeFiles           = "Files.ReadWrite"
 	ScopePeople          = "People.Read"
 	ScopeUser            = "User.Read"
 	ScopeUserReadAll     = "User.ReadBasic.All"
@@ -23,6 +24,7 @@ func DefaultScopes() []string {
 		ScopeCalendar,
 		ScopeContacts,
 		ScopeTasks,
+		ScopeFiles,
 		ScopePeople,
 	}
 }
@@ -43,6 +45,7 @@ func ReadOnlyScopes() []string {
 		"Calendars.Read",
 		"Contacts.Read",
 		"Tasks.Read",
+		"Files.Read",
 		"People.Read",
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `olk drive` command group with **15 subcommands** for OneDrive file management: `list`, `info`, `ls`, `get`, `search`, `recent`, `shared`, `download`, `upload`, `mkdir`, `cp`, `mv`, `rm`, `share`, `versions`
- Scoped to user's personal/business OneDrive — no SharePoint dependencies
- Adds `Files.ReadWrite` OAuth scope (personal + enterprise); `Files.Read` for read-only login
- All output formats supported: table (default), JSON (`--json`), TSV (`--plain`)

### Key design decisions

- **Path-based access** via Graph API raw URL builders (`/drives/{id}/root:/{path}:`)
- **Dual upload path**: simple PUT for <4MB, resumable chunked sessions for >=4MB with progress output
- **Streaming download** for large files (>50MB) via `@microsoft.graph.downloadUrl` with `io.LimitReader` bound; small files use SDK `Content().Get()`
- **Scope-upgrade UX**: `scopeUpgradeError()` detects 403s from missing scopes and hints `olk auth login`

### Security hardening

- Pre-authenticated download URLs excluded from JSON output (`json:"-"`) to prevent token leakage
- `validateGraphURL()` enforces HTTPS + Microsoft host allowlist + DNS resolution SSRF check
- KQL injection prevention on search queries via `safeDriveSearchQuery` regex
- `sanitizeFilename` strips null bytes and control characters (hardened for both mail and drive)
- `validateDrivePath` rejects traversal (`..`), single-dot (`.`), null bytes
- `safeCreateFile` with `O_EXCL` prevents overwrite; numeric suffix collision avoidance
- Error messages sanitized to avoid leaking pre-auth URL tokens
- `emailMutex` normalized to lowercase matching `TokenKey` canonicalization
- `safeIDPattern` extended with `!` for OneDrive item IDs

## Test plan

- [x] `make build` — compiles cleanly
- [x] `make lint` — 0 issues
- [x] `make test` — all passing
- [x] All 15 commands tested against **consumer account** (rramesan@outlook.com)
- [x] All 15 commands tested against **enterprise account** (roshinlal@nextgenchannels.onmicrosoft.com)
- [x] Verified all 3 output formats (table, JSON, plain TSV)
- [x] Verified `--force` guard on `drive rm`
- [x] Verified `--dry-run` on all mutation commands (upload, download, mkdir, cp, mv, rm, share)
- [x] Verified upload conflict behavior (`fail` default, `--replace` override)
- [x] Verified path-like ID hint errors
- [x] Security audit: govulncheck clean, gosec clean, manual audit complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)