### PR TITLE
docs: OneDrive reference + README/SKILL/AGENTS quality pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 ## Testing Guidelines
 
 - Unit tests: stdlib `testing` package. Test files go next to the code they test (`*_test.go`).
-- Existing coverage: `internal/outfmt`, `internal/config`, `internal/msauth/scopes`, `internal/graphapi/validate`, and `internal/cmd/paging` (filter builder + mailbox-target validation). Other packages are not yet unit-tested.
+- Existing coverage: `internal/outfmt` (formatting + untrusted-wrapping), `internal/config`, `internal/msauth/scopes`, `internal/graphapi` (validate + capability guards), and `internal/cmd` (paging filters + mailbox-target validation, MCP server/registry, schema generation, argv building, output capture). Coverage is partial — many command and Graph-wrapper paths remain untested.
 - Integration tests require a valid OAuth token + live Graph access — run manually, not in CI.
 - New tests should run cleanly under `go test -race -count=1 ./...` and pass `golangci-lint run`.
 
@@ -59,6 +59,13 @@
 - Follow Conventional Commits (e.g. `feat(mail): add --attach flag to send`).
 - Group related changes; avoid bundling unrelated refactors.
 - PRs should summarize scope, note testing performed, and mention user-facing changes.
+- Attribution: when adapting or reworking someone else's PR/patch, keep them as a `Co-Authored-By:` trailer on the commit even if the code was substantially rewritten.
+
+### Review vs. Land
+
+- **Review mode is read-only.** Inspect with `gh pr view <n>` / `gh pr diff <n>`; don't push to a contributor's branch while reviewing.
+- **Land mode**: never commit directly to `main` — branch, open a PR, and **wait for both CI jobs (`test`, `lint`) to pass** before merging. Merge with **squash** and delete the branch. Sync `main` and prune afterward.
+- Verify behavior before landing user-facing changes (run the binary / a live smoke test), not just unit tests.
 
 ## Security & Configuration
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ olk contacts list
 | `--json` | JSON envelope | Scripting with `jq` |
 | `--plain` | Tab-separated | Piping to `awk`, `cut` |
 
+Results go to **stdout**; errors, prompts, and diagnostics go to **stderr** — so `olk … --json | jq` (or an agent reading stdout) stays clean even when a prompt or warning fires.
+
 ### JSON Envelope
 
 ```bash
@@ -343,6 +345,17 @@ These capability guards apply to **every** entry path — the bare CLI, scripts/
 - **Prompt-injection defense.** Tool output is emitted with `--wrap-untrusted` forced on: externally-controlled fields (email bodies, subjects, sender names, file names…) are wrapped in `‹untrusted›…‹/untrusted›` markers. Instruct your agent to treat marked spans as data, never instructions.
 - **No HTTP transport** is shipped (stdio only) — a deliberate scope choice to avoid running a networked service.
 
+**Hardening agents that drive the CLI directly** (instead of MCP) — the same guards apply to every entry path, so compose them as env vars in a CI job or agent sandbox:
+
+```bash
+# Read-only, injection-wrapped, restricted to a few commands, never blocks on a prompt
+export OLK_NO_WRITE=1 OLK_WRAP_UNTRUSTED=1 OLK_NO_INPUT=1
+export OLK_ENABLE_COMMANDS_EXACT=mail.list,mail.get,mail.search,calendar.events
+olk mail list --json
+```
+
+See [Global Flags](#global-flags) for the full guard list (`--no-write`, `--no-send`, `--no-input`, `--wrap-untrusted`, `--enable-commands[-exact]`, `--disable-commands`), and [AI Agent Integration](#ai-agent-integration) for the skill-based path.
+
 > **Not affiliated with Microsoft.** olk is an independent client for the Microsoft Graph API.
 
 ## Commands Reference
@@ -539,6 +552,8 @@ olk mail list --json --results-only | jq -r '.[] | select(.isRead == false) | "\
 ## AI Agent Integration
 
 `olk` ships with a [`SKILL.md`](SKILL.md) that follows the [Agent Skills](https://agentskills.io) open standard. This lets AI coding assistants discover and use `olk` commands on your behalf — checking mail, scheduling meetings, managing contacts, all from within your AI workflow.
+
+> Two ways to give an agent access: the **skill** below (the agent runs `olk` CLI commands directly), or the **[MCP server](#mcp-server-ai-agents)** (`olk mcp`, a curated read-first tool surface for MCP clients like Claude Desktop). Use the skill for coding-assistant workflows in a terminal; use MCP for tool-calling agents.
 
 ### Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,13 @@ These capability guards apply to **every** entry path — the bare CLI, scripts/
 }
 ```
 
-- **Read-only by default.** Only safe read tools (`mail_list`, `mail_get`, `mail_search`, `calendar_events`, `contacts_search`, `drive_ls`, …) are exposed. Destructive and send commands have **no** MCP exposure path at all.
+- **Read-only by default.** A curated set of 23 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
+  - **Mail:** `mail_list`, `mail_get`, `mail_search`, `mail_folders_list`
+  - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_availability`, `calendar_find_times`
+  - **Contacts:** `contacts_list`, `contacts_get`, `contacts_search`
+  - **OneDrive:** `drive_ls`, `drive_get`, `drive_search`, `drive_recent`, `drive_shared` *(reads only — no upload/download/move/delete/share via MCP)*
+  - **To Do:** `todo_lists_list`, `todo_list`, `todo_get`
+  - **Directory & meta:** `people_search`, `whoami`, `version`
 - **Opt into safe writes per-tool** by naming each one: `olk mcp --allow-write mail_drafts_create` (repeatable, or `OLK_MCP_ALLOW_WRITE=mail_drafts_create,todo_create`). Only the curated, non-send/non-destructive writes — `mail_drafts_create` and `todo_create` — are eligible; nothing is exposed by default. Naming a write is a deliberate action separate from starting the server (defense in depth).
 - **Prompt-injection defense.** Tool output is emitted with `--wrap-untrusted` forced on: externally-controlled fields (email bodies, subjects, sender names, file names…) are wrapped in `‹untrusted›…‹/untrusted›` markers. Instruct your agent to treat marked spans as data, never instructions.
 - **No HTTP transport** is shipped (stdio only) — a deliberate scope choice to avoid running a networked service.
@@ -445,6 +451,28 @@ olk todo links list <TASK_ID> [--list ID]            List linked resources
 olk todo links create <TASK_ID> -n "Name" --url "URL" [--list ID]   Create a linked resource
 olk todo links delete <TASK_ID> <RESOURCE_ID> --force [--list ID]   Delete a linked resource
 ```
+
+### OneDrive
+
+```
+olk drive list                                       List available drives
+olk drive info [--drive-id ID]                       Drive details and quota
+olk drive ls [PATH] [--drive-id ID] [-n 50]          List folder contents
+olk drive get <ID> [--drive-id ID]                   Item details
+olk drive search <QUERY> [--drive-id ID] [-n 25]     Search files
+olk drive recent [--drive-id ID]                     Recently accessed files
+olk drive shared [--drive-id ID]                     Files shared with you
+olk drive download <ID> [--out DIR] [--drive-id ID]  Download a file
+olk drive upload <LOCAL> <REMOTE> [--drive-id ID] [--replace]   Upload a file
+olk drive mkdir <PATH> [--drive-id ID]               Create a folder
+olk drive cp <ID> <DEST> [--name NEW_NAME] [--drive-id ID]      Copy a file or folder
+olk drive mv <ID> <DEST> [--drive-id ID]             Move or rename
+olk drive rm <ID> --force [--drive-id ID]            Delete a file or folder
+olk drive share <ID> [--type view|edit] [--scope anonymous|organization] [--drive-id ID]   Create a sharing link
+olk drive versions <ID> [--drive-id ID]              List version history
+```
+
+If `--drive-id` is omitted, your primary drive is used.
 
 ### Configuration
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -298,6 +298,7 @@ Notes
 - Set `OLK_DRIVE_ID=<drive-id>` to avoid repeating `--drive-id` for drive commands.
 - Set `OLK_KEYRING_PASSWORD=<password>` for headless/non-interactive environments (file-backend keyring).
 - For scripting, prefer `--json --results-only` plus `jq`.
+- Results go to stdout; errors, prompts, and diagnostics go to stderr — piped `--json` stays clean. Set `OLK_NO_INPUT=1` so a command fails instead of blocking on a prompt.
 - IDs are opaque Microsoft Graph strings. Always get them from `list` or `search` first — never guess.
 - Dates are ISO 8601: `2025-06-15` or `2025-06-15T09:00`.
 - Mail search uses KQL, not regex. Operators: `from:`, `to:`, `subject:`, `hasAttachment:`, `received>=`.


### PR DESCRIPTION
Documentation improvements, reviewed against gogcli's docs.

## 1. Fix missing OneDrive coverage (README)
- Commands Reference had no OneDrive subsection (Tasks → Configuration). Added the full `drive` listing.
- MCP tool list was vague (`drive_ls, …`). Replaced with the explicit 23-tool inventory grouped by area; clarified OneDrive is **read-only over MCP**.

## 2. README / SKILL clarity pass (gogcli-inspired)
- **stdout/stderr contract** now stated (results→stdout; errors/prompts→stderr) so piped `--json` stays clean.
- **"Hardening agents that drive the CLI" recipe** (env-var guard combo), mirroring gogcli's "for agents/CI" block.
- **Cross-linked** the MCP-server and SKILL-based agent sections (previously disconnected).

## 3. AGENTS.md refresh
- Fixed **stale test-coverage** claim (now reflects the MCP/guard/untrusted tests added in #34).
- Added a **"Review vs. Land"** PR-workflow subsection (read-only review; branch → PR → CI-green → squash-merge → delete) + a Co-Authored-By attribution rule.

Docs only — no code changes. Verified: anchors resolve, code fences balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)