### PR TITLE
fix(auth): document tenant-id pitfall for personal accounts; add verbose HTTP logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,18 @@ Uses an embedded public client ID with device-code flow. The `--enterprise` flag
 If your organization blocks the default client ID, or your admin requires apps to be registered under your tenant, you'll need to create your own app registration:
 
 1. Go to [Azure Portal > App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) and click **New registration**
-2. Set **Supported account types** to match your needs (single tenant or multi-tenant)
+2. Set **Supported account types** to match your needs — use **"Personal Microsoft accounts only"** for outlook.com/hotmail.com, **"Accounts in any organizational directory and personal Microsoft accounts"** for both, or single-tenant for org-only
 3. Under **Authentication > Advanced settings**, set **Allow public client flows** to **Yes** (required for device-code flow)
 4. Under **API permissions**, add **Microsoft Graph** delegated permissions: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`, `Files.ReadWrite`, `People.Read`, `User.Read`, `User.ReadBasic.All`, `MailboxSettings.ReadWrite`, `offline_access` (use `Files.Read` instead of `Files.ReadWrite` for read-only access)
-5. Copy the **Application (client) ID** and **Directory (tenant) ID** from the app's Overview page
+5. Copy the **Application (client) ID** from the app's Overview page
 
-Then use them:
+Then use it:
 
 ```bash
+# Personal Microsoft account (outlook.com, hotmail.com, live.com) — omit --tenant-id
+olk auth login --client-id YOUR_CLIENT_ID
+
+# Work or school account — include your Directory (tenant) ID from the app's Overview page
 olk auth login --client-id YOUR_CLIENT_ID --tenant-id YOUR_TENANT_ID
 ```
 
@@ -192,9 +196,11 @@ Or via environment variables:
 
 ```bash
 export OLK_CLIENT_ID=your-client-id
-export OLK_TENANT_ID=your-tenant-id
+export OLK_TENANT_ID=your-tenant-id  # omit for personal accounts
 olk auth login
 ```
+
+> **Note:** Personal Microsoft accounts (outlook.com, hotmail.com, live.com) do not have a meaningful tenant ID — they share Microsoft's common consumer tenant. Passing `--tenant-id` with a personal account will cause a 401 error. Omitting it lets `olk` use the `common` endpoint, which works for both personal and work/school accounts.
 
 ### Additional Scopes
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/alecthomas/kong v1.15.0
 	github.com/microsoft/kiota-abstractions-go v1.9.3
+	github.com/microsoft/kiota-http-go v1.5.5
 	github.com/microsoftgraph/msgraph-sdk-go v1.96.0
+	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0
 	golang.org/x/term v0.39.0
 	golang.org/x/text v0.33.0
 )
@@ -24,12 +26,10 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/microsoft/kiota-authentication-azure-go v1.3.1 // indirect
-	github.com/microsoft/kiota-http-go v1.5.5 // indirect
 	github.com/microsoft/kiota-serialization-form-go v1.1.2 // indirect
 	github.com/microsoft/kiota-serialization-json-go v1.1.2 // indirect
 	github.com/microsoft/kiota-serialization-multipart-go v1.1.2 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.1.3 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -120,7 +120,12 @@ func (r *RunContext) GraphClient() (*graphapi.Client, error) {
 		return nil, fmt.Errorf("getting credentials: %w", err)
 	}
 
-	client, err := graphapi.NewClient(cred)
+	var client *graphapi.Client
+	if r.Flags.Verbose {
+		client, err = graphapi.NewClientVerbose(cred)
+	} else {
+		client, err = graphapi.NewClient(cred)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("creating Graph client: %w", err)
 	}

--- a/internal/graphapi/client.go
+++ b/internal/graphapi/client.go
@@ -1,8 +1,18 @@
 package graphapi
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	khttp "github.com/microsoft/kiota-http-go"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	graphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
+	graphauth "github.com/microsoftgraph/msgraph-sdk-go-core/authentication"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 )
 
@@ -13,11 +23,92 @@ type Client struct {
 
 // NewClient creates a new Graph API client from a token credential
 func NewClient(cred azcore.TokenCredential) (*Client, error) {
-	client, err := msgraphsdk.NewGraphServiceClientWithCredentials(cred, nil)
+	return newClient(cred, false)
+}
+
+// NewClientVerbose creates a new Graph API client with HTTP request/response logging to stderr
+func NewClientVerbose(cred azcore.TokenCredential) (*Client, error) {
+	return newClient(cred, true)
+}
+
+func newClient(cred azcore.TokenCredential, verbose bool) (*Client, error) {
+	if !verbose {
+		inner, err := msgraphsdk.NewGraphServiceClientWithCredentials(cred, nil)
+		if err != nil {
+			return nil, err
+		}
+		return &Client{inner: inner}, nil
+	}
+
+	// Verbose mode rebuilds the client with the SDK's own Graph middleware
+	// pipeline — telemetry plus the built-in /users/me-token-to-replace → /me URL
+	// rewrite (msgraph-sdk-go-core graph_client_factory.go ReplacementPairs) — and
+	// appends a logging handler as the innermost middleware so it observes the
+	// final, post-rewrite request. The /me rewrite is part of the default pipeline,
+	// so personal Microsoft accounts (MSA/outlook.com) need no special handling;
+	// passing nil scopes/hosts to the core auth provider applies the same Graph
+	// defaults the standard constructor uses.
+	auth, err := graphauth.NewAzureIdentityAuthenticationProviderWithScopesAndValidHosts(cred, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{inner: client}, nil
+
+	opts := msgraphsdk.GetDefaultClientOptions()
+	middlewares := append(graphcore.GetDefaultMiddlewaresWithOptions(&opts), &loggingMiddleware{out: os.Stderr})
+	httpClient := graphcore.GetDefaultClient(&opts, middlewares...)
+
+	adapter, err := msgraphsdk.NewGraphRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(auth, nil, nil, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{inner: msgraphsdk.NewGraphServiceClient(adapter)}, nil
+}
+
+// loggingMiddleware logs HTTP requests and responses (redacting Authorization
+// headers) to out. It runs as the innermost middleware so it sees the request as
+// it goes on the wire, after URL rewriting and telemetry handlers have applied.
+type loggingMiddleware struct {
+	out io.Writer
+}
+
+func (m *loggingMiddleware) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *http.Request) (*http.Response, error) {
+	w := m.out
+	if w == nil {
+		w = os.Stderr
+	}
+
+	// Log request
+	fmt.Fprintf(w, "[verbose] --> %s %s\n", req.Method, req.URL.String())
+	for k, vs := range req.Header {
+		if strings.EqualFold(k, "authorization") {
+			fmt.Fprintf(w, "[verbose]     %s: <redacted>\n", k)
+			continue
+		}
+		fmt.Fprintf(w, "[verbose]     %s: %s\n", k, strings.Join(vs, ", "))
+	}
+
+	resp, err := pipeline.Next(req, middlewareIndex)
+	if err != nil {
+		fmt.Fprintf(w, "[verbose] <-- error: %v\n", err)
+		return resp, err
+	}
+
+	fmt.Fprintf(w, "[verbose] <-- %s\n", resp.Status)
+	for k, vs := range resp.Header {
+		fmt.Fprintf(w, "[verbose]     %s: %s\n", k, strings.Join(vs, ", "))
+	}
+
+	// Always capture body, but only fully dump it on non-2xx
+	if resp.Body != nil {
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		if readErr == nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+			fmt.Fprintf(w, "[verbose]     body: %s\n", string(body))
+		}
+	}
+
+	return resp, nil
 }
 
 // Inner returns the underlying Graph SDK client

--- a/internal/graphapi/client_test.go
+++ b/internal/graphapi/client_test.go
@@ -1,0 +1,88 @@
+package graphapi
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// stubPipeline implements khttp.Pipeline, building a canned response inside
+// Next() so the loggingMiddleware can be exercised without a real HTTP round
+// trip. The response is constructed here (rather than passed in) so its Body is
+// owned end-to-end by the code under test and its single caller.
+type stubPipeline struct {
+	status int
+	body   string
+}
+
+func (p *stubPipeline) Next(req *http.Request, middlewareIndex int) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: p.status,
+		Status:     http.StatusText(p.status),
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(p.body)),
+	}, nil
+}
+
+func TestLoggingMiddlewareRedactsAuthorization(t *testing.T) {
+	var buf bytes.Buffer
+	mw := &loggingMiddleware{out: &buf}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://graph.microsoft.com/v1.0/me", http.NoBody)
+	req.Header.Set("Authorization", "Bearer super-secret-token")
+	req.Header.Set("Client-Request-Id", "abc-123")
+
+	got, err := mw.Intercept(&stubPipeline{status: http.StatusOK, body: `{"ok":true}`}, 0, req)
+	if err != nil {
+		t.Fatalf("Intercept returned error: %v", err)
+	}
+	defer got.Body.Close()
+
+	out := buf.String()
+	if strings.Contains(out, "super-secret-token") {
+		t.Fatalf("token leaked into verbose log:\n%s", out)
+	}
+	if !strings.Contains(out, "<redacted>") {
+		t.Fatalf("expected Authorization header to be redacted:\n%s", out)
+	}
+	if !strings.Contains(out, "abc-123") {
+		t.Fatalf("expected non-sensitive headers to be logged:\n%s", out)
+	}
+}
+
+func TestLoggingMiddlewareBodyDumpOnlyOnError(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantBody bool
+	}{
+		{"success body not dumped", http.StatusOK, `{"value":"sensitive"}`, false},
+		{"error body dumped", http.StatusForbidden, `{"error":"forbidden"}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			mw := &loggingMiddleware{out: &buf}
+			req, _ := http.NewRequest(http.MethodGet, "https://graph.microsoft.com/v1.0/me", http.NoBody)
+
+			got, err := mw.Intercept(&stubPipeline{status: tc.status, body: tc.body}, 0, req)
+			if err != nil {
+				t.Fatalf("Intercept returned error: %v", err)
+			}
+			defer got.Body.Close()
+
+			if strings.Contains(buf.String(), "body:") != tc.wantBody {
+				t.Fatalf("body-dump=%v, want %v; log:\n%s", !tc.wantBody, tc.wantBody, buf.String())
+			}
+
+			// The body must remain fully readable by downstream consumers.
+			read, _ := io.ReadAll(got.Body)
+			if string(read) != tc.body {
+				t.Fatalf("downstream body = %q, want %q", string(read), tc.body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adapts #23 by @tbutkiewicz. Personal Microsoft accounts (outlook.com/hotmail.com) hit a `401` on every command — the root cause is passing `--tenant-id` with a personal account (which has no tenant), which the docs previously told users to always do.

## Changes
- **README**: split the custom-app login example for personal vs. work/school accounts and warn that `--tenant-id` causes a 401 for personal accounts.
- **Verbose logging**: wire the existing `--verbose`/`-v` flag to log Graph HTTP requests/responses to stderr (`Authorization` redacted; bodies dumped only on non-2xx), implemented as a kiota middleware appended to the SDK's default Graph pipeline.
- **Tests**: cover `Authorization` redaction and error-only body dumps.

## How this differs from #23
The original PR also added a transport that rewrote the `/users/me-token-to-replace` sentinel to `/me`. That rewrite is **already** performed by the Graph SDK's default `UrlReplaceHandler` middleware (`msgraph-sdk-go-core` `ReplacementPairs`), so reimplementing it required bypassing the default pipeline — which inadvertently dropped the `GraphTelemetryHandler`. This PR keeps @tbutkiewicz's docs fix and verbose-logging idea but layers logging **on top of** the stock Graph pipeline, so the `/me` rewrite and telemetry are preserved.

## Validation
- `make build`, `make test` (`-race`), `make lint` — all green.

Co-authored with @tbutkiewicz (original author of #23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)