### PR TITLE
feat(contacts): --mailbox delegation for read paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ Use `--scope` (repeatable) at login time to request additional OAuth scopes beyo
 ```bash
 olk auth login --enterprise \
   --scope Mail.Read.Shared \
-  --scope Calendars.Read.Shared
+  --scope Calendars.Read.Shared \
+  --scope Contacts.Read.Shared
 ```
 
 The flag merges with the default scope set (case-insensitive dedup) so you don't need to re-list the defaults. Make sure the corresponding API permissions are added to your app registration.
@@ -225,6 +226,11 @@ olk calendar view --mailbox boss@example.com --after 2026-06-01 --before 2026-06
 olk calendar get EVENT_ID --mailbox boss@example.com
 olk calendar calendars --mailbox boss@example.com
 
+# Contacts (requires Contacts.Read.Shared)
+olk contacts list --mailbox boss@example.com
+olk contacts get CONTACT_ID --mailbox boss@example.com
+olk contacts search "alice" --mailbox boss@example.com
+
 # Or set it once for the shell session
 export OLK_MAILBOX=boss@example.com
 olk mail list
@@ -233,7 +239,7 @@ olk calendar events
 
 This is the canonical executive-assistant / AI-agent pattern: the signed-in identity is your own (or a service account), Exchange ACLs control which mailboxes you can reach, and the OAuth scope controls what you can do inside them.
 
-> **Scope limits:** read-only delegated access — mail (list / get / search / folders) and calendar (events / view / get / calendars). Sending mail, creating/updating/deleting events, modifying anything, and contacts / drive / todo across delegation are not yet supported.
+> **Scope limits:** read-only delegated access — mail (list / get / search / folders), calendar (events / view / get / calendars), and contacts (list / get / search). Sending mail, creating/updating/deleting anything, and drive / todo across delegation are not yet supported.
 
 ### Multi-Account
 

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -64,7 +64,12 @@ func (c *ContactsListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	contacts, err := client.ListContacts(ctx.Ctx, c.Top, c.Skip, c.Sort)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	contacts, err := client.ListContacts(ctx.Ctx, target, c.Top, c.Skip, c.Sort)
 	if err != nil {
 		return err
 	}
@@ -99,7 +104,12 @@ func (c *ContactsGetCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	contact, err := client.GetContact(ctx.Ctx, c.ID)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	contact, err := client.GetContact(ctx.Ctx, target, c.ID)
 	if err != nil {
 		return err
 	}
@@ -361,7 +371,8 @@ func (c *ContactsUpdateCmd) Run(ctx *RunContext) error {
 	if c.Street != "" || c.City != "" || c.State != "" || c.PostalCode != "" || c.Country != "" {
 		// Read-modify-write: fetch existing address, merge provided fields,
 		// so unspecified fields are preserved. 'none' clears individual parts.
-		existing, err := client.GetContact(ctx.Ctx, c.ID)
+		// Update is not a delegated operation — always reads from /me.
+		existing, err := client.GetContact(ctx.Ctx, "", c.ID)
 		if err != nil {
 			return err
 		}
@@ -461,7 +472,12 @@ func (c *ContactsSearchCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	contacts, err := client.SearchContacts(ctx.Ctx, c.Query, c.Top)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	contacts, err := client.SearchContacts(ctx.Ctx, target, c.Query, c.Top)
 	if err != nil {
 		return err
 	}

--- a/internal/graphapi/contacts.go
+++ b/internal/graphapi/contacts.go
@@ -86,7 +86,11 @@ type Contact struct {
 	OtherAddress     *Address `json:"otherAddress,omitempty"`
 }
 
-func (c *Client) ListContacts(ctx context.Context, top, skip int32, orderBy string) ([]Contact, error) {
+// ListContacts returns contacts from the target mailbox, or the signed-in
+// user's mailbox when target is empty. Targeting another mailbox requires the
+// calling token to carry Contacts.Read.Shared and the calling user to have
+// Exchange Full Access delegation on the target.
+func (c *Client) ListContacts(ctx context.Context, target string, top, skip int32, orderBy string) ([]Contact, error) {
 	top = clampTop(top)
 
 	queryParams := &users.ItemContactsRequestBuilderGetQueryParameters{
@@ -107,7 +111,7 @@ func (c *Client) ListContacts(ctx context.Context, top, skip int32, orderBy stri
 		QueryParameters: queryParams,
 	}
 
-	resp, err := c.inner.Me().Contacts().Get(ctx, config)
+	resp, err := c.targetUser(target).Contacts().Get(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("listing contacts: %w", err)
 	}
@@ -119,11 +123,13 @@ func (c *Client) ListContacts(ctx context.Context, top, skip int32, orderBy stri
 	return contacts, nil
 }
 
-func (c *Client) GetContact(ctx context.Context, contactID string) (*Contact, error) {
+// GetContact returns a single contact from the target mailbox, or the signed-in
+// user's mailbox when target is empty. See ListContacts for scope requirements.
+func (c *Client) GetContact(ctx context.Context, target, contactID string) (*Contact, error) {
 	if err := validateID(contactID, "contact ID"); err != nil {
 		return nil, err
 	}
-	ct, err := c.inner.Me().Contacts().ByContactId(contactID).Get(ctx, nil)
+	ct, err := c.targetUser(target).Contacts().ByContactId(contactID).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting contact: %w", err)
 	}
@@ -520,7 +526,10 @@ func (c *Client) DeleteContact(ctx context.Context, contactID string) error {
 	return nil
 }
 
-func (c *Client) SearchContacts(ctx context.Context, query string, top int32) ([]Contact, error) {
+// SearchContacts runs a prefix search against contacts in the target mailbox,
+// or the signed-in user's mailbox when target is empty. See ListContacts for
+// scope requirements.
+func (c *Client) SearchContacts(ctx context.Context, target, query string, top int32) ([]Contact, error) {
 	top = clampTop(top)
 	// Strict allowlist: only safe characters permitted in search queries
 	if !safeSearchQuery.MatchString(query) {
@@ -540,7 +549,7 @@ func (c *Client) SearchContacts(ctx context.Context, query string, top int32) ([
 		QueryParameters: queryParams,
 	}
 
-	resp, err := c.inner.Me().Contacts().Get(ctx, config)
+	resp, err := c.targetUser(target).Contacts().Get(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("searching contacts: %w", err)
 	}


### PR DESCRIPTION
## Summary

Extends delegated mailbox access (mail #27, calendar #28) to **contacts reads**. Same pattern, same `--mailbox` flag, no new abstractions.

```bash
# Extend the login scope list
olk auth login --enterprise \
  --scope Mail.Read.Shared \
  --scope Calendars.Read.Shared \
  --scope Contacts.Read.Shared

# Then per-call or via OLK_MAILBOX
olk contacts list   --mailbox boss@example.com
olk contacts get    CONTACT_ID --mailbox boss@example.com
olk contacts search "alice"   --mailbox boss@example.com
```

## Design

Three `graphapi` methods gain a `target string` first-positional arg and route through the existing `c.targetUser(target)` helper:

- `ListContacts`
- `GetContact`
- `SearchContacts`

Three `cmd` callers (`ContactsListCmd`, `ContactsGetCmd`, `ContactsSearchCmd`) resolve `ctx.Flags.Mailbox` via the existing `resolveMailboxTarget` helper and pass through.

**One subtle detail** — `ContactsUpdateCmd` calls `GetContact` internally as a read-modify-write precondition (to merge address fields). That signature also changed, but update is **not** a delegated operation, so it explicitly passes `""` as target. A comment marks this so the reasoning is obvious to future readers.

## Scope discipline (consistent with #27, #28)

**In:** read-contacts (list / get / search).

**Intentionally not in:**
- Write paths (`CreateContact`, `UpdateContact`, `DeleteContact`) — need `Contacts.ReadWrite.Shared` and more careful consent UX
- Drive / Todo across delegation — different Graph permission models, separate PRs

## What's in each commit

| Commit | Change | LOC |
|---|---|---|
| `feat(graphapi)` | Thread `target` through 3 contacts-read methods | +15 / -6 |
| `feat(cmd)` | Pass `--mailbox` through 3 contacts-read commands + comment update path | +20 / -4 |
| `docs` | Extend README Delegated Mailbox Access section | +8 / -2 |

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` passes — existing `--mailbox` validation tests cover input handling; no contacts-specific tests added (same rationale as mail/calendar PRs)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` 0 issues
- [x] `olk contacts list --mailbox not-an-email` rejects with the standard `--mailbox` validation error
- [ ] End-to-end against a real M365 tenant — not testable from CI

## Where this leaves issue #24

| Domain | Read | Write |
|---|---|---|
| Mail | ✅ #27 | — |
| Calendar | ✅ #28 (open) | — |
| Contacts | ✅ this PR | — |
| Drive / Todo | — | — |

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
