### PR TITLE
feat(auth): add --scope flag for delegated mailbox tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,20 @@ export OLK_TENANT_ID=your-tenant-id
 olk auth login
 ```
 
+### Additional Scopes
+
+Use `--scope` (repeatable) at login time to request additional OAuth scopes beyond the defaults — typically for tokens that need to read or act on a *different* user's mailbox under Microsoft 365 mailbox delegation (the executive-assistant pattern):
+
+```bash
+olk auth login --enterprise \
+  --scope Mail.Read.Shared \
+  --scope Calendars.Read.Shared
+```
+
+The flag merges with the default scope set (case-insensitive dedup) so you don't need to re-list the defaults. Make sure the corresponding API permissions are added to your app registration.
+
+> **Note:** `.Shared` scopes only grant the token *claim* — the existing `olk mail list` / `olk calendar events` calls still target your own mailbox via `/me`. Targeting another user's mailbox (`/users/{id}/...`) is a separate feature not yet implemented.
+
 ### Multi-Account
 
 ```bash

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -22,10 +22,11 @@ type AuthCmd struct {
 }
 
 type AuthLoginCmd struct {
-	ClientID   string `help:"OAuth2 client ID" env:"OLK_CLIENT_ID"`
-	TenantID   string `help:"Azure AD tenant ID" env:"OLK_TENANT_ID" default:"common"`
-	ReadOnly   bool   `help:"Request read-only permissions"`
-	Enterprise bool   `help:"Request enterprise scopes (work/school accounts)" env:"OLK_ENTERPRISE"`
+	ClientID   string   `help:"OAuth2 client ID" env:"OLK_CLIENT_ID"`
+	TenantID   string   `help:"Azure AD tenant ID" env:"OLK_TENANT_ID" default:"common"`
+	ReadOnly   bool     `help:"Request read-only permissions"`
+	Enterprise bool     `help:"Request enterprise scopes (work/school accounts)" env:"OLK_ENTERPRISE"`
+	Scope      []string `help:"Additional OAuth scopes to request (repeatable, e.g. --scope Mail.Read.Shared)" name:"scope"`
 }
 
 func (c *AuthLoginCmd) Run(ctx *RunContext) error {
@@ -53,6 +54,12 @@ func (c *AuthLoginCmd) Run(ctx *RunContext) error {
 		} else {
 			scopes = msauth.ReadOnlyScopes()
 		}
+	}
+	// Merge --scope additions (e.g. Mail.Read.Shared for delegated mailbox access).
+	// Dedup is case-insensitive so callers can't accidentally request a duplicate
+	// that Graph would reject.
+	if len(c.Scope) > 0 {
+		scopes = msauth.MergeScopes(scopes, c.Scope)
 	}
 	// Use a dedicated context for login — the global --timeout (default 60s)
 	// is too short for device-code flow which needs minutes for the user to

--- a/internal/msauth/scopes.go
+++ b/internal/msauth/scopes.go
@@ -1,5 +1,7 @@
 package msauth
 
+import "strings"
+
 // Microsoft Graph API scopes
 const (
 	ScopeMail            = "Mail.ReadWrite"
@@ -53,4 +55,32 @@ func ReadOnlyScopes() []string {
 // EnterpriseReadOnlyScopes returns read-only scopes including enterprise-only ones.
 func EnterpriseReadOnlyScopes() []string {
 	return append(ReadOnlyScopes(), "User.ReadBasic.All", "MailboxSettings.Read")
+}
+
+// MergeScopes appends extras to base, trimming whitespace and de-duplicating
+// case-insensitively while preserving order. First occurrence wins for casing.
+// Used to layer caller-provided scopes (e.g. --scope Mail.Read.Shared) on top of
+// the default scope set without producing duplicates that Graph would reject.
+func MergeScopes(base, extras []string) []string {
+	seen := make(map[string]struct{}, len(base)+len(extras))
+	result := make([]string, 0, len(base)+len(extras))
+	add := func(scope string) {
+		s := strings.TrimSpace(scope)
+		if s == "" {
+			return
+		}
+		key := strings.ToLower(s)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		result = append(result, s)
+	}
+	for _, s := range base {
+		add(s)
+	}
+	for _, s := range extras {
+		add(s)
+	}
+	return result
 }

--- a/internal/msauth/scopes_test.go
+++ b/internal/msauth/scopes_test.go
@@ -1,0 +1,105 @@
+package msauth
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeScopes_EmptyExtras(t *testing.T) {
+	base := []string{"offline_access", "User.Read", "Mail.ReadWrite"}
+	got := MergeScopes(base, nil)
+	if !reflect.DeepEqual(got, base) {
+		t.Errorf("got %v, want %v", got, base)
+	}
+}
+
+func TestMergeScopes_AppendsNew(t *testing.T) {
+	base := []string{"User.Read", "Mail.ReadWrite"}
+	extras := []string{"Mail.Read.Shared", "Calendars.Read.Shared"}
+	got := MergeScopes(base, extras)
+	want := []string{"User.Read", "Mail.ReadWrite", "Mail.Read.Shared", "Calendars.Read.Shared"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestMergeScopes_DedupCaseInsensitive(t *testing.T) {
+	base := []string{"User.Read", "Mail.ReadWrite"}
+	extras := []string{"mail.readwrite", "Mail.Read.Shared", "MAIL.READ.SHARED"}
+	got := MergeScopes(base, extras)
+	want := []string{"User.Read", "Mail.ReadWrite", "Mail.Read.Shared"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestMergeScopes_FirstCasingWins(t *testing.T) {
+	got := MergeScopes([]string{"Mail.ReadWrite"}, []string{"mail.readwrite"})
+	want := []string{"Mail.ReadWrite"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v — first occurrence's casing should win", got, want)
+	}
+}
+
+func TestMergeScopes_TrimsWhitespace(t *testing.T) {
+	got := MergeScopes(nil, []string{"  Mail.Read.Shared  ", "\tCalendars.Read.Shared\n"})
+	want := []string{"Mail.Read.Shared", "Calendars.Read.Shared"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestMergeScopes_DropsEmpty(t *testing.T) {
+	got := MergeScopes([]string{"User.Read", ""}, []string{"", "  ", "Mail.Read.Shared"})
+	want := []string{"User.Read", "Mail.Read.Shared"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestMergeScopes_DoesNotMutateBase(t *testing.T) {
+	base := []string{"User.Read", "Mail.ReadWrite"}
+	baseCopy := append([]string(nil), base...)
+	_ = MergeScopes(base, []string{"Mail.Read.Shared"})
+	if !reflect.DeepEqual(base, baseCopy) {
+		t.Errorf("base was mutated: got %v, want %v", base, baseCopy)
+	}
+}
+
+func TestDefaultScopes_IncludesEssentials(t *testing.T) {
+	got := DefaultScopes()
+	required := []string{ScopeOfflineAccess, ScopeUser, ScopeMail, ScopeMailSend}
+	for _, r := range required {
+		found := false
+		for _, s := range got {
+			if s == r {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DefaultScopes missing %q in %v", r, got)
+		}
+	}
+}
+
+func TestEnterpriseScopes_ExtendsDefault(t *testing.T) {
+	def := DefaultScopes()
+	ent := EnterpriseScopes()
+	if len(ent) <= len(def) {
+		t.Errorf("EnterpriseScopes should extend DefaultScopes, got %d vs %d", len(ent), len(def))
+	}
+	hasUserReadAll := false
+	hasMailboxSettings := false
+	for _, s := range ent {
+		switch s {
+		case ScopeUserReadAll:
+			hasUserReadAll = true
+		case ScopeMailboxSettings:
+			hasMailboxSettings = true
+		}
+	}
+	if !hasUserReadAll || !hasMailboxSettings {
+		t.Errorf("EnterpriseScopes missing enterprise-only scopes: %v", ent)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Option A** from #24 — adds a repeatable `--scope` flag to `olk auth login` so callers can extend the default OAuth scope set with extras (e.g. `Mail.Read.Shared` for delegated-mailbox access in the M365 exec-assistant pattern).

```bash
olk auth login --enterprise \
  --scope Mail.Read.Shared \
  --scope Calendars.Read.Shared
```

## What's in the box

| Commit | Change |
|---|---|
| `feat(msauth)` | `MergeScopes(base, extras)` helper: case-insensitive dedup, whitespace trim, order-preserving, first-casing-wins. 9 unit tests. |
| `feat(auth)` | New `Scope []string` Kong flag on `AuthLoginCmd`. After base scopes resolve (`default` / `enterprise` / `read-only`), `MergeScopes` layers `c.Scope` on top before calling `LoginDeviceCode`. |
| `docs` | README "Additional Scopes" subsection under Authentication. |

## Important nuance (also called out in README + commit message)

`.Shared` scopes only add the token *claim* — they do not change which mailbox `olk` actually targets. Every Graph call still hits `/me/...`. Reading a *different* user's mailbox additionally requires `/users/{id}/...` targeting throughout the graphapi package, which is a separate, larger feature (Option C in #24). This PR unblocks the auth half so a follow-up can do the mailbox-targeting half cleanly.

## Why Option A first

- Smallest reversible surface (~30 LOC of production code)
- Composable — works for *any* future scope the user wants, not just `.Shared`
- Leaves Option B (config-file persistence) and Option C (mailbox-targeting) free to land later

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` passes — including 9 new tests in `internal/msauth`
- [x] `go vet ./...` clean
- [x] `golangci-lint run` 0 issues
- [x] `olk auth login --help` shows the new flag in the expected position
- [ ] End-to-end login test against a real tenant — not possible from this PR (needs a tenant + browser). Worth a manual smoke before merge if you have one handy.

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
