### PR TITLE
fix(release): strip Gatekeeper quarantine in cask postflight

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,3 +54,14 @@ homebrew_casks:
     homepage: https://github.com/rlrghb/olkcli
     description: CLI for Microsoft Outlook via Microsoft Graph API
     license: MIT
+    # The macOS binary is unsigned, so Homebrew's cask quarantine makes
+    # Gatekeeper SIGKILL it on first run ("killed: 9"). Strip the quarantine
+    # flag on install. This is the goreleaser-documented pattern for unsigned
+    # casks (cf. gibo, GraalVM, Stream CLI). Remove once the build is
+    # Developer ID-signed + notarized.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/olk"]
+          end


### PR DESCRIPTION
## Problem
olk's macOS cask binary is **unsigned**, so Homebrew's cask quarantine makes Gatekeeper **SIGKILL it on first run** (`killed: 9`, exit 137). Every macOS/Apple-Silicon user has hit this since v0.4.x and needs the README `xattr -d com.apple.quarantine` workaround — a silent failure with no error message.

## Fix
Add a `homebrew_casks` **postflight hook** that strips the quarantine flag on install:
```ruby
postflight do
  if OS.mac?
    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/olk"]
  end
end
```
This is **goreleaser's documented pattern for unsigned casks**, used by real projects: **gibo** (2k★, identical goreleaser `hooks` block), **GraalVM** (Oracle), and **Stream CLI**.

## Why this approach (not the alternatives)
- **Stays a cask** → no migration. (Switching to a Homebrew *formula* would fix it too but is **deprecated in goreleaser, removed in v2.16**, and would force every existing cask user to `brew uninstall --cask && brew install`.)
- **Free.** The "proper" fix is Developer ID signing + notarization (~$99/yr Apple Developer Program) — tracked as a follow-up in the code comment; this is the free interim.

## Tradeoff (acknowledged)
Stripping quarantine is a **Gatekeeper bypass** — it removes a supply-chain backstop. Acceptable for a personal tap (Homebrew's *official* repos disallow it; these are all third-party taps). The real fix is signing+notarization later.

## Validation
- `goreleaser check` ✅ (v2.15.2)
- Snapshot build ✅ — rendered `dist/homebrew/Casks/olk.rb` contains the correct postflight block.
- Takes effect on the **next tag (v0.9.1+)**; existing users get the auto-fix on their next `brew upgrade`. No `brew` CI runs on PRs, so this isn't exercised by PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)