### PR TITLE
feat(calendar): --mailbox delegation for read paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ Use `--scope` (repeatable) at login time to request additional OAuth scopes beyo
 
 ```bash
 olk auth login --enterprise \
-  --scope Mail.Read.Shared
+  --scope Mail.Read.Shared \
+  --scope Calendars.Read.Shared
 ```
 
 The flag merges with the default scope set (case-insensitive dedup) so you don't need to re-list the defaults. Make sure the corresponding API permissions are added to your app registration.
@@ -212,26 +213,27 @@ The flag merges with the default scope set (case-insensitive dedup) so you don't
 Once your token carries `Mail.Read.Shared`, use the global `--mailbox` flag to target a mailbox you have **Full Access** to (granted in M365 Admin Center → Mailbox permissions):
 
 ```bash
-# Read another user's inbox
+# Mail
 olk mail list --mailbox boss@example.com
-
-# Read a specific message
 olk mail get MESSAGE_ID --mailbox boss@example.com
-
-# Search via KQL
 olk mail search "from:partner@example.com" --mailbox boss@example.com
-
-# List their folder tree
 olk mail folders --mailbox boss@example.com
+
+# Calendar (requires Calendars.Read.Shared)
+olk calendar events --mailbox boss@example.com
+olk calendar view --mailbox boss@example.com --after 2026-06-01 --before 2026-06-08
+olk calendar get EVENT_ID --mailbox boss@example.com
+olk calendar calendars --mailbox boss@example.com
 
 # Or set it once for the shell session
 export OLK_MAILBOX=boss@example.com
 olk mail list
+olk calendar events
 ```
 
 This is the canonical executive-assistant / AI-agent pattern: the signed-in identity is your own (or a service account), Exchange ACLs control which mailboxes you can reach, and the OAuth scope controls what you can do inside them.
 
-> **Scope limits:** read-only delegated access (list / get / search / folders). Sending mail from another mailbox, modifying messages, calendar / contacts / drive / todo across delegation, and `/users/{id}/calendar`-style scoping are not yet supported.
+> **Scope limits:** read-only delegated access — mail (list / get / search / folders) and calendar (events / view / get / calendars). Sending mail, creating/updating/deleting events, modifying anything, and contacts / drive / todo across delegation are not yet supported.
 
 ### Multi-Account
 

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -66,7 +66,12 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 		end = t
 	}
 
-	events, err := client.ListEvents(ctx.Ctx, start, end, c.Calendar, c.Top)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	events, err := client.ListEvents(ctx.Ctx, target, start, end, c.Calendar, c.Top)
 	if err != nil {
 		return err
 	}
@@ -101,7 +106,12 @@ func (c *CalendarGetCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	event, err := client.GetEvent(ctx.Ctx, c.ID)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	event, err := client.GetEvent(ctx.Ctx, target, c.ID)
 	if err != nil {
 		return err
 	}
@@ -279,7 +289,12 @@ func (c *CalendarCalendarsCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	calendars, err := client.ListCalendars(ctx.Ctx)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	calendars, err := client.ListCalendars(ctx.Ctx, target)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/calendar_view.go
+++ b/internal/cmd/calendar_view.go
@@ -46,7 +46,12 @@ func (c *CalendarViewCmd) Run(ctx *RunContext) error {
 		end = t
 	}
 
-	events, err := client.ListCalendarView(ctx.Ctx, start, end, c.Calendar, c.Top)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	events, err := client.ListCalendarView(ctx.Ctx, target, start, end, c.Calendar, c.Top)
 	if err != nil {
 		return err
 	}

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -41,7 +41,11 @@ type CalendarInfo struct {
 	Owner string `json:"owner"`
 }
 
-func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
+// ListEvents returns calendar events in [startTime, endTime] from the target
+// mailbox, or the signed-in user's calendar when target is empty. Targeting
+// another mailbox requires the calling token to carry Calendars.Read.Shared
+// and the calling user to have Exchange Full Access delegation on the target.
+func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
 	top = clampTop(top)
 
 	startStr := startTime.UTC().Format("2006-01-02T15:04:05")
@@ -68,7 +72,7 @@ func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, c
 				Orderby:       queryParams.Orderby,
 			},
 		}
-		resp, err := c.inner.Me().Calendars().ByCalendarId(calendarID).CalendarView().Get(ctx, calConfig)
+		resp, err := c.targetUser(target).Calendars().ByCalendarId(calendarID).CalendarView().Get(ctx, calConfig)
 		if err != nil {
 			return nil, fmt.Errorf("listing events: %w", err)
 		}
@@ -83,7 +87,7 @@ func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, c
 		QueryParameters: queryParams,
 	}
 
-	resp, err := c.inner.Me().CalendarView().Get(ctx, config)
+	resp, err := c.targetUser(target).CalendarView().Get(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("listing events: %w", err)
 	}
@@ -95,11 +99,13 @@ func (c *Client) ListEvents(ctx context.Context, startTime, endTime time.Time, c
 	return events, nil
 }
 
-func (c *Client) GetEvent(ctx context.Context, eventID string) (*CalendarEvent, error) {
+// GetEvent returns a single event from the target mailbox, or the signed-in
+// user's calendar when target is empty. See ListEvents for scope requirements.
+func (c *Client) GetEvent(ctx context.Context, target, eventID string) (*CalendarEvent, error) {
 	if err := validateID(eventID, "event ID"); err != nil {
 		return nil, err
 	}
-	event, err := c.inner.Me().Events().ByEventId(eventID).Get(ctx, nil)
+	event, err := c.targetUser(target).Events().ByEventId(eventID).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting event: %w", err)
 	}
@@ -239,8 +245,10 @@ func (c *Client) RespondToEvent(ctx context.Context, eventID, response string) e
 	}
 }
 
-func (c *Client) ListCalendars(ctx context.Context) ([]CalendarInfo, error) {
-	resp, err := c.inner.Me().Calendars().Get(ctx, nil)
+// ListCalendars returns calendars from the target mailbox, or the signed-in
+// user's mailbox when target is empty. See ListEvents for scope requirements.
+func (c *Client) ListCalendars(ctx context.Context, target string) ([]CalendarInfo, error) {
+	resp, err := c.targetUser(target).Calendars().Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing calendars: %w", err)
 	}
@@ -462,9 +470,10 @@ func formatDaysOfWeek(days []models.DayOfWeek) string {
 }
 
 // ListCalendarView returns expanded occurrences (including recurring) in a date range.
-func (c *Client) ListCalendarView(ctx context.Context, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
-	// This uses the same calendarView endpoint as ListEvents, which already expands recurrences.
-	return c.ListEvents(ctx, startTime, endTime, calendarID, top)
+// ListCalendarView is an alias for ListEvents (which already calls the
+// calendarView endpoint and expands recurrences). Kept for caller clarity.
+func (c *Client) ListCalendarView(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
+	return c.ListEvents(ctx, target, startTime, endTime, calendarID, top)
 }
 
 // MeetingTimeSuggestion represents a suggested meeting time


### PR DESCRIPTION
## Summary

Extends delegated mailbox access (introduced for mail in #27) to **calendar reads** — same scope discipline, same flag, no new surface.

```bash
# Once, at login (extend the existing scope arg)
olk auth login --enterprise \
  --scope Mail.Read.Shared \
  --scope Calendars.Read.Shared

# Then per-call, or via OLK_MAILBOX
olk calendar events --mailbox boss@example.com
olk calendar view   --mailbox boss@example.com --after 2026-06-01 --before 2026-06-08
olk calendar get    EVENT_ID --mailbox boss@example.com
olk calendar calendars --mailbox boss@example.com
```

## Design

Reuses the `c.targetUser(target)` helper added in #27 — no new abstraction. The mail PR's helper works identically for calendar because the kiota-generated SDK gives `Me().Calendars()` and `Users().ByUserId(...).Calendars()` the same `*ItemCalendarsRequestBuilder` return type (and similarly for `Events()` and `CalendarView()`).

Four `graphapi` methods gain a `target string` first-positional argument:
- `ListEvents`
- `GetEvent`
- `ListCalendars`
- `ListCalendarView` (already a thin alias for `ListEvents`)

Four `cmd` methods read `ctx.Flags.Mailbox` via the existing `resolveMailboxTarget` helper and pass it down.

## Scope discipline (matches #27)

**In:** read-calendar (events / view / get / calendars).

**Intentionally not in:**
- Write paths (`CreateEvent`, `UpdateEvent`, `DeleteEvent`, `RespondToEvent`) — need `Calendars.ReadWrite.Shared` and more thought on consent + audit logging
- `FindMeetingTimes` — the mental model is "find times that work for *this user's* calendar against an attendee list," not "search another user's calendar." If anyone wants to find times for boss's calendar against attendees, that's a different feature and would need its own flag
- Contacts / Drive / Todo across delegation — each has its own Graph permission model and is worth its own PR

## What's in each commit

| Commit | Change | LOC |
|---|---|---|
| `feat(graphapi)` | Thread `target` through 4 calendar-read methods | +19 / -10 |
| `feat(cmd)` | Pass `--mailbox` through 4 calendar-read commands | +24 / -4 |
| `docs` | Extend README "Delegated Mailbox Access" with calendar examples | +11 / -9 |

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` passes — existing tests cover the `--mailbox` flag validation and helper; no calendar-specific tests added (calendar methods are SDK orchestration, hard to unit-test without a fake SDK)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` 0 issues
- [x] `olk calendar events --mailbox not-an-email` rejects with a clear `--mailbox` validation error (same as mail)
- [ ] End-to-end against a real M365 tenant with Full Access delegation — not testable from CI

Refs #24 — combined with #26 (`--scope`) and #27 (`--mailbox` + mail reads), the read-mail and read-calendar half of the executive-assistant pattern is now functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
