### PR TITLE
feat(mail): --mailbox flag for delegated read access

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,36 @@ Use `--scope` (repeatable) at login time to request additional OAuth scopes beyo
 
 ```bash
 olk auth login --enterprise \
-  --scope Mail.Read.Shared \
-  --scope Calendars.Read.Shared
+  --scope Mail.Read.Shared
 ```
 
 The flag merges with the default scope set (case-insensitive dedup) so you don't need to re-list the defaults. Make sure the corresponding API permissions are added to your app registration.
 
-> **Note:** `.Shared` scopes only grant the token *claim* — the existing `olk mail list` / `olk calendar events` calls still target your own mailbox via `/me`. Targeting another user's mailbox (`/users/{id}/...`) is a separate feature not yet implemented.
+### Delegated Mailbox Access
+
+Once your token carries `Mail.Read.Shared`, use the global `--mailbox` flag to target a mailbox you have **Full Access** to (granted in M365 Admin Center → Mailbox permissions):
+
+```bash
+# Read another user's inbox
+olk mail list --mailbox boss@example.com
+
+# Read a specific message
+olk mail get MESSAGE_ID --mailbox boss@example.com
+
+# Search via KQL
+olk mail search "from:partner@example.com" --mailbox boss@example.com
+
+# List their folder tree
+olk mail folders --mailbox boss@example.com
+
+# Or set it once for the shell session
+export OLK_MAILBOX=boss@example.com
+olk mail list
+```
+
+This is the canonical executive-assistant / AI-agent pattern: the signed-in identity is your own (or a service account), Exchange ACLs control which mailboxes you can reach, and the OAuth scope controls what you can do inside them.
+
+> **Scope limits:** read-only delegated access (list / get / search / folders). Sending mail from another mailbox, modifying messages, calendar / contacts / drive / todo across delegation, and `/users/{id}/calendar`-style scoping are not yet supported.
 
 ### Multi-Account
 

--- a/internal/cmd/mail_folders.go
+++ b/internal/cmd/mail_folders.go
@@ -23,7 +23,12 @@ func (c *MailFoldersListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	folders, err := client.ListMailFolders(ctx.Ctx)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	folders, err := client.ListMailFolders(ctx.Ctx, target)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_get.go
+++ b/internal/cmd/mail_get.go
@@ -18,7 +18,12 @@ func (c *MailGetCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	msg, err := client.GetMessage(ctx.Ctx, c.ID)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	msg, err := client.GetMessage(ctx.Ctx, target, c.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -45,13 +45,18 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		filter += "inferenceClassification eq 'other'"
 	}
 
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
 	opts := graphapi.ListMessagesOptions{
 		FolderID: c.Folder,
 		Top:      c.Top,
 		Filter:   filter,
 	}
 
-	messages, err := client.ListMessages(ctx.Ctx, &opts)
+	messages, err := client.ListMessages(ctx.Ctx, target, &opts)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_search.go
+++ b/internal/cmd/mail_search.go
@@ -13,7 +13,12 @@ func (c *MailSearchCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	messages, err := client.SearchMessages(ctx.Ctx, c.Query, c.Top)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	messages, err := client.SearchMessages(ctx.Ctx, target, c.Query, c.Top)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/paging.go
+++ b/internal/cmd/paging.go
@@ -8,6 +8,21 @@ import (
 	"github.com/rlrghb/olkcli/internal/graphapi"
 )
 
+// resolveMailboxTarget validates the --mailbox value and returns it for use in
+// graphapi calls. Empty input is a no-op (the call targets /me). Non-empty input
+// must parse as a valid email address — Graph requires either the userPrincipalName
+// or the user's object id, and we constrain to UPN-shaped values for safety.
+func resolveMailboxTarget(mailbox string) (string, error) {
+	mailbox = strings.TrimSpace(mailbox)
+	if mailbox == "" {
+		return "", nil
+	}
+	if err := graphapi.ValidateEmail(mailbox); err != nil {
+		return "", fmt.Errorf("invalid --mailbox value: %w", err)
+	}
+	return mailbox, nil
+}
+
 // buildMailFilter builds an OData filter string from common mail filter options
 func buildMailFilter(unread bool, from, after, before string) (string, error) {
 	var filters []string

--- a/internal/cmd/paging_test.go
+++ b/internal/cmd/paging_test.go
@@ -5,6 +5,66 @@ import (
 	"testing"
 )
 
+func TestResolveMailboxTarget_Empty(t *testing.T) {
+	got, err := resolveMailboxTarget("")
+	if err != nil {
+		t.Fatalf("empty input should be a no-op, got err: %v", err)
+	}
+	if got != "" {
+		t.Errorf("empty input should return empty string, got %q", got)
+	}
+}
+
+func TestResolveMailboxTarget_TrimsWhitespace(t *testing.T) {
+	got, err := resolveMailboxTarget("   ")
+	if err != nil {
+		t.Fatalf("whitespace-only input should be treated as empty, got err: %v", err)
+	}
+	if got != "" {
+		t.Errorf("whitespace-only input should return empty string, got %q", got)
+	}
+}
+
+func TestResolveMailboxTarget_Valid(t *testing.T) {
+	got, err := resolveMailboxTarget("boss@example.com")
+	if err != nil {
+		t.Fatalf("valid email should pass, got err: %v", err)
+	}
+	if got != "boss@example.com" {
+		t.Errorf("got %q, want %q", got, "boss@example.com")
+	}
+}
+
+func TestResolveMailboxTarget_TrimsAroundValid(t *testing.T) {
+	got, err := resolveMailboxTarget("  boss@example.com  ")
+	if err != nil {
+		t.Fatalf("trimmed valid email should pass, got err: %v", err)
+	}
+	if got != "boss@example.com" {
+		t.Errorf("got %q, want %q", got, "boss@example.com")
+	}
+}
+
+func TestResolveMailboxTarget_Invalid(t *testing.T) {
+	cases := []string{
+		"not-an-email",
+		"@example.com",
+		"boss@",
+		"boss example.com",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := resolveMailboxTarget(in)
+			if err == nil {
+				t.Errorf("expected error for %q, got nil", in)
+			}
+			if err != nil && !strings.Contains(err.Error(), "--mailbox") {
+				t.Errorf("error message should mention --mailbox; got %v", err)
+			}
+		})
+	}
+}
+
 func TestBuildMailFilter_Empty(t *testing.T) {
 	got, err := buildMailFilter(false, "", "", "")
 	if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -26,6 +26,7 @@ type RootFlags struct {
 	JSON        bool   `help:"Output as JSON" env:"OLK_JSON"`
 	Plain       bool   `help:"Output as plain TSV" env:"OLK_PLAIN"`
 	Account     string `help:"Account email to use" env:"OLK_ACCOUNT"`
+	Mailbox     string `help:"Target a different user's mailbox via delegated access (requires Mail.Read.Shared at login)" env:"OLK_MAILBOX"`
 	Verbose     bool   `help:"Verbose output" short:"v" env:"OLK_VERBOSE"`
 	DryRun      bool   `help:"Dry run mode" env:"OLK_DRY_RUN"`
 	Force       bool   `help:"Force operation" env:"OLK_FORCE"`

--- a/internal/graphapi/client.go
+++ b/internal/graphapi/client.go
@@ -3,6 +3,7 @@ package graphapi
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
 )
 
 // Client wraps the Graph SDK client
@@ -22,4 +23,17 @@ func NewClient(cred azcore.TokenCredential) (*Client, error) {
 // Inner returns the underlying Graph SDK client
 func (c *Client) Inner() *msgraphsdk.GraphServiceClient {
 	return c.inner
+}
+
+// targetUser returns the user-scoped request builder for the target mailbox, or
+// the signed-in user's mailbox when target is empty. Both Me() and
+// Users().ByUserId() return the same *UserItemRequestBuilder type because the
+// kiota-generated SDK reuses item-level builders across the /me and /users/{id}
+// aliases — so the same chained calls work for either scope. Callers pass an
+// empty target to keep the existing /me behavior.
+func (c *Client) targetUser(target string) *users.UserItemRequestBuilder {
+	if target == "" {
+		return c.inner.Me()
+	}
+	return c.inner.Users().ByUserId(target)
 }

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -74,7 +74,11 @@ type ListMessagesOptions struct {
 	Select   []string
 }
 
-func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([]MailMessage, error) {
+// ListMessages returns messages from the target mailbox, or the signed-in user's
+// mailbox when target is empty. Targeting another mailbox requires the calling
+// token to carry the Mail.Read.Shared scope claim and the calling user to have
+// Full Access delegation on the target mailbox in Exchange.
+func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMessagesOptions) ([]MailMessage, error) {
 	if opts == nil {
 		opts = &ListMessagesOptions{}
 	}
@@ -138,7 +142,7 @@ func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([
 		if opts.Search != "" {
 			folderQueryParams.Search = &opts.Search
 		}
-		resp, err := c.inner.Me().MailFolders().ByMailFolderId(opts.FolderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+		resp, err := c.targetUser(target).MailFolders().ByMailFolderId(opts.FolderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
 			QueryParameters: folderQueryParams,
 		})
 		if err != nil {
@@ -151,7 +155,7 @@ func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([
 		return result, nil
 	}
 
-	resp, err := c.inner.Me().Messages().Get(ctx, config)
+	resp, err := c.targetUser(target).Messages().Get(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("listing messages: %w", err)
 	}
@@ -162,11 +166,13 @@ func (c *Client) ListMessages(ctx context.Context, opts *ListMessagesOptions) ([
 	return result, nil
 }
 
-func (c *Client) GetMessage(ctx context.Context, messageID string) (*MailMessage, error) {
+// GetMessage returns a single message from the target mailbox, or the signed-in
+// user's mailbox when target is empty. See ListMessages for scope requirements.
+func (c *Client) GetMessage(ctx context.Context, target, messageID string) (*MailMessage, error) {
 	if err := validateID(messageID, "message ID"); err != nil {
 		return nil, err
 	}
-	msg, err := c.inner.Me().Messages().ByMessageId(messageID).Get(ctx, &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
+	msg, err := c.targetUser(target).Messages().ByMessageId(messageID).Get(ctx, &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemMessagesMessageItemRequestBuilderGetQueryParameters{
 			Select: []string{"id", "subject", "from", "toRecipients", "ccRecipients", "bccRecipients", "receivedDateTime", "isRead", "hasAttachments", "body", "bodyPreview"},
 		},
@@ -353,9 +359,11 @@ func (c *Client) MarkMessage(ctx context.Context, messageID string, isRead bool)
 	return nil
 }
 
-func (c *Client) ListMailFolders(ctx context.Context) ([]MailFolder, error) {
+// ListMailFolders returns folders from the target mailbox, or the signed-in
+// user's mailbox when target is empty. See ListMessages for scope requirements.
+func (c *Client) ListMailFolders(ctx context.Context, target string) ([]MailFolder, error) {
 	var top int32 = 100
-	resp, err := c.inner.Me().MailFolders().Get(ctx, &users.ItemMailFoldersRequestBuilderGetRequestConfiguration{
+	resp, err := c.targetUser(target).MailFolders().Get(ctx, &users.ItemMailFoldersRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemMailFoldersRequestBuilderGetQueryParameters{
 			Top: &top,
 		},
@@ -446,13 +454,15 @@ func (c *Client) DeleteMailFolder(ctx context.Context, folderID string) error {
 	return nil
 }
 
-func (c *Client) SearchMessages(ctx context.Context, query string, top int32) ([]MailMessage, error) {
+// SearchMessages runs a KQL search against the target mailbox, or the signed-in
+// user's mailbox when target is empty. See ListMessages for scope requirements.
+func (c *Client) SearchMessages(ctx context.Context, target, query string, top int32) ([]MailMessage, error) {
 	// The $search parameter value must be wrapped in double quotes per
 	// Graph API requirements. KQL property restrictions (from:, subject:, etc.)
 	// and boolean operators (AND, OR, NOT) work inside the quoted string.
 	// Strip literal double quotes from user input to prevent breaking the wrapper.
 	search := `"` + strings.ReplaceAll(query, `"`, "") + `"`
-	return c.ListMessages(ctx, &ListMessagesOptions{
+	return c.ListMessages(ctx, target, &ListMessagesOptions{
 		Top:    top,
 		Search: search,
 	})


### PR DESCRIPTION
## Summary

Delivers the **read-mail half** of issue #24's delegated-mailbox / executive-assistant use case. Pairs with PR #26 (`--scope`) to make the full flow work end-to-end:

```bash
# Once, at login
olk auth login --enterprise --scope Mail.Read.Shared

# Then per-call, or via env var
olk mail list --mailbox boss@example.com
olk mail get MESSAGE_ID --mailbox boss@example.com
olk mail search "from:partner@example.com" --mailbox boss@example.com
olk mail folders --mailbox boss@example.com
```

## Design

One private helper in `graphapi/client.go`:

```go
func (c *Client) targetUser(target string) *users.UserItemRequestBuilder {
    if target == "" { return c.inner.Me() }
    return c.inner.Users().ByUserId(target)
}
```

This works because the kiota-generated SDK gives `Me()` and `Users().ByUserId()` the **same return type** (`*UserItemRequestBuilder`) — they're aliases that differ only in URL path. So every existing `c.inner.Me().X()` chain becomes `c.targetUser(target).X()` with zero structural change.

Four `graphapi` methods gain a `target string` first-positional argument:
- `ListMessages`
- `GetMessage`
- `SearchMessages`
- `ListMailFolders`

Four `cmd` files read `ctx.Flags.Mailbox` and pass it through. A small `resolveMailboxTarget` helper validates the value as an email and produces a clear error naming the `--mailbox` flag.

## Scope discipline

**In:** read-mail (list / get / search / folders).

**Intentionally not in:**
- write paths (send, reply, move, flag, categorize, delete) — need `.ReadWrite.Shared` / `.Send.Shared` scopes and more careful consent UX
- calendar, contacts, drive, todo — each has its own Graph permission model
- attachments download from a delegated message — easy follow-up once the read-side ergonomics are validated

The README "Delegated Mailbox Access" section explicitly enumerates these so adopters know the boundary.

## What's in each commit

| Commit | Change | LOC |
|---|---|---|
| `feat(graphapi)` | `targetUser` helper + thread `target` through 4 methods | +33 / -9 |
| `feat(cmd)` | `--mailbox` flag + `resolveMailboxTarget` + plumbing through 4 commands + tests | +100 / -4 |
| `docs` | README "Delegated Mailbox Access" section | +26 / -3 |

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` passes — 5 new `resolveMailboxTarget` tests covering empty / whitespace / valid / trimmed-valid / invalid inputs
- [x] `go vet ./...` clean
- [x] `golangci-lint run` 0 issues
- [x] `olk --help` shows `--mailbox` in the global flag block
- [ ] End-to-end against a real M365 tenant with Full Access delegation — not testable from CI; needs manual smoke

## Try it locally

```bash
# Empty / unset → no-op, existing behavior
olk mail list

# Trimmed and validated
OLK_MAILBOX="  boss@example.com  " olk mail list   # works
olk mail list --mailbox "not-an-email"             # clear validation error
```

Refs #24 (delivers the read-mail half; full-domain delegation tracked there for future iterations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
