### PR TITLE
docs: align AGENTS.md and SKILL.md with current repo state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,10 @@
 - `cmd/olk/`: CLI entrypoint — minimal, delegates to `internal/cmd.Execute()`.
 - `internal/cmd/`: Command implementations using kong structs. Each command group has its own file(s): `mail_*.go`, `calendar*.go`, `todo.go`, `todo_checklist.go`, `todo_attachments.go`, `todo_links.go`, `whoami.go`, etc.
 - `internal/msauth/`: Microsoft OAuth2 implementation — device code flow, token refresh, credential bridge.
-- `internal/graphapi/`: Microsoft Graph API wrapper — mail, calendar, contacts, todo (tasks, checklist items, attachments, linked resources), availability, mailbox settings, mail rules, people.
+- `internal/graphapi/`: Microsoft Graph API wrapper — mail, calendar, contacts, todo (tasks, checklist items, attachments, linked resources), availability, mailbox settings, mail rules, people. Includes the `targetUser` helper that routes reads to `/me` or `/users/{id}` for delegated mailbox access, and error-shaping helpers (`graphErrorMessage`, `enterpriseError`, `scopeUpgradeError`) in `validate.go`.
 - `internal/config/`: Configuration and XDG paths (`~/.config/olk/`).
 - `internal/secrets/`: OS keyring integration via `99designs/keyring`.
 - `internal/outfmt/`: Output formatting — JSON envelope, aligned tables, TSV, timezone conversion via `ConvertTime()`.
-- `internal/errfmt/`: Graph API error mapping to actionable user messages.
 - `SKILL.md`: [Agent Skills](https://agentskills.io) standard file — teaches AI assistants (Claude Code, OpenClaw, etc.) how to use `olk` commands.
 - `bin/`: build outputs (gitignored).
 
@@ -24,7 +23,7 @@
 
 ## Coding Style & Naming Conventions
 
-- Formatting: `goimports` with local prefix `github.com/rlrghb/olkcli` + `gofumpt`.
+- Formatting: `gofmt` + `goimports` with local prefix `github.com/rlrghb/olkcli` (configured in `.golangci.yml`).
 - Output: keep stdout parseable (`--json` / `--plain`); send human hints/progress to stderr.
 - Graph API pointer types: always nil-check before dereferencing (`if x.GetFoo() != nil`).
 - Kong commands: one struct per command, `Run(ctx *RunContext) error` method.
@@ -32,9 +31,17 @@
 
 ## Testing Guidelines
 
-- Unit tests: stdlib `testing` package.
-- Integration tests require a valid OAuth token — run manually, not in CI.
-- Test files go next to the code they test (`*_test.go`).
+- Unit tests: stdlib `testing` package. Test files go next to the code they test (`*_test.go`).
+- Existing coverage: `internal/outfmt`, `internal/config`, `internal/msauth/scopes`, `internal/graphapi/validate`, and `internal/cmd/paging` (filter builder + mailbox-target validation). Other packages are not yet unit-tested.
+- Integration tests require a valid OAuth token + live Graph access — run manually, not in CI.
+- New tests should run cleanly under `go test -race -count=1 ./...` and pass `golangci-lint run`.
+
+## CI
+
+- `.github/workflows/ci.yml` runs on every pull request and push to `main`.
+- The `test` job runs `go mod tidy` drift check → `go vet ./...` → `go build ./...` → `go test -race -count=1 ./...` on Ubuntu using the Go version pinned in `go.mod`.
+- The `lint` job runs `golangci-lint` v2.5.0 against `.golangci.yml`.
+- Both jobs use pinned action SHAs to match `release.yml` style.
 
 ## Key Design Decisions
 
@@ -43,6 +50,7 @@
 - **Embedded Client ID**: `51e726d0-22a4-45f7-a71c-b472ff84c027`. Overridable via `--client-id` / `OLK_CLIENT_ID`.
 - **Tenant `common`**: Default tenant accepts both personal and enterprise accounts.
 - **Lazy client init**: `RunContext.GraphClient()` initializes on first call — auth commands don't need a Graph client.
+- **Delegated mailbox routing**: read paths in `internal/graphapi/{mail,calendar,contacts}.go` take a `target string` first parameter and route through `c.targetUser(target)`. Empty target preserves `/me` behavior; a non-empty value hits `/users/{target}/…`. The CLI exposes this as the global `--mailbox` flag (env `OLK_MAILBOX`), validated once via `resolveMailboxTarget` in `internal/cmd/paging.go`. New read methods should follow the same shape; write paths intentionally stay on `/me` for now.
 
 ## Commit & Pull Request Guidelines
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,7 @@ Setup (once)
 - `olk auth login` — device-code OAuth2 flow for personal accounts (opens browser)
 - `olk auth login --enterprise` — login with enterprise scopes for work/school accounts (enables OOO, inbox rules, directory search)
 - `olk auth login --client-id ID --tenant-id ID` — enterprise custom app registration
+- `olk auth login --scope SCOPE` — request additional OAuth scopes (repeatable). Use for delegated access, e.g. `--scope Mail.Read.Shared --scope Calendars.Read.Shared --scope Contacts.Read.Shared`. Merges with the default set, case-insensitive dedup.
 - `olk auth list` — list authenticated accounts
 - `olk auth status` — check token validity
 - `olk auth logout [EMAIL]` — remove stored credentials
@@ -204,6 +205,21 @@ User Profile
 
 - `olk whoami` — display current user's name, email, job title, department, office, phone
 
+Delegated Mailbox Access (executive-assistant pattern)
+
+Use when the signed-in account needs to read another user's mailbox under Microsoft 365 mailbox delegation. The signed-in identity is your own (or a service account), Exchange ACLs control which mailboxes you can reach, and the OAuth scope controls what you can do inside them. Read-only for now — sending mail or modifying anything in a delegated mailbox is not supported.
+
+- One-time login with shared scopes: `olk auth login --enterprise --scope Mail.Read.Shared --scope Calendars.Read.Shared --scope Contacts.Read.Shared`
+- Read another user's mail: `olk mail list --mailbox boss@example.com`
+- Read a specific message: `olk mail get <ID> --mailbox boss@example.com`
+- Search via KQL: `olk mail search "from:partner@example.com" --mailbox boss@example.com`
+- List their folders: `olk mail folders --mailbox boss@example.com`
+- Their calendar: `olk calendar events --mailbox boss@example.com` (also `view`, `get`, `calendars`)
+- Their contacts: `olk contacts list --mailbox boss@example.com` (also `get`, `search`)
+- Persist for the shell session: `export OLK_MAILBOX=boss@example.com`
+- The target must have granted Full Access via M365 Admin Center → Mailbox permissions; the calling token must carry the matching `.Shared` scope.
+- Write commands (send, reply, move, flag, create event, update contact, etc.) ignore `--mailbox` and always act on the signed-in user's own mailbox.
+
 Shortcuts
 
 - `olk send ...` → `olk mail send ...`
@@ -226,6 +242,7 @@ Global Flags
 - `--json` — JSON output (env: `OLK_JSON`)
 - `--plain` — TSV output (env: `OLK_PLAIN`)
 - `--account EMAIL` — use a specific account (env: `OLK_ACCOUNT`)
+- `--mailbox EMAIL` — target a different user's mailbox via delegated access for mail / calendar / contacts reads. Requires the corresponding `.Shared` scope at login and Exchange Full Access delegation on the target (env: `OLK_MAILBOX`)
 - `--results-only` — unwrap JSON envelope (env: `OLK_RESULTS_ONLY`)
 - `--select FIELDS` — field projection (env: `OLK_SELECT`)
 - `--force` — skip confirmations (env: `OLK_FORCE`)
@@ -251,6 +268,7 @@ Scripting Examples
 - Find meeting times: `olk calendar find-times --attendees a@b.com --attendees c@d.com --json --results-only | jq '.[0]'`
 - Search people: `olk people search "engineering" --json --results-only | jq -r '.[].email'`
 - Focused inbox unread: `olk mail list --focused --unread --json --results-only | jq length`
+- Summarize boss's unread (delegated): `olk mail list --mailbox boss@example.com --unread --json --results-only | jq -r '.[] | "\(.from): \(.subject)"'`
 - List large files: `olk drive ls /Documents --json --results-only | jq '[.[] | select(.size > 10000000)] | sort_by(.size) | reverse'`
 - Check quota: `olk drive info --json --results-only | jq '{used: .quotaUsed, total: .quotaTotal}'`
 
@@ -258,6 +276,7 @@ Notes
 
 - Set `OLK_TIMEZONE=America/New_York` to display times in your timezone.
 - Set `OLK_ACCOUNT=you@example.com` to avoid repeating `--account`.
+- Set `OLK_MAILBOX=boss@example.com` to read a delegated mailbox by default for mail / calendar / contacts (requires the matching `.Shared` scope at login).
 - Set `OLK_TODO_LIST=<list-id>` to avoid repeating `--list` for todo commands.
 - Set `OLK_DRIVE_ID=<drive-id>` to avoid repeating `--drive-id` for drive commands.
 - Set `OLK_KEYRING_PASSWORD=<password>` for headless/non-interactive environments (file-backend keyring).


### PR DESCRIPTION
## Summary

Cleanup pass on `AGENTS.md` and `SKILL.md` to fix factual drift and document the delegated-mailbox work that landed in #26–#29. Audit-driven, no functional code changes.

## What was wrong

### `AGENTS.md`

| Issue | Fix |
|---|---|
| Listed `internal/errfmt/` as a directory — it doesn't exist | Removed; folded the actual error-shaping helpers (`graphErrorMessage`, `enterpriseError`, `scopeUpgradeError` in `graphapi/validate.go`) into the `internal/graphapi/` line |
| Claimed `gofumpt` in coding style — repo doesn't configure it | Replaced with `gofmt` + `goimports` to match what's actually in `.golangci.yml` |
| Testing Guidelines understated reality — didn't mention the new unit-test packages or CI | Expanded with the actual packages now covered + added a new "CI" section describing `.github/workflows/ci.yml` |
| No record of the `targetUser` helper or `--mailbox` plumbing | Added a Key Design Decision entry so future contributors touching read paths follow the same pattern |

### `SKILL.md`

This one mattered more — it's what AI assistants read to learn the CLI surface. The recent delegated-mailbox feature was completely invisible to them, so assistants wouldn't have suggested the exec-assistant pattern even when users described that exact use case.

| Gap | Fix |
|---|---|
| `--scope` flag undocumented on `auth login` | Added with a delegated-access example |
| `--mailbox` not in Global Flags | Added with env-var note |
| No "Delegated Mailbox Access" section | Added — full one-time-login + per-call workflow for mail / calendar / contacts, with the read-only constraint called out explicitly |
| `OLK_MAILBOX` not in Notes | Added alongside `OLK_ACCOUNT` |
| No delegated scripting example | Added "summarize boss's unread" |

## Test plan

- [x] `go build ./...` clean (no code changes, but verifies the repo still builds)
- [x] Files render as expected; no markdown structure broken
- [ ] AI-assistant smoke test — out of scope here; the SKILL.md changes need real-world use to validate, but the structure follows the existing patterns in that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
