### PR TITLE
test: add initial unit test suite + CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Verify go.mod tidiness
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test -race -count=1 ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.5.0

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -227,7 +227,7 @@ func (c *AuthListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"EMAIL", "NAME", "DEFAULT"}
-	var rows [][]string
+	rows := make([][]string, 0, len(accounts))
 	for _, a := range accounts {
 		def := ""
 		if strings.EqualFold(a.Email, defaultAccount) {

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -78,7 +78,7 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "SUBJECT", "START", "END", "LOCATION", "STATUS", "RECURRENCE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(events))
 	for i := range events {
 		e := &events[i]
 		id := outfmt.Truncate(e.ID, 15)
@@ -290,7 +290,7 @@ func (c *CalendarCalendarsCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "COLOR", "OWNER"}
-	var rows [][]string
+	rows := make([][]string, 0, len(calendars))
 	for _, cal := range calendars {
 		rows = append(rows, []string{cal.ID, cal.Name, cal.Color, cal.Owner})
 	}

--- a/internal/cmd/calendar_availability.go
+++ b/internal/cmd/calendar_availability.go
@@ -64,7 +64,7 @@ func (c *CalendarAvailabilityCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"EMAIL", "STATUS", "START", "END", "SUBJECT"}
-	var rows [][]string
+	rows := make([][]string, 0, len(schedules))
 	for _, sched := range schedules {
 		if len(sched.Items) == 0 {
 			rows = append(rows, []string{sched.Email, "free", "", "", ""})

--- a/internal/cmd/calendar_find_times.go
+++ b/internal/cmd/calendar_find_times.go
@@ -59,7 +59,7 @@ func (c *CalendarFindTimesCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"START", "END", "CONFIDENCE", "ATTENDEE AVAILABILITY"}
-	var rows [][]string
+	rows := make([][]string, 0, len(suggestions))
 	for _, s := range suggestions {
 		var avails []string
 		for _, a := range s.AttendeeAvailabilities {

--- a/internal/cmd/calendar_view.go
+++ b/internal/cmd/calendar_view.go
@@ -58,7 +58,7 @@ func (c *CalendarViewCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "SUBJECT", "START", "END", "LOCATION", "STATUS", "RECURRENCE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(events))
 	for i := range events {
 		e := &events[i]
 		id := outfmt.Truncate(e.ID, 15)

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -75,7 +75,7 @@ func (c *ContactsListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "EMAIL", "PHONE", "COMPANY", "TITLE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(contacts))
 	for i := range contacts {
 		ct := &contacts[i]
 		id := outfmt.Truncate(ct.ID, 15)

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -472,7 +472,7 @@ func (c *ContactsSearchCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "EMAIL", "PHONE", "COMPANY"}
-	var rows [][]string
+	rows := make([][]string, 0, len(contacts))
 	for i := range contacts {
 		ct := &contacts[i]
 		id := outfmt.Truncate(ct.ID, 15)

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -156,7 +156,7 @@ func printDriveItems(ctx *RunContext, items []graphapi.DriveItem) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"NAME", "TYPE", "SIZE", "MODIFIED", "ID"}
-	var rows [][]string
+	rows := make([][]string, 0, len(items))
 	for i := range items {
 		item := &items[i]
 		size := ""

--- a/internal/cmd/drive_list.go
+++ b/internal/cmd/drive_list.go
@@ -24,7 +24,7 @@ func (c *DriveListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "TYPE", "USED", "TOTAL"}
-	var rows [][]string
+	rows := make([][]string, 0, len(drives))
 	for i := range drives {
 		d := &drives[i]
 		rows = append(rows, []string{

--- a/internal/cmd/drive_versions.go
+++ b/internal/cmd/drive_versions.go
@@ -44,7 +44,7 @@ func (c *DriveVersionsCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"VERSION", "MODIFIED", "SIZE", "MODIFIED BY"}
-	var rows [][]string
+	rows := make([][]string, 0, len(versions))
 	for _, v := range versions {
 		rows = append(rows, []string{
 			outfmt.Sanitize(v.ID),

--- a/internal/cmd/mail_attachments.go
+++ b/internal/cmd/mail_attachments.go
@@ -170,7 +170,7 @@ func (c *MailAttachmentsCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "TYPE", "SIZE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(attachments))
 	for _, a := range attachments {
 		rows = append(rows, []string{
 			a.ID,

--- a/internal/cmd/mail_categories.go
+++ b/internal/cmd/mail_categories.go
@@ -33,7 +33,7 @@ func (c *MailCategoriesListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "COLOR"}
-	var rows [][]string
+	rows := make([][]string, 0, len(categories))
 	for _, cat := range categories {
 		rows = append(rows, []string{
 			outfmt.Truncate(outfmt.Sanitize(cat.ID), 20),

--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -41,7 +41,7 @@ func (c *MailDraftsListCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "SUBJECT", "TO", "CREATED"}
-	var rows [][]string
+	rows := make([][]string, 0, len(drafts))
 	for _, d := range drafts {
 		id := outfmt.Truncate(d.ID, 15)
 		subject := outfmt.Truncate(d.Subject, 60)

--- a/internal/cmd/mail_folders.go
+++ b/internal/cmd/mail_folders.go
@@ -34,7 +34,7 @@ func (c *MailFoldersListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "TOTAL", "UNREAD"}
-	var rows [][]string
+	rows := make([][]string, 0, len(folders))
 	for _, f := range folders {
 		rows = append(rows, []string{
 			f.ID,

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -63,7 +63,7 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "FROM", "SUBJECT", "DATE", "READ", "ATTACH"}
-	var rows [][]string
+	rows := make([][]string, 0, len(messages))
 	for i := range messages {
 		m := &messages[i]
 		read := " "

--- a/internal/cmd/mail_rules.go
+++ b/internal/cmd/mail_rules.go
@@ -33,7 +33,7 @@ func (c *MailRulesListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "ENABLED", "CONDITIONS", "ACTIONS"}
-	var rows [][]string
+	rows := make([][]string, 0, len(rules))
 	for _, r := range rules {
 		id := outfmt.Truncate(r.ID, 15)
 		enabled := "N"

--- a/internal/cmd/mail_search.go
+++ b/internal/cmd/mail_search.go
@@ -25,7 +25,7 @@ func (c *MailSearchCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "FROM", "SUBJECT", "DATE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(messages))
 	for i := range messages {
 		m := &messages[i]
 		id := outfmt.Truncate(m.ID, 15)

--- a/internal/cmd/paging_test.go
+++ b/internal/cmd/paging_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildMailFilter_Empty(t *testing.T) {
+	got, err := buildMailFilter(false, "", "", "")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "" {
+		t.Errorf("empty inputs should produce empty filter, got %q", got)
+	}
+}
+
+func TestBuildMailFilter_UnreadOnly(t *testing.T) {
+	got, err := buildMailFilter(true, "", "", "")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "isRead eq false" {
+		t.Errorf("unread-only: got %q", got)
+	}
+}
+
+func TestBuildMailFilter_FromValid(t *testing.T) {
+	got, err := buildMailFilter(false, "alice@example.com", "", "")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "from/emailAddress/address eq 'alice@example.com'" {
+		t.Errorf("from-only: got %q", got)
+	}
+}
+
+func TestBuildMailFilter_FromInvalid(t *testing.T) {
+	_, err := buildMailFilter(false, "not-an-email", "", "")
+	if err == nil {
+		t.Fatalf("invalid email should fail")
+	}
+	if !strings.Contains(err.Error(), "invalid --from") {
+		t.Errorf("error wording should mention --from; got %v", err)
+	}
+}
+
+func TestBuildMailFilter_QuotesEscaped(t *testing.T) {
+	// OData escapes single quotes by doubling them. An apostrophe in the local
+	// part of an email is technically valid; we want the resulting filter to
+	// not introduce an injection.
+	got, err := buildMailFilter(false, "o'connor@example.com", "", "")
+	// safeEmailPattern does NOT allow apostrophes, so this should currently
+	// reject upstream of the escape step. Document that behavior.
+	if err == nil {
+		// If ValidateEmail ever loosens, ensure quotes get doubled.
+		if !strings.Contains(got, "o''connor") {
+			t.Errorf("expected escaped o''connor in filter, got %q", got)
+		}
+	}
+}
+
+func TestBuildMailFilter_DateRange(t *testing.T) {
+	got, err := buildMailFilter(false, "", "2026-01-15", "2026-02-15T10:30:00Z")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(got, "receivedDateTime ge 2026-01-15T00:00:00Z") {
+		t.Errorf("after filter missing or wrong: %q", got)
+	}
+	if !strings.Contains(got, "receivedDateTime le 2026-02-15T10:30:00Z") {
+		t.Errorf("before filter missing or wrong: %q", got)
+	}
+	if !strings.Contains(got, " and ") {
+		t.Errorf("multiple filters should be joined with ' and ': %q", got)
+	}
+}
+
+func TestBuildMailFilter_InvalidAfter(t *testing.T) {
+	_, err := buildMailFilter(false, "", "yesterday", "")
+	if err == nil {
+		t.Fatalf("invalid --after should fail")
+	}
+	if !strings.Contains(err.Error(), "invalid --after") {
+		t.Errorf("expected --after error, got %v", err)
+	}
+}
+
+func TestBuildMailFilter_InvalidBefore(t *testing.T) {
+	_, err := buildMailFilter(false, "", "", "tomorrow")
+	if err == nil {
+		t.Fatalf("invalid --before should fail")
+	}
+	if !strings.Contains(err.Error(), "invalid --before") {
+		t.Errorf("expected --before error, got %v", err)
+	}
+}
+
+func TestBuildMailFilter_AllCombined(t *testing.T) {
+	got, err := buildMailFilter(true, "alice@example.com", "2026-01-15", "2026-02-15")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	parts := []string{
+		"isRead eq false",
+		"from/emailAddress/address eq 'alice@example.com'",
+		"receivedDateTime ge 2026-01-15T00:00:00Z",
+		"receivedDateTime le 2026-02-15T00:00:00Z",
+	}
+	for _, p := range parts {
+		if !strings.Contains(got, p) {
+			t.Errorf("combined filter missing %q in %q", p, got)
+		}
+	}
+}
+
+func TestParseDateTime(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantNon string // non-empty substring expected, "" means we want parse failure
+	}{
+		{"rfc3339 with Z", "2026-01-15T09:00:00Z", "2026-01-15T09:00:00Z"},
+		{"rfc3339 with offset", "2026-01-15T09:00:00-05:00", "2026-01-15T09:00:00-05:00"},
+		{"date+time no zone treated as UTC", "2026-01-15T09:00", "2026-01-15T09:00:00Z"},
+		{"date only", "2026-01-15", "2026-01-15T00:00:00Z"},
+		{"empty", "", ""},
+		{"garbage", "not a date", ""},
+		{"month name", "Jan 15 2026", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDateTime(tc.in)
+			if tc.wantNon == "" {
+				if got != "" {
+					t.Errorf("parseDateTime(%q) should reject, got %q", tc.in, got)
+				}
+				return
+			}
+			if got != tc.wantNon {
+				t.Errorf("parseDateTime(%q) = %q, want %q", tc.in, got, tc.wantNon)
+			}
+		})
+	}
+}

--- a/internal/cmd/people.go
+++ b/internal/cmd/people.go
@@ -30,7 +30,7 @@ func (c *PeopleSearchCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"NAME", "EMAIL", "JOB TITLE", "DEPARTMENT", "COMPANY"}
-	var rows [][]string
+	rows := make([][]string, 0, len(people))
 	for _, p := range people {
 		rows = append(rows, []string{
 			outfmt.Sanitize(p.DisplayName),

--- a/internal/cmd/todo.go
+++ b/internal/cmd/todo.go
@@ -70,7 +70,7 @@ func (c *TodoListsListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "OWNER"}
-	var rows [][]string
+	rows := make([][]string, 0, len(lists))
 	for _, l := range lists {
 		owner := " "
 		if l.IsOwner {
@@ -174,7 +174,7 @@ func (c *TodoListCmd) Run(ctx *RunContext) error {
 
 	loc, _ := ctx.Timezone()
 	headers := []string{"ID", "TITLE", "STATUS", "IMPORTANCE", "DUE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(tasks))
 	for i := range tasks {
 		t := &tasks[i]
 		rows = append(rows, []string{

--- a/internal/cmd/todo_attachments.go
+++ b/internal/cmd/todo_attachments.go
@@ -50,7 +50,7 @@ func (c *TodoAttachListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "TYPE", "SIZE"}
-	var rows [][]string
+	rows := make([][]string, 0, len(attachments))
 	for _, a := range attachments {
 		rows = append(rows, []string{
 			outfmt.Sanitize(a.ID),

--- a/internal/cmd/todo_checklist.go
+++ b/internal/cmd/todo_checklist.go
@@ -43,7 +43,7 @@ func (c *TodoChecklistListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "CHECKED"}
-	var rows [][]string
+	rows := make([][]string, 0, len(items))
 	for _, item := range items {
 		checked := " "
 		if item.IsChecked {

--- a/internal/cmd/todo_links.go
+++ b/internal/cmd/todo_links.go
@@ -42,7 +42,7 @@ func (c *TodoLinksListCmd) Run(ctx *RunContext) error {
 	}
 
 	headers := []string{"ID", "NAME", "APP", "URL"}
-	var rows [][]string
+	rows := make([][]string, 0, len(links))
 	for _, l := range links {
 		rows = append(rows, []string{
 			outfmt.Truncate(outfmt.Sanitize(l.ID), 15),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,253 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// useTempConfigDir points OLK_CONFIG_DIR at a t.TempDir and restores the prior
+// env when the test ends.
+func useTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("OLK_CONFIG_DIR", dir)
+	return dir
+}
+
+func TestLoad_MissingFile_ReturnsEmpty(t *testing.T) {
+	useTempConfigDir(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load on empty dir: %v", err)
+	}
+	if cfg.DefaultAccount != "" {
+		t.Errorf("DefaultAccount should be empty, got %q", cfg.DefaultAccount)
+	}
+	if cfg.Clients == nil {
+		t.Errorf("Clients map should be initialized, got nil")
+	}
+	if len(cfg.Clients) != 0 {
+		t.Errorf("Clients map should be empty, got %d entries", len(cfg.Clients))
+	}
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	useTempConfigDir(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cfg.SetDefaultAccount("alice@example.com")
+	cfg.SetClient("alice@example.com", Client{ClientID: "cid-1", TenantID: "tid-1"})
+	cfg.SetClient("bob@example.com", Client{ClientID: "cid-2"})
+	cfg.SetTimezone("America/Los_Angeles")
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load after Save: %v", err)
+	}
+	if loaded.GetDefaultAccount() != "alice@example.com" {
+		t.Errorf("default account: got %q", loaded.GetDefaultAccount())
+	}
+	if loaded.GetTimezone() != "America/Los_Angeles" {
+		t.Errorf("timezone: got %q", loaded.GetTimezone())
+	}
+	a := loaded.GetClient("alice@example.com")
+	if a.ClientID != "cid-1" || a.TenantID != "tid-1" {
+		t.Errorf("alice client roundtrip: got %+v", a)
+	}
+	b := loaded.GetClient("bob@example.com")
+	if b.ClientID != "cid-2" {
+		t.Errorf("bob client roundtrip: got %+v", b)
+	}
+}
+
+func TestGetClient_DefaultsForUnknownAccount(t *testing.T) {
+	cfg := &Config{Clients: map[string]Client{}}
+	got := cfg.GetClient("nobody@example.com")
+	if got.ClientID != DefaultClientID {
+		t.Errorf("default ClientID: got %q, want %q", got.ClientID, DefaultClientID)
+	}
+	if got.TenantID != DefaultTenantID {
+		t.Errorf("default TenantID: got %q, want %q", got.TenantID, DefaultTenantID)
+	}
+}
+
+func TestRemoveAccount(t *testing.T) {
+	cfg := &Config{Clients: map[string]Client{}}
+	cfg.SetClient("alice@example.com", Client{ClientID: "cid-1"})
+	cfg.SetClient("bob@example.com", Client{ClientID: "cid-2"})
+	cfg.SetDefaultAccount("alice@example.com")
+
+	cfg.RemoveAccount("alice@example.com")
+
+	if _, ok := cfg.Clients["alice@example.com"]; ok {
+		t.Errorf("alice should be removed from Clients map")
+	}
+	if cfg.GetDefaultAccount() != "" {
+		t.Errorf("DefaultAccount should be cleared when matching removed account; got %q", cfg.GetDefaultAccount())
+	}
+	if _, ok := cfg.Clients["bob@example.com"]; !ok {
+		t.Errorf("unrelated account bob should still exist")
+	}
+}
+
+func TestRemoveAccount_PreservesUnrelatedDefault(t *testing.T) {
+	cfg := &Config{Clients: map[string]Client{}}
+	cfg.SetClient("alice@example.com", Client{ClientID: "cid-1"})
+	cfg.SetClient("bob@example.com", Client{ClientID: "cid-2"})
+	cfg.SetDefaultAccount("bob@example.com")
+
+	cfg.RemoveAccount("alice@example.com")
+
+	if cfg.GetDefaultAccount() != "bob@example.com" {
+		t.Errorf("DefaultAccount should be preserved when not matching removed account; got %q", cfg.GetDefaultAccount())
+	}
+}
+
+func TestSave_PermissionsAre0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only permission semantics")
+	}
+	useTempConfigDir(t)
+	cfg := &Config{Clients: map[string]Client{}}
+	cfg.SetDefaultAccount("alice@example.com")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	info, err := os.Stat(ConfigFilePath())
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("config file perm: got %o, want 0600", got)
+	}
+}
+
+func TestLoad_RejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink-creation requires elevated perms on windows")
+	}
+	dir := useTempConfigDir(t)
+
+	// Create a real target file and symlink the config path to it.
+	target := filepath.Join(dir, "target.json")
+	if err := os.WriteFile(target, []byte(`{"default_account":"x"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(target, ConfigFilePath()); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := Load()
+	if err == nil {
+		t.Fatalf("Load should refuse symlinked config file")
+	}
+}
+
+func TestLoad_AutoFixesWorldReadablePerm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only permission semantics")
+	}
+	useTempConfigDir(t)
+	if err := os.MkdirAll(ConfigDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(ConfigFilePath(), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	info, err := os.Stat(ConfigFilePath())
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("Load should chmod to 0600; got %o", got)
+	}
+}
+
+func TestLoad_RejectsMalformedJSON(t *testing.T) {
+	useTempConfigDir(t)
+	if err := os.MkdirAll(ConfigDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(ConfigFilePath(), []byte("{ not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(); err == nil {
+		t.Fatalf("Load should fail on malformed JSON")
+	}
+}
+
+func TestConcurrentReadWrite_NoRace(t *testing.T) {
+	// Run with -race in CI to validate the sync.RWMutex guarding the Config fields.
+	cfg := &Config{Clients: map[string]Client{}}
+	cfg.SetClient("alice@example.com", Client{ClientID: "cid-1"})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cfg.SetClient("bob@example.com", Client{ClientID: "cid-2"})
+			cfg.SetDefaultAccount("bob@example.com")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = cfg.GetClient("alice@example.com")
+			_ = cfg.GetDefaultAccount()
+			_ = cfg.GetTimezone()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestSave_AtomicWritesProduceValidJSON sanity-checks that atomicWriteFile
+// produces a complete, parseable file (no partial writes).
+func TestSave_AtomicWritesProduceValidJSON(t *testing.T) {
+	useTempConfigDir(t)
+	cfg := &Config{Clients: map[string]Client{}}
+	cfg.SetDefaultAccount("alice@example.com")
+	cfg.SetClient("alice@example.com", Client{ClientID: "cid-1"})
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(ConfigFilePath())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v\ncontent: %s", err, data)
+	}
+	if m["default_account"] != "alice@example.com" {
+		t.Errorf("default_account: got %v", m["default_account"])
+	}
+}
+
+func TestPaths_HonorsEnvOverride(t *testing.T) {
+	t.Setenv("OLK_CONFIG_DIR", "/tmp/olk-test-xyzzy")
+	if ConfigDir() != "/tmp/olk-test-xyzzy" {
+		t.Errorf("ConfigDir should honor OLK_CONFIG_DIR; got %q", ConfigDir())
+	}
+	if ConfigFilePath() != "/tmp/olk-test-xyzzy/config.json" {
+		t.Errorf("ConfigFilePath: got %q", ConfigFilePath())
+	}
+	if AccountsDir() != "/tmp/olk-test-xyzzy/accounts" {
+		t.Errorf("AccountsDir: got %q", AccountsDir())
+	}
+}

--- a/internal/graphapi/availability.go
+++ b/internal/graphapi/availability.go
@@ -56,7 +56,7 @@ func (c *Client) GetSchedule(ctx context.Context, emails []string, start, end ti
 		return nil, fmt.Errorf("getting schedule: %w", err)
 	}
 
-	var result []ScheduleInfo
+	result := make([]ScheduleInfo, 0, len(resp.GetValue()))
 	for _, si := range resp.GetValue() {
 		info := ScheduleInfo{}
 		if si.GetScheduleId() != nil {

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -55,8 +55,6 @@ func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, c
 		Orderby:       []string{"start/dateTime"},
 	}
 
-	var events []CalendarEvent
-
 	if calendarID != "" {
 		if err := validateID(calendarID, "calendar ID"); err != nil {
 			return nil, err
@@ -74,6 +72,7 @@ func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, c
 		if err != nil {
 			return nil, fmt.Errorf("listing events: %w", err)
 		}
+		events := make([]CalendarEvent, 0, len(resp.GetValue()))
 		for _, e := range resp.GetValue() {
 			events = append(events, convertEvent(e))
 		}
@@ -89,6 +88,7 @@ func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, c
 		return nil, fmt.Errorf("listing events: %w", err)
 	}
 
+	events := make([]CalendarEvent, 0, len(resp.GetValue()))
 	for _, e := range resp.GetValue() {
 		events = append(events, convertEvent(e))
 	}
@@ -245,7 +245,7 @@ func (c *Client) ListCalendars(ctx context.Context) ([]CalendarInfo, error) {
 		return nil, fmt.Errorf("listing calendars: %w", err)
 	}
 
-	var calendars []CalendarInfo
+	calendars := make([]CalendarInfo, 0, len(resp.GetValue()))
 	for _, cal := range resp.GetValue() {
 		ci := CalendarInfo{}
 		if cal.GetId() != nil {
@@ -493,7 +493,7 @@ func (c *Client) FindMeetingTimes(ctx context.Context, attendees []string, start
 	body := users.NewItemFindMeetingTimesPostRequestBody()
 
 	// Set attendees
-	var attList []models.AttendeeBaseable
+	attList := make([]models.AttendeeBaseable, 0, len(attendees))
 	for _, email := range attendees {
 		att := models.NewAttendeeBase()
 		addr := models.NewEmailAddress()
@@ -539,7 +539,7 @@ func (c *Client) FindMeetingTimes(ctx context.Context, attendees []string, start
 		return nil, fmt.Errorf("no meeting times available: %s", *resp.GetEmptySuggestionsReason())
 	}
 
-	var suggestions []MeetingTimeSuggestion
+	suggestions := make([]MeetingTimeSuggestion, 0, len(resp.GetMeetingTimeSuggestions()))
 	for _, s := range resp.GetMeetingTimeSuggestions() {
 		suggestion := MeetingTimeSuggestion{}
 		if s.GetConfidence() != nil {

--- a/internal/graphapi/categories.go
+++ b/internal/graphapi/categories.go
@@ -20,7 +20,7 @@ func (c *Client) ListCategories(ctx context.Context) ([]Category, error) {
 		return nil, fmt.Errorf("listing categories: %s", graphErrorMessage(err))
 	}
 
-	var categories []Category
+	categories := make([]Category, 0, len(resp.GetValue()))
 	for _, cat := range resp.GetValue() {
 		categories = append(categories, convertCategory(cat))
 	}

--- a/internal/graphapi/contacts.go
+++ b/internal/graphapi/contacts.go
@@ -31,7 +31,7 @@ var contactSelectFields = []string{
 
 // buildEmailAddresses validates and converts a slice of email strings to Graph EmailAddressable objects.
 func buildEmailAddresses(emails []string) ([]models.EmailAddressable, error) {
-	var addrs []models.EmailAddressable
+	addrs := make([]models.EmailAddressable, 0, len(emails))
 	for _, e := range emails {
 		if e == "" {
 			continue

--- a/internal/graphapi/contacts.go
+++ b/internal/graphapi/contacts.go
@@ -112,7 +112,7 @@ func (c *Client) ListContacts(ctx context.Context, top, skip int32, orderBy stri
 		return nil, fmt.Errorf("listing contacts: %w", err)
 	}
 
-	var contacts []Contact
+	contacts := make([]Contact, 0, len(resp.GetValue()))
 	for _, ct := range resp.GetValue() {
 		contacts = append(contacts, convertContact(ct))
 	}
@@ -545,7 +545,7 @@ func (c *Client) SearchContacts(ctx context.Context, query string, top int32) ([
 		return nil, fmt.Errorf("searching contacts: %w", err)
 	}
 
-	var contacts []Contact
+	contacts := make([]Contact, 0, len(resp.GetValue()))
 	for _, ct := range resp.GetValue() {
 		contacts = append(contacts, convertContact(ct))
 	}

--- a/internal/graphapi/drafts.go
+++ b/internal/graphapi/drafts.go
@@ -32,7 +32,7 @@ func (c *Client) ListDrafts(ctx context.Context, top int32) ([]DraftMessage, err
 		return nil, fmt.Errorf("listing drafts: %w", err)
 	}
 
-	var drafts []DraftMessage
+	drafts := make([]DraftMessage, 0, len(resp.GetValue()))
 	for _, msg := range resp.GetValue() {
 		drafts = append(drafts, convertDraft(msg))
 	}

--- a/internal/graphapi/drive.go
+++ b/internal/graphapi/drive.go
@@ -229,7 +229,7 @@ func (c *Client) ListDrives(ctx context.Context) ([]DriveInfo, error) {
 	if err != nil {
 		return nil, scopeUpgradeError("listing drives", err)
 	}
-	var result []DriveInfo
+	result := make([]DriveInfo, 0, len(resp.GetValue()))
 	for _, d := range resp.GetValue() {
 		result = append(result, convertDrive(d))
 	}
@@ -276,7 +276,7 @@ func (c *Client) ListDriveChildren(ctx context.Context, driveID, itemID string, 
 	if err != nil {
 		return nil, scopeUpgradeError("listing folder contents", err)
 	}
-	var result []DriveItem
+	result := make([]DriveItem, 0, len(resp.GetValue()))
 	for _, d := range resp.GetValue() {
 		result = append(result, convertDriveItem(d))
 	}
@@ -312,7 +312,7 @@ func (c *Client) ListDriveChildrenByPath(ctx context.Context, driveID, path stri
 	if err != nil {
 		return nil, scopeUpgradeError("listing folder contents", err)
 	}
-	var result []DriveItem
+	result := make([]DriveItem, 0, len(resp.GetValue()))
 	for _, d := range resp.GetValue() {
 		result = append(result, convertDriveItem(d))
 	}

--- a/internal/graphapi/drive.go
+++ b/internal/graphapi/drive.go
@@ -354,7 +354,7 @@ func (c *Client) SearchDrive(ctx context.Context, driveID, query string, top int
 	if err != nil {
 		return nil, scopeUpgradeError("searching drive", err)
 	}
-	var result []DriveItem
+	result := make([]DriveItem, 0, len(resp.GetValue()))
 	for _, d := range resp.GetValue() {
 		result = append(result, convertDriveItem(d))
 	}
@@ -374,7 +374,7 @@ func (c *Client) RecentDriveItems(ctx context.Context, driveID string) ([]DriveI
 	if err != nil {
 		return nil, scopeUpgradeError("getting recent items", err)
 	}
-	var result []DriveItem
+	result := make([]DriveItem, 0, len(resp.GetValue()))
 	for _, d := range resp.GetValue() {
 		result = append(result, convertDriveItem(d))
 	}
@@ -390,7 +390,7 @@ func (c *Client) SharedWithMeItems(ctx context.Context, driveID string) ([]Drive
 	if err != nil {
 		return nil, scopeUpgradeError("getting shared items", err)
 	}
-	var result []DriveItem
+	result := make([]DriveItem, 0, len(resp.GetValue()))
 	for _, d := range resp.GetValue() {
 		result = append(result, convertDriveItem(d))
 	}
@@ -621,7 +621,7 @@ func (c *Client) ListDriveItemVersions(ctx context.Context, driveID, itemID stri
 	if err != nil {
 		return nil, scopeUpgradeError("listing versions", err)
 	}
-	var result []DriveItemVersion
+	result := make([]DriveItemVersion, 0, len(resp.GetValue()))
 	for _, v := range resp.GetValue() {
 		result = append(result, convertDriveItemVersion(v))
 	}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -121,8 +121,6 @@ func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([
 		QueryParameters: queryParams,
 	}
 
-	var result []MailMessage
-
 	if opts.FolderID != "" {
 		if err := validateID(opts.FolderID, "folder ID"); err != nil {
 			return nil, err
@@ -146,6 +144,7 @@ func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([
 		if err != nil {
 			return nil, fmt.Errorf("listing messages: %w", err)
 		}
+		result := make([]MailMessage, 0, len(resp.GetValue()))
 		for _, msg := range resp.GetValue() {
 			result = append(result, convertMessage(msg))
 		}
@@ -156,6 +155,7 @@ func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([
 	if err != nil {
 		return nil, fmt.Errorf("listing messages: %w", err)
 	}
+	result := make([]MailMessage, 0, len(resp.GetValue()))
 	for _, msg := range resp.GetValue() {
 		result = append(result, convertMessage(msg))
 	}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -364,7 +364,7 @@ func (c *Client) ListMailFolders(ctx context.Context) ([]MailFolder, error) {
 		return nil, fmt.Errorf("listing folders: %w", err)
 	}
 
-	var folders []MailFolder
+	folders := make([]MailFolder, 0, len(resp.GetValue()))
 	for _, f := range resp.GetValue() {
 		folder := MailFolder{
 			DisplayName: derefStr(f.GetDisplayName()),
@@ -520,7 +520,7 @@ func (c *Client) GetAttachments(ctx context.Context, messageID string) ([]Attach
 		return nil, fmt.Errorf("getting attachments: %w", err)
 	}
 
-	var attachments []Attachment
+	attachments := make([]Attachment, 0, len(resp.GetValue()))
 	for _, a := range resp.GetValue() {
 		att := Attachment{
 			Name:        derefStr(a.GetName()),
@@ -649,7 +649,7 @@ func convertMessage(msg models.Messageable) MailMessage {
 }
 
 func makeRecipients(emails []string) ([]models.Recipientable, error) {
-	var recipients []models.Recipientable
+	recipients := make([]models.Recipientable, 0, len(emails))
 	for _, email := range emails {
 		if err := ValidateEmail(email); err != nil {
 			return nil, err

--- a/internal/graphapi/mail_rules.go
+++ b/internal/graphapi/mail_rules.go
@@ -30,7 +30,7 @@ func (c *Client) ListMailRules(ctx context.Context) ([]MailRule, error) {
 		return nil, enterpriseError("listing mail rules", err)
 	}
 
-	var rules []MailRule
+	rules := make([]MailRule, 0, len(resp.GetValue()))
 	for _, r := range resp.GetValue() {
 		rules = append(rules, convertMailRule(r))
 	}

--- a/internal/graphapi/people.go
+++ b/internal/graphapi/people.go
@@ -41,7 +41,7 @@ func (c *Client) SearchPeople(ctx context.Context, query string, top int32) ([]P
 		return nil, enterpriseError("searching people", err)
 	}
 
-	var people []Person
+	people := make([]Person, 0, len(resp.GetValue()))
 	for _, p := range resp.GetValue() {
 		person := Person{
 			DisplayName: derefStr(p.GetDisplayName()),
@@ -93,7 +93,7 @@ func (c *Client) SearchDirectory(ctx context.Context, query string, top int32) (
 		return nil, fmt.Errorf("searching directory: %s", graphErrorMessage(err))
 	}
 
-	var people []Person
+	people := make([]Person, 0, len(resp.GetValue()))
 	for _, u := range resp.GetValue() {
 		person := Person{
 			DisplayName: derefStr(u.GetDisplayName()),

--- a/internal/graphapi/todo.go
+++ b/internal/graphapi/todo.go
@@ -75,7 +75,7 @@ func (c *Client) ListTodoLists(ctx context.Context) ([]TodoList, error) {
 		return nil, fmt.Errorf("listing todo lists: %w", err)
 	}
 
-	var result []TodoList
+	result := make([]TodoList, 0, len(resp.GetValue()))
 	for _, l := range resp.GetValue() {
 		tl := TodoList{
 			DisplayName: derefStr(l.GetDisplayName()),
@@ -159,7 +159,7 @@ func (c *Client) ListTodoTasks(ctx context.Context, listID string, top int32, st
 		return nil, fmt.Errorf("listing todo tasks: %w", err)
 	}
 
-	var result []TodoTask
+	result := make([]TodoTask, 0, len(resp.GetValue()))
 	for _, t := range resp.GetValue() {
 		result = append(result, convertTodoTask(t))
 	}
@@ -515,7 +515,7 @@ func (c *Client) ListChecklistItems(ctx context.Context, listID, taskID string) 
 		return nil, fmt.Errorf("listing checklist items: %w", err)
 	}
 
-	var result []TodoChecklistItem
+	result := make([]TodoChecklistItem, 0, len(resp.GetValue()))
 	for _, item := range resp.GetValue() {
 		result = append(result, convertChecklistItem(item))
 	}
@@ -657,7 +657,7 @@ func (c *Client) ListTodoAttachments(ctx context.Context, listID, taskID string)
 		return nil, fmt.Errorf("listing todo attachments: %w", err)
 	}
 
-	var result []TodoAttachment
+	result := make([]TodoAttachment, 0, len(resp.GetValue()))
 	for _, a := range resp.GetValue() {
 		att := TodoAttachment{}
 		if a.GetId() != nil {
@@ -785,7 +785,7 @@ func (c *Client) ListLinkedResources(ctx context.Context, listID, taskID string)
 		return nil, fmt.Errorf("listing linked resources: %w", err)
 	}
 
-	var result []TodoLinkedResource
+	result := make([]TodoLinkedResource, 0, len(resp.GetValue()))
 	for _, r := range resp.GetValue() {
 		result = append(result, convertLinkedResource(r))
 	}

--- a/internal/graphapi/validate_test.go
+++ b/internal/graphapi/validate_test.go
@@ -1,0 +1,196 @@
+package graphapi
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr string // substring expected in error, "" means success
+	}{
+		{"empty", "", "cannot be empty"},
+		{"too long", strings.Repeat("a", 1025), "too long"},
+		{"alphanumeric ok", "abc123", ""},
+		{"hyphens ok", "abc-123-DEF", ""},
+		{"underscore ok", "abc_123", ""},
+		{"base64 chars ok", "AAMkAGI=", ""},
+		{"onedrive bang ok", "01ABCD!12345", ""},
+		{"plus and slash ok", "AAA+BBB/CCC", ""},
+		{"space rejected", "abc 123", "invalid characters"},
+		{"semicolon rejected", "abc;rm", "invalid characters"},
+		{"quote rejected", "abc'", "invalid characters"},
+		{"newline rejected", "abc\n", "invalid characters"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateID(tc.id, "id")
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tc.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateEmail(t *testing.T) {
+	cases := []struct {
+		name   string
+		email  string
+		wantOK bool
+	}{
+		{"basic ok", "alice@example.com", true},
+		{"plus tag ok", "alice+tag@example.com", true},
+		{"dots ok", "first.last@sub.example.com", true},
+		{"hyphen in domain ok", "u@ex-ample.com", true},
+		{"empty", "", false},
+		{"no at", "alice.example.com", false},
+		{"no tld", "alice@example", false},
+		{"trailing space", "alice@example.com ", false},
+		{"too long", strings.Repeat("a", 250) + "@a.co", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEmail(tc.email)
+			if tc.wantOK && err != nil {
+				t.Errorf("expected success for %q, got %v", tc.email, err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Errorf("expected error for %q, got nil", tc.email)
+			}
+		})
+	}
+}
+
+func TestValidatePhone(t *testing.T) {
+	cases := []struct {
+		name   string
+		phone  string
+		wantOK bool
+	}{
+		{"plain digits", "5551234567", true},
+		{"with hyphens", "555-123-4567", true},
+		{"with country code", "+1 (555) 123-4567", true},
+		{"with dots", "555.123.4567", true},
+		{"empty", "", false},
+		{"alpha rejected", "555-CALL", false},
+		{"too long", strings.Repeat("1", 31), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePhone(tc.phone)
+			if tc.wantOK && err != nil {
+				t.Errorf("expected success for %q, got %v", tc.phone, err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Errorf("expected error for %q, got nil", tc.phone)
+			}
+		})
+	}
+}
+
+func TestValidateBirthday(t *testing.T) {
+	future := time.Now().AddDate(1, 0, 0).Format("2006-01-02")
+	cases := []struct {
+		name   string
+		in     string
+		wantOK bool
+	}{
+		{"valid", "1990-05-15", true},
+		{"year 1900 boundary ok", "1900-01-01", true},
+		{"too early", "1899-12-31", false},
+		{"future date", future, false},
+		{"wrong format", "05/15/1990", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidateBirthday(tc.in)
+			if tc.wantOK && err != nil {
+				t.Errorf("expected success for %q, got %v", tc.in, err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Errorf("expected error for %q, got nil", tc.in)
+			}
+		})
+	}
+}
+
+func TestValidateContactFieldLen(t *testing.T) {
+	cases := []struct {
+		name   string
+		value  string
+		limit  int
+		wantOK bool
+	}{
+		{"under limit", "hi", 10, true},
+		{"equal limit", "hello", 5, true},
+		{"over limit", "hello world", 5, false},
+		{"empty under any limit", "", 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateContactFieldLen(tc.value, "label", tc.limit)
+			if tc.wantOK && err != nil {
+				t.Errorf("expected success, got %v", err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestClampTop(t *testing.T) {
+	cases := []struct {
+		in, want int32
+	}{
+		{0, 25},
+		{-5, 25},
+		{1, 1},
+		{500, 500},
+		{1000, 1000},
+		{1001, 1000},
+		{10000, 1000},
+	}
+	for _, tc := range cases {
+		if got := clampTop(tc.in); got != tc.want {
+			t.Errorf("clampTop(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeGraphUTC(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty passes through", "", ""},
+		{"unparseable passes through", "not a date", "not a date"},
+		{"graph seven-digit fraction", "2026-04-22T15:15:00.0000000", "2026-04-22T15:15:00Z"},
+		{"graph no fraction", "2026-04-22T15:15:00", "2026-04-22T15:15:00Z"},
+		{"graph minute precision", "2026-04-22T15:15", "2026-04-22T15:15:00Z"},
+		{"rfc3339 with Z preserved", "2026-04-22T15:15:00Z", "2026-04-22T15:15:00Z"},
+		{"rfc3339 with offset normalized", "2026-04-22T11:15:00-04:00", "2026-04-22T15:15:00Z"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeGraphUTC(tc.in); got != tc.want {
+				t.Errorf("normalizeGraphUTC(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/msauth/auth.go
+++ b/internal/msauth/auth.go
@@ -220,7 +220,7 @@ func (a *Authenticator) ListAccounts() ([]AccountInfo, error) {
 		_ = os.Chmod(acctDir, 0o700)
 	}
 
-	var accounts []AccountInfo
+	accounts := make([]AccountInfo, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 			continue

--- a/internal/outfmt/outfmt_test.go
+++ b/internal/outfmt/outfmt_test.go
@@ -1,0 +1,236 @@
+package outfmt
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewPrinter_FormatDispatch(t *testing.T) {
+	cases := []struct {
+		name       string
+		json       bool
+		plain      bool
+		wantFormat Format
+	}{
+		{"default is table", false, false, FormatTable},
+		{"json flag wins", true, false, FormatJSON},
+		{"plain flag", false, true, FormatPlain},
+		{"json wins over plain", true, true, FormatJSON},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewPrinter(tc.json, tc.plain, false, "", "UTC")
+			if p.Format != tc.wantFormat {
+				t.Fatalf("got format %d, want %d", p.Format, tc.wantFormat)
+			}
+		})
+	}
+}
+
+func TestPrintJSON_Envelope(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Printer{Format: FormatJSON, Writer: &buf, Timezone: "America/New_York"}
+	results := []map[string]string{{"id": "1"}, {"id": "2"}}
+	if err := p.PrintJSON(results, 2, "next-url"); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Count != 2 {
+		t.Errorf("count: got %d, want 2", env.Count)
+	}
+	if env.NextLink != "next-url" {
+		t.Errorf("nextLink: got %q, want %q", env.NextLink, "next-url")
+	}
+	if env.Timezone != "America/New_York" {
+		t.Errorf("timezone: got %q, want %q", env.Timezone, "America/New_York")
+	}
+}
+
+func TestPrintJSON_ResultsOnly(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Printer{Format: FormatJSON, Writer: &buf, ResultsOnly: true}
+	results := []int{1, 2, 3}
+	if err := p.PrintJSON(results, 3, ""); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+	if strings.Contains(buf.String(), "\"results\"") {
+		t.Fatalf("ResultsOnly output should not contain envelope; got %s", buf.String())
+	}
+	var got []int
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("got %d items, want 3", len(got))
+	}
+}
+
+func TestPrintPlain_TSVNoHeaders(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Printer{Format: FormatPlain, Writer: &buf}
+	headers := []string{"id", "subject"}
+	rows := [][]string{{"1", "hello"}, {"2", "world"}}
+	if err := p.PrintPlain(headers, rows); err != nil {
+		t.Fatalf("PrintPlain: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines (no header), got %d: %q", len(lines), buf.String())
+	}
+	if lines[0] != "1\thello" {
+		t.Errorf("line 0: got %q, want %q", lines[0], "1\thello")
+	}
+}
+
+func TestPrintTable_IncludesHeaders(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Printer{Format: FormatTable, Writer: &buf}
+	if err := p.PrintTable([]string{"id", "subject"}, [][]string{{"1", "hi"}}); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+	if !strings.Contains(buf.String(), "id") || !strings.Contains(buf.String(), "subject") {
+		t.Errorf("table output missing headers: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "hi") {
+		t.Errorf("table output missing data row: %q", buf.String())
+	}
+}
+
+func TestFieldSelection_CaseInsensitive(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Printer{Format: FormatPlain, Writer: &buf, Select: "SUBJECT, id"}
+	headers := []string{"id", "subject", "from"}
+	rows := [][]string{{"1", "hello", "alice@example.com"}}
+	if err := p.PrintPlain(headers, rows); err != nil {
+		t.Fatalf("PrintPlain: %v", err)
+	}
+	line := strings.TrimRight(buf.String(), "\n")
+	if line != "hello\t1" {
+		t.Errorf("select=subject,id should reorder to those columns; got %q, want %q", line, "hello\t1")
+	}
+}
+
+func TestFieldSelection_UnknownFieldIgnored(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Printer{Format: FormatPlain, Writer: &buf, Select: "nope,id"}
+	headers := []string{"id", "subject"}
+	rows := [][]string{{"1", "hi"}}
+	if err := p.PrintPlain(headers, rows); err != nil {
+		t.Fatalf("PrintPlain: %v", err)
+	}
+	line := strings.TrimRight(buf.String(), "\n")
+	if line != "1" {
+		t.Errorf("unknown field should be ignored; got %q, want %q", line, "1")
+	}
+}
+
+func TestPrint_Dispatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		format Format
+		want   string
+	}{
+		{"json", FormatJSON, "\"results\""},
+		{"plain", FormatPlain, "hi"},
+		{"table", FormatTable, "subject"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			p := &Printer{Format: tc.format, Writer: &buf}
+			if err := p.Print([]string{"subject"}, [][]string{{"hi"}}, []map[string]string{{"subject": "hi"}}, 1, ""); err != nil {
+				t.Fatalf("Print: %v", err)
+			}
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("format %s output missing %q: %q", tc.name, tc.want, buf.String())
+			}
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain", "hello", "hello"},
+		{"newline becomes space", "hello\nworld", "hello world"},
+		{"tab becomes space", "hello\tworld", "hello world"},
+		{"ansi escape stripped", "\x1b[31mred\x1b[0m", "[31mred[0m"}, // ESC is dropped, brackets/text kept
+		{"null byte stripped", "ab\x00cd", "abcd"},
+		{"bell stripped", "hi\x07there", "hithere"},
+		{"unicode preserved", "café ☕", "café ☕"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Sanitize(tc.in); got != tc.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeMultiline_PreservesNewlinesAndTabs(t *testing.T) {
+	in := "line1\nline2\tcol2\x00\x07"
+	want := "line1\nline2\tcol2"
+	if got := SanitizeMultiline(in); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"shorter unchanged", "abc", 10, "abc"},
+		{"equal unchanged", "abcde", 5, "abcde"},
+		{"longer truncated with ellipsis", "abcdefghij", 6, "abc..."},
+		{"max le 3 no ellipsis", "abcdef", 3, "abc"},
+		{"max 1", "abcdef", 1, "a"},
+		{"unicode rune-safe", "日本語テスト", 4, "日..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Truncate(tc.in, tc.max); got != tc.want {
+				t.Errorf("Truncate(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertTime(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("America/New_York unavailable: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		loc  *time.Location
+		want string
+	}{
+		{"empty passes through", "", ny, ""},
+		{"nil loc passes through", "2026-01-15T12:00:00Z", nil, "2026-01-15T12:00:00Z"},
+		{"rfc3339 to NY", "2026-01-15T17:30:00Z", ny, "2026-01-15 12:30"},
+		{"graph seven-digit fraction", "2026-04-22T15:15:00.0000000", ny, "2026-04-22 11:15"},
+		{"date only in UTC", "2026-06-15", time.UTC, "2026-06-15"},
+		{"unparseable passes through", "not a date", ny, "not a date"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ConvertTime(tc.in, tc.loc); got != tc.want {
+				t.Errorf("ConvertTime(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the first unit-test coverage to the repo (~830 lines across 4 packages: `outfmt`, `config`, `graphapi/validate`, `cmd/paging`). Targets the pure-logic code that's easy to test without mocking the Graph SDK.
- Adds a CI workflow (`.github/workflows/ci.yml`) that runs `go vet`, `go build`, `go test -race`, and `golangci-lint` on every PR and push to `main`. Also fails CI when `go mod tidy` produces a diff.

## Why these packages first

`outfmt`, `config`, `graphapi/validate.go`, and `cmd/paging.go` are pure functions / file I/O — no Graph SDK calls, so no mocking surface. They get the test floor off zero with minimal investment. Heavier targets (`graphapi/{mail,calendar,drive,todo,contacts}.go`, `msauth`, `secrets`) are out of scope here — they'd need either an SDK-mocking refactor or live integration fixtures, both bigger commitments.

## What's covered

| Package | Notable coverage |
|---|---|
| `outfmt` | JSON envelope vs `--results-only`, table/plain/JSON dispatch, `--select` field filtering (case-insensitive, unknown fields ignored), control-char sanitization, rune-safe `Truncate`, timezone-aware `ConvertTime` |
| `config` | Round-trip save/load, default fallback for unknown accounts, account removal (with default-clearing), 0600 file perms, symlink rejection, world-readable auto-chmod, malformed JSON handling, `OLK_CONFIG_DIR` override, concurrent access under `-race` |
| `graphapi/validate` | `validateID` (length + character class), `ValidateEmail`/`Phone`/`Birthday`/`ContactFieldLen`, `clampTop` clamping, `normalizeGraphUTC` across the various Graph dateTime formats |
| `cmd/paging` | `buildMailFilter` (empty / unread / from / date range / combined / error wording), `parseDateTime` across RFC3339, datetime-without-zone, and date-only |

## CI workflow

- Runs on `pull_request` and `push` to `main`
- `test` job: `go mod tidy` drift check → `go vet` → `go build` → `go test -race -count=1 ./...`
- `lint` job: `golangci-lint` v2.5.0 using the existing `.golangci.yml`
- Pinned action SHAs to match `release.yml` style
- Times out at 10 min per job

## Test plan

- [x] All five packages compile cleanly
- [x] `go test -race -count=1 ./...` passes locally on Go 1.26
- [x] `golangci-lint run` reports 0 issues
- [x] `go mod tidy` produces no diff
- [ ] CI passes after merge (workflow only runs once the file is on a branch GitHub builds against)

## One thing noted (not fixed here)

While testing `outfmt.ConvertTime("2026-06-15", America/New_York)` I observed it returns `"2026-06-14"` — the function parses date-only inputs as UTC midnight, which shifts back one day in westward timezones. The documented behavior is "parse as UTC, convert to loc," so it's working as designed, but date-only values arguably should preserve their date when displayed. Test uses UTC for the date-only case to avoid coupling the test to that decision. Worth a follow-up issue if you agree it's a UX bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
