### PR TITLE
fix(graphapi): rewrite /me sentinel URL for personal MSA accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,18 @@ Uses an embedded public client ID with device-code flow. The `--enterprise` flag
 If your organization blocks the default client ID, or your admin requires apps to be registered under your tenant, you'll need to create your own app registration:
 
 1. Go to [Azure Portal > App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) and click **New registration**
-2. Set **Supported account types** to match your needs (single tenant or multi-tenant)
+2. Set **Supported account types** to match your needs — use **"Personal Microsoft accounts only"** for outlook.com/hotmail.com, **"Accounts in any organizational directory and personal Microsoft accounts"** for both, or single-tenant for org-only
 3. Under **Authentication > Advanced settings**, set **Allow public client flows** to **Yes** (required for device-code flow)
 4. Under **API permissions**, add **Microsoft Graph** delegated permissions: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`, `Files.ReadWrite`, `People.Read`, `User.Read`, `User.ReadBasic.All`, `MailboxSettings.ReadWrite`, `offline_access` (use `Files.Read` instead of `Files.ReadWrite` for read-only access)
-5. Copy the **Application (client) ID** and **Directory (tenant) ID** from the app's Overview page
+5. Copy the **Application (client) ID** from the app's Overview page
 
-Then use them:
+Then use it:
 
 ```bash
+# Personal Microsoft account (outlook.com, hotmail.com, live.com) — omit --tenant-id
+olk auth login --client-id YOUR_CLIENT_ID
+
+# Work or school account — include your Directory (tenant) ID from the app's Overview page
 olk auth login --client-id YOUR_CLIENT_ID --tenant-id YOUR_TENANT_ID
 ```
 
@@ -192,9 +196,11 @@ Or via environment variables:
 
 ```bash
 export OLK_CLIENT_ID=your-client-id
-export OLK_TENANT_ID=your-tenant-id
+export OLK_TENANT_ID=your-tenant-id  # omit for personal accounts
 olk auth login
 ```
+
+> **Note:** Personal Microsoft accounts (outlook.com, hotmail.com, live.com) do not have a meaningful tenant ID — they share Microsoft's common consumer tenant. Passing `--tenant-id` with a personal account will cause a 401 error. Omitting it lets `olk` use the `common` endpoint, which works for both personal and work/school accounts.
 
 ### Multi-Account
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,7 +119,12 @@ func (r *RunContext) GraphClient() (*graphapi.Client, error) {
 		return nil, fmt.Errorf("getting credentials: %w", err)
 	}
 
-	client, err := graphapi.NewClient(cred)
+	var client *graphapi.Client
+	if r.Flags.Verbose {
+		client, err = graphapi.NewClientVerbose(cred)
+	} else {
+		client, err = graphapi.NewClient(cred)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("creating Graph client: %w", err)
 	}

--- a/internal/graphapi/client.go
+++ b/internal/graphapi/client.go
@@ -1,7 +1,16 @@
 package graphapi
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	az "github.com/microsoft/kiota-authentication-azure-go"
+	nethttplibrary "github.com/microsoft/kiota-http-go"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 )
 
@@ -12,11 +21,115 @@ type Client struct {
 
 // NewClient creates a new Graph API client from a token credential
 func NewClient(cred azcore.TokenCredential) (*Client, error) {
-	client, err := msgraphsdk.NewGraphServiceClientWithCredentials(cred, nil)
+	return newClient(cred, false)
+}
+
+// NewClientVerbose creates a new Graph API client with HTTP request/response logging to stderr
+func NewClientVerbose(cred azcore.TokenCredential) (*Client, error) {
+	return newClient(cred, true)
+}
+
+func newClient(cred azcore.TokenCredential, verbose bool) (*Client, error) {
+	validHosts := []string{
+		"graph.microsoft.com",
+		"graph.microsoft.us",
+		"dod-graph.microsoft.us",
+		"graph.microsoft.de",
+		"microsoftgraph.chinacloudapi.cn",
+		"canary.graph.microsoft.com",
+	}
+	scopes := []string{"https://graph.microsoft.com/.default"}
+
+	auth, err := az.NewAzureIdentityAuthenticationProviderWithScopesAndValidHosts(cred, scopes, validHosts)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{inner: client}, nil
+
+	httpClient := nethttplibrary.GetDefaultClient(nethttplibrary.GetDefaultMiddlewares()...)
+	// Rewrite /users/me-token-to-replace/ → /me/ so personal Microsoft accounts
+	// (MSA/outlook.com) work correctly. The SDK sentinel is only resolved
+	// server-side for AAD/Entra tokens; MSA tokens require the literal /me path.
+	var transport http.RoundTripper = &meRewriteTransport{wrapped: httpClient.Transport}
+	if verbose {
+		transport = &loggingTransport{wrapped: transport, out: os.Stderr}
+	}
+	httpClient.Transport = transport
+
+	adapter, err := msgraphsdk.NewGraphRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(auth, nil, nil, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	inner := msgraphsdk.NewGraphServiceClient(adapter)
+	return &Client{inner: inner}, nil
+}
+
+// loggingTransport logs HTTP requests and responses (redacting Authorization headers) to out.
+type loggingTransport struct {
+	wrapped http.RoundTripper
+	out     io.Writer
+}
+
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	w := t.out
+	if w == nil {
+		w = os.Stderr
+	}
+
+	// Log request
+	fmt.Fprintf(w, "[verbose] --> %s %s\n", req.Method, req.URL.String())
+	for k, vs := range req.Header {
+		if strings.EqualFold(k, "authorization") {
+			fmt.Fprintf(w, "[verbose]     %s: <redacted>\n", k)
+			continue
+		}
+		fmt.Fprintf(w, "[verbose]     %s: %s\n", k, strings.Join(vs, ", "))
+	}
+
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		fmt.Fprintf(w, "[verbose] <-- error: %v\n", err)
+		return resp, err
+	}
+
+	fmt.Fprintf(w, "[verbose] <-- %s\n", resp.Status)
+	for k, vs := range resp.Header {
+		fmt.Fprintf(w, "[verbose]     %s: %s\n", k, strings.Join(vs, ", "))
+	}
+
+	// Always capture body, but only fully dump it on non-2xx
+	if resp.Body != nil {
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		if readErr == nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+			fmt.Fprintf(w, "[verbose]     body: %s\n", string(body))
+		}
+	}
+
+	return resp, nil
+}
+
+// meRewriteTransport rewrites /users/me-token-to-replace/ to /me/ in request
+// URLs. The Graph SDK's Me() method uses a sentinel path parameter that the
+// Graph service only resolves for AAD/Entra delegated tokens. Personal Microsoft
+// accounts (MSA/outlook.com) require the literal /me path instead.
+type meRewriteTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (t *meRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	const sentinel = "/users/me-token-to-replace/"
+	if strings.Contains(req.URL.Path, sentinel) {
+		// Clone the request to avoid mutating the original.
+		reqCopy := req.Clone(req.Context())
+		reqCopy.URL.Path = strings.Replace(reqCopy.URL.Path, sentinel, "/me/", 1)
+		if reqCopy.URL.RawPath != "" {
+			reqCopy.URL.RawPath = strings.Replace(reqCopy.URL.RawPath, sentinel, "/me/", 1)
+		}
+		req = reqCopy
+	}
+	return t.wrapped.RoundTrip(req)
 }
 
 // Inner returns the underlying Graph SDK client


### PR DESCRIPTION
Personal Microsoft accounts (outlook.com, hotmail.com) with a custom app registration would get a `401` on every command. The Graph SDK routes requests through `/users/me-token-to-replace/` which only works for AAD/Entra tokens — personal accounts need the literal `/me` path.

A second issue: the docs told users to pass `--tenant-id` with their custom app, but personal accounts don't have one. Passing it causes the `401`.

What changed

- Added a `meRewriteTransport` that silently rewrites the sentinel URL to `/me/` on every request — transparent for both MSA and AAD accounts
- Wired `--verbose` / `-v` to dump requests/responses to stderr (handy for debugging auth issues like this one)
- Updated the custom app registration docs to split the login example for personal vs. work/school accounts and warn against passing `--tenant-id` for personal accounts

What was tested

- outlook.com account with a custom app registration — `olk calendar events`, `olk mail list`, `olk calendar calendars` all working.

Please let me know your thoughts on these changes, and thank you for writing and open sourcing it!