### PR TITLE
fix(graphapi): normalize Graph dateTimeTimeZone to RFC3339 UTC in JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ go mod tidy         # After changing dependencies
 - **API**: Official `msgraph-sdk-go` wrapped in `internal/graphapi/` for ergonomic access
 - **Secrets**: OS keyring via `github.com/99designs/keyring` (macOS Keychain, Linux Secret Service, Windows WinCred). File-backend password prompt writes to stderr (not stdout) to avoid corrupting piped output. Set `OLK_KEYRING_PASSWORD` for headless/non-interactive use
 - **Output**: JSON envelope (`--json`), aligned table (default), TSV (`--plain`)
-- **Timezone**: Display-layer conversion via `outfmt.ConvertTime()`. Resolved once per command via `RunContext.Timezone()` (flag > env > config > Local). JSON output keeps raw UTC; envelope includes `timezone` field. IANA db embedded via `import _ "time/tzdata"`
+- **Timezone**: Display-layer conversion via `outfmt.ConvertTime()`. Resolved once per command via `RunContext.Timezone()` (flag > env > config > Local). JSON output emits UTC timestamps as RFC3339 with a `Z` suffix (normalized via `normalizeGraphUTC` — Graph's `DateTimeTimeZone.dateTime` strings lack a zone); envelope includes `timezone` field. IANA db embedded via `import _ "time/tzdata"`
 
 ## Key Patterns
 
@@ -65,7 +65,7 @@ Add it to `RootFlags` in `internal/cmd/root.go` with `env:"OLK_*"` tag.
 ### Adding timezone conversion to a new command
 1. Get the location: `loc, _ := ctx.Timezone()`
 2. Wrap time fields: `outfmt.ConvertTime(field, loc)`
-3. Only convert for table/plain output — JSON keeps raw UTC strings
+3. Only convert for table/plain output — JSON keeps RFC3339 UTC strings (`...Z`). When pulling a value from Graph's `DateTimeTimeZone.GetDateTime()` into a JSON-tagged field, wrap the deref with `normalizeGraphUTC(...)` so the emitted string has a zone suffix.
 
 ### Changing Graph API calls
 Edit files in `internal/graphapi/` — these wrap the verbose SDK calls into simple methods returning plain structs.

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ export OLK_TIMEZONE=Europe/London
 olk config set timezone America/Chicago
 ```
 
-Precedence: `--tz` flag > `OLK_TIMEZONE` env var > config file > system local timezone. JSON output always contains raw UTC strings; the `timezone` field in the envelope indicates the display timezone.
+Precedence: `--tz` flag > `OLK_TIMEZONE` env var > config file > system local timezone. JSON output emits UTC timestamps as RFC3339 with a `Z` suffix (e.g. `2026-04-22T15:15:00Z`), so `new Date(...)` parses them correctly; the `timezone` field in the envelope indicates the display timezone.
 
 ## Scripting Examples
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -198,7 +198,7 @@ Configuration
 - Set timezone: `olk config set timezone America/New_York`
 - Get timezone: `olk config get timezone`
 - Timezone precedence: `--tz` flag > `OLK_TIMEZONE` env > config file > system local
-- JSON output keeps raw UTC times; envelope includes `"timezone"` field
+- JSON output emits UTC times as RFC3339 with a `Z` suffix (so `new Date(...)` parses them correctly); envelope includes `"timezone"` field
 
 User Profile
 

--- a/internal/graphapi/availability.go
+++ b/internal/graphapi/availability.go
@@ -71,10 +71,10 @@ func (c *Client) GetSchedule(ctx context.Context, emails []string, start, end ti
 				si.Status = item.GetStatus().String()
 			}
 			if item.GetStart() != nil && item.GetStart().GetDateTime() != nil {
-				si.Start = *item.GetStart().GetDateTime()
+				si.Start = normalizeGraphUTC(*item.GetStart().GetDateTime())
 			}
 			if item.GetEnd() != nil && item.GetEnd().GetDateTime() != nil {
-				si.End = *item.GetEnd().GetDateTime()
+				si.End = normalizeGraphUTC(*item.GetEnd().GetDateTime())
 			}
 			if item.GetSubject() != nil {
 				si.Subject = *item.GetSubject()

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -274,10 +274,10 @@ func convertEvent(e models.Eventable) CalendarEvent {
 		ev.Subject = *e.GetSubject()
 	}
 	if e.GetStart() != nil && e.GetStart().GetDateTime() != nil {
-		ev.Start = *e.GetStart().GetDateTime()
+		ev.Start = normalizeGraphUTC(*e.GetStart().GetDateTime())
 	}
 	if e.GetEnd() != nil && e.GetEnd().GetDateTime() != nil {
-		ev.End = *e.GetEnd().GetDateTime()
+		ev.End = normalizeGraphUTC(*e.GetEnd().GetDateTime())
 	}
 	if e.GetLocation() != nil && e.GetLocation().GetDisplayName() != nil {
 		ev.Location = *e.GetLocation().GetDisplayName()
@@ -550,10 +550,10 @@ func (c *Client) FindMeetingTimes(ctx context.Context, attendees []string, start
 		}
 		if ts := s.GetMeetingTimeSlot(); ts != nil {
 			if ts.GetStart() != nil && ts.GetStart().GetDateTime() != nil {
-				suggestion.Start = *ts.GetStart().GetDateTime()
+				suggestion.Start = normalizeGraphUTC(*ts.GetStart().GetDateTime())
 			}
 			if ts.GetEnd() != nil && ts.GetEnd().GetDateTime() != nil {
-				suggestion.End = *ts.GetEnd().GetDateTime()
+				suggestion.End = normalizeGraphUTC(*ts.GetEnd().GetDateTime())
 			}
 		}
 		for _, a := range s.GetAttendeeAvailability() {

--- a/internal/graphapi/mailbox_settings.go
+++ b/internal/graphapi/mailbox_settings.go
@@ -49,10 +49,10 @@ func (c *Client) GetAutoReply(ctx context.Context) (*AutoReplySettings, error) {
 		result.ExternalAudience = ars.GetExternalAudience().String()
 	}
 	if ars.GetScheduledStartDateTime() != nil && ars.GetScheduledStartDateTime().GetDateTime() != nil {
-		result.StartTime = *ars.GetScheduledStartDateTime().GetDateTime()
+		result.StartTime = normalizeGraphUTC(*ars.GetScheduledStartDateTime().GetDateTime())
 	}
 	if ars.GetScheduledEndDateTime() != nil && ars.GetScheduledEndDateTime().GetDateTime() != nil {
-		result.EndTime = *ars.GetScheduledEndDateTime().GetDateTime()
+		result.EndTime = normalizeGraphUTC(*ars.GetScheduledEndDateTime().GetDateTime())
 	}
 
 	return result, nil

--- a/internal/graphapi/todo.go
+++ b/internal/graphapi/todo.go
@@ -470,22 +470,22 @@ func convertTodoTask(t models.TodoTaskable) TodoTask {
 		task.CreatedAt = t.GetCreatedDateTime().Format("2006-01-02T15:04:05Z")
 	}
 	if t.GetCompletedDateTime() != nil && t.GetCompletedDateTime().GetDateTime() != nil {
-		task.CompletedAt = *t.GetCompletedDateTime().GetDateTime()
+		task.CompletedAt = normalizeGraphUTC(*t.GetCompletedDateTime().GetDateTime())
 	}
 	if t.GetDueDateTime() != nil && t.GetDueDateTime().GetDateTime() != nil {
-		task.DueDate = *t.GetDueDateTime().GetDateTime()
+		task.DueDate = normalizeGraphUTC(*t.GetDueDateTime().GetDateTime())
 	}
 	if t.GetBody() != nil && t.GetBody().GetContent() != nil {
 		task.Body = *t.GetBody().GetContent()
 	}
 	if t.GetStartDateTime() != nil && t.GetStartDateTime().GetDateTime() != nil {
-		task.StartDate = *t.GetStartDateTime().GetDateTime()
+		task.StartDate = normalizeGraphUTC(*t.GetStartDateTime().GetDateTime())
 	}
 	if t.GetIsReminderOn() != nil {
 		task.IsReminderOn = *t.GetIsReminderOn()
 	}
 	if t.GetReminderDateTime() != nil && t.GetReminderDateTime().GetDateTime() != nil {
-		task.ReminderDate = *t.GetReminderDateTime().GetDateTime()
+		task.ReminderDate = normalizeGraphUTC(*t.GetReminderDateTime().GetDateTime())
 	}
 	if t.GetRecurrence() != nil {
 		task.Recurrence = formatRecurrence(t.GetRecurrence())

--- a/internal/graphapi/validate.go
+++ b/internal/graphapi/validate.go
@@ -13,6 +13,33 @@ import (
 // graphTimeZoneUTC is the time zone string Microsoft Graph expects on dateTimeTimeZone values.
 const graphTimeZoneUTC = "UTC"
 
+// graphDateTimeFormats are the layouts Microsoft Graph returns on dateTimeTimeZone.dateTime fields.
+// The values are UTC wall-clock times without a zone suffix, so we parse as UTC and re-emit as RFC3339.
+var graphDateTimeFormats = []string{
+	"2006-01-02T15:04:05.0000000",
+	"2006-01-02T15:04:05.9999999",
+	"2006-01-02T15:04:05",
+	"2006-01-02T15:04",
+	time.RFC3339Nano,
+	time.RFC3339,
+}
+
+// normalizeGraphUTC converts a Microsoft Graph dateTimeTimeZone.dateTime string to RFC3339 with a Z suffix.
+// Graph returns values like "2026-04-22T15:15:00.0000000" (UTC wall-clock, no zone), which JSON clients
+// misinterpret as local time. We always request timeZone=UTC, so it is safe to force Z here. Returns
+// the input unchanged if empty or unparseable.
+func normalizeGraphUTC(s string) string {
+	if s == "" {
+		return s
+	}
+	for _, layout := range graphDateTimeFormats {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	return s
+}
+
 // safeIDPattern matches typical Microsoft Graph IDs (alphanumeric, hyphens, underscores, equals, plus, slash for base64, exclamation for OneDrive).
 var safeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_=+/!-]+$`)
 


### PR DESCRIPTION
## Summary
- Graph returns `DateTimeTimeZone.dateTime` as UTC wall-clock strings with no zone suffix (e.g. `2026-04-22T15:15:00.0000000`). We were passing that straight into JSON, so JS `new Date(...)` parsed it as local time and shifted the displayed value (e.g. 15:15 UTC read as 15:15 PDT → off by 7–8 hours).
- Added `normalizeGraphUTC` in `internal/graphapi/validate.go` that parses the known Graph layouts and re-emits RFC3339 with an explicit `Z`.
- Wrapped every `*.GetDateTime()` deref that populates a JSON-tagged string field: events (start/end), meeting-time suggestions, todo tasks (completed/due/start/reminder), free/busy schedule items, and auto-reply start/end.
- Updated `CLAUDE.md`, `README.md`, `SKILL.md` to document the new JSON contract.

Fixes #19.

## Test plan
- [x] `make build` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — pass (no package tests)
- [ ] Manual: `olk calendar list --json` → verify `start`/`end` end with `Z`
- [ ] Manual: `olk todo list --json` → verify `dueDate` etc. end with `Z`
- [ ] Manual: `olk mailbox auto-reply --json` (if scheduled) → verify start/end end with `Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)