### PR TITLE
fix(secrets): write keyring prompt to stderr, add OLK_KEYRING_PASSWORD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@
 ## Security & Configuration
 
 - Never commit OAuth tokens or client secrets.
-- Prefer OS keychain backends; the file fallback is for headless environments only.
+- Prefer OS keychain backends; the file fallback is for headless environments only. Set `OLK_KEYRING_PASSWORD` for non-interactive file-backend access.
 - Config dir (`~/.config/olk/`) uses 0700 permissions; token files use 0600.
 - Device code flow uses PKCE (RFC 7636) — `code_challenge` sent with device code request, `code_verifier` sent during token polling.
 - Token refresh is serialized per-email via `sync.Map` of mutexes in `internal/msauth/auth.go` to prevent race conditions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ go mod tidy         # After changing dependencies
 - **CLI framework**: `github.com/alecthomas/kong` — commands are Go structs with `Run(ctx *RunContext) error`
 - **Auth**: Raw OAuth2 device code flow with PKCE (RFC 7636) against `login.microsoftonline.com` — no MSAL. Scopes defined in `internal/msauth/scopes.go`. Enterprise-only scopes (`MailboxSettings.ReadWrite`, `User.ReadBasic.All`) are only requested with `--enterprise` flag — personal accounts cannot consent to them. Token refresh is serialized per-email via `sync.Map` of mutexes to prevent race conditions
 - **API**: Official `msgraph-sdk-go` wrapped in `internal/graphapi/` for ergonomic access
-- **Secrets**: OS keyring via `github.com/99designs/keyring` (macOS Keychain, Linux Secret Service, Windows WinCred)
+- **Secrets**: OS keyring via `github.com/99designs/keyring` (macOS Keychain, Linux Secret Service, Windows WinCred). File-backend password prompt writes to stderr (not stdout) to avoid corrupting piped output. Set `OLK_KEYRING_PASSWORD` for headless/non-interactive use
 - **Output**: JSON envelope (`--json`), aligned table (default), TSV (`--plain`)
 - **Timezone**: Display-layer conversion via `outfmt.ConvertTime()`. Resolved once per command via `RunContext.Timezone()` (flag > env > config > Local). JSON output keeps raw UTC; envelope includes `timezone` field. IANA db embedded via `import _ "time/tzdata"`
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ Refresh tokens are stored in the OS credential manager:
 - **Linux**: Secret Service (GNOME Keyring / KDE Wallet)
 - **Windows**: Windows Credential Manager
 
+When no native credential manager is available (e.g. headless Linux without Secret Service), `olk` falls back to an encrypted file store and prompts for a password on **stderr**.
+
+#### Headless / Non-interactive Use
+
+For headless environments, CI/CD pipelines, or LLM-driven automation, set the `OLK_KEYRING_PASSWORD` environment variable to supply the file-backend password without an interactive prompt:
+
+```bash
+export OLK_KEYRING_PASSWORD="your-keyring-password"
+olk mail list --json | jq '.subject'
+```
+
 ## Shortcuts
 
 For common workflows, `olk` provides top-level shortcuts:
@@ -246,6 +257,7 @@ For common workflows, `olk` provides top-level shortcuts:
 | `--select FIELDS` | `OLK_SELECT` | Field projection |
 | `--results-only` | `OLK_RESULTS_ONLY` | Unwrap JSON envelope |
 | `--tz TIMEZONE` | `OLK_TIMEZONE` | IANA time zone for display (e.g. `America/New_York`) |
+| | `OLK_KEYRING_PASSWORD` | File-backend keyring password (for headless use) |
 
 ## Commands Reference
 
@@ -483,7 +495,7 @@ Most features work with both personal and enterprise accounts. A few features re
 
 - **No telemetry**: `olk` collects no analytics, usage data, or crash reports
 - **No third-party services**: All communication is directly between your machine and Microsoft Graph API
-- **Token storage**: OAuth refresh tokens are stored in your OS credential manager (macOS Keychain, Linux Secret Service, Windows Credential Manager) — never in plain-text files
+- **Token storage**: OAuth refresh tokens are stored in your OS credential manager (macOS Keychain, Linux Secret Service, Windows Credential Manager) — never in plain-text files. The encrypted file fallback prompts on stderr; set `OLK_KEYRING_PASSWORD` for non-interactive use
 - **PKCE**: Device code flow uses Proof Key for Code Exchange (RFC 7636) for defense-in-depth
 - **Data stays local**: Email bodies, attachments, and contacts are streamed to stdout and never cached to disk
 - **Clean removal**: Run `olk auth clean --force` to remove all stored accounts and tokens

--- a/SKILL.md
+++ b/SKILL.md
@@ -260,6 +260,7 @@ Notes
 - Set `OLK_ACCOUNT=you@example.com` to avoid repeating `--account`.
 - Set `OLK_TODO_LIST=<list-id>` to avoid repeating `--list` for todo commands.
 - Set `OLK_DRIVE_ID=<drive-id>` to avoid repeating `--drive-id` for drive commands.
+- Set `OLK_KEYRING_PASSWORD=<password>` for headless/non-interactive environments (file-backend keyring).
 - For scripting, prefer `--json --results-only` plus `jq`.
 - IDs are opaque Microsoft Graph strings. Always get them from `list` or `search` first — never guess.
 - Dates are ISO 8601: `2025-06-15` or `2025-06-15T09:00`.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/microsoft/kiota-abstractions-go v1.9.3
 	github.com/microsoftgraph/msgraph-sdk-go v1.96.0
+	golang.org/x/term v0.39.0
 	golang.org/x/text v0.33.0
 )
 
@@ -36,5 +37,4 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 )

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/99designs/keyring"
+	"golang.org/x/term"
 
 	"github.com/rlrghb/olkcli/internal/config"
 )
@@ -32,6 +33,37 @@ type KeyringStore struct {
 	ring keyring.Keyring
 }
 
+// stderrPrompt prompts for a password on stderr and reads it from the
+// controlling terminal. Unlike keyring.TerminalPrompt it never writes to
+// stdout, so JSON/pipe output is not corrupted.
+func stderrPrompt(prompt string) (string, error) {
+	if runtime.GOOS == "windows" {
+		fmt.Fprintf(os.Stderr, "%s: ", prompt)
+		b, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", fmt.Errorf("reading password: %w", err)
+		}
+		fmt.Fprintln(os.Stderr)
+		return string(b), nil
+	}
+
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		return "", fmt.Errorf(
+			"cannot open terminal for password prompt: %w\n"+
+				"Set OLK_KEYRING_PASSWORD to provide the keyring password non-interactively", err)
+	}
+	defer tty.Close()
+
+	fmt.Fprintf(os.Stderr, "%s: ", prompt)
+	b, err := term.ReadPassword(int(tty.Fd()))
+	if err != nil {
+		return "", fmt.Errorf("reading password: %w", err)
+	}
+	fmt.Fprintln(os.Stderr)
+	return string(b), nil
+}
+
 // NewKeyringStore creates a new KeyringStore backed by the OS credential manager.
 func NewKeyringStore() (*KeyringStore, error) {
 	// Pre-create keyring fallback directory with restrictive permissions
@@ -45,6 +77,15 @@ func NewKeyringStore() (*KeyringStore, error) {
 		if err := os.Chmod(keyringDir, 0o700); err != nil {
 			return nil, fmt.Errorf("setting keyring directory permissions: %w", err)
 		}
+	}
+
+	// Use OLK_KEYRING_PASSWORD for non-interactive/headless environments;
+	// otherwise prompt on stderr to avoid corrupting piped output.
+	var passwordFunc keyring.PromptFunc
+	if pw := os.Getenv("OLK_KEYRING_PASSWORD"); pw != "" {
+		passwordFunc = keyring.FixedStringPrompt(pw)
+	} else {
+		passwordFunc = stderrPrompt
 	}
 
 	cfg := keyring.Config{
@@ -64,7 +105,7 @@ func NewKeyringStore() (*KeyringStore, error) {
 		// Fall back to an encrypted file store when no native backend is
 		// available (e.g. headless Linux without Secret Service).
 		FileDir:          keyringDir,
-		FilePasswordFunc: keyring.TerminalPrompt,
+		FilePasswordFunc: passwordFunc,
 	}
 
 	// On macOS, prefer Keychain (native UI with "Always Allow") but fall


### PR DESCRIPTION
## Summary

- Replace `keyring.TerminalPrompt` (writes to stdout) with a custom `stderrPrompt` that writes to **stderr** and reads from `/dev/tty`, preventing JSON output corruption when piping (e.g. `olk mail list --json | jq`)
- Add `OLK_KEYRING_PASSWORD` env var for headless/non-interactive environments (CI/CD, LLM automation, headless Linux VMs)
- On headless systems without a terminal, return a clear error pointing to `OLK_KEYRING_PASSWORD` instead of hanging

Closes #16

## Test plan

- [ ] `make build` compiles cleanly
- [ ] `make test` passes
- [ ] `make lint` — zero issues
- [ ] Verify password prompt text does not appear on stdout when piping JSON output
- [ ] Verify `OLK_KEYRING_PASSWORD=<pw>` skips interactive prompt on file-backend keyring
- [ ] Verify macOS Keychain path is unaffected (no prompt when Keychain is available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)