### PR TITLE
docs: note macOS Keychain prompt (README, SKILL, AGENTS, CLAUDE)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@
 - Unit tests: stdlib `testing` package. Test files go next to the code they test (`*_test.go`).
 - Existing coverage: `internal/outfmt` (formatting + untrusted-wrapping), `internal/config`, `internal/msauth/scopes`, `internal/graphapi` (validate + capability guards), and `internal/cmd` (paging filters + mailbox-target validation, MCP server/registry, schema generation, argv building, output capture). Coverage is partial — many command and Graph-wrapper paths remain untested.
 - Integration tests require a valid OAuth token + live Graph access — run manually, not in CI.
+- **macOS validation:** each `make build` produces a fresh (ad-hoc) binary identity, so the first run of the new `./bin/olk` that reads stored tokens triggers a macOS Keychain access prompt — a human must click **"Always Allow"**. An automated/agent run can't dismiss the dialog, so a hang on the first post-build command is expected (not a code bug); surface it for manual approval.
 - New tests should run cleanly under `go test -race -count=1 ./...` and pass `golangci-lint run`.
 
 ## CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ make lint           # Lint with golangci-lint
 go mod tidy         # After changing dependencies
 ```
 
+> **Validating on macOS:** running a freshly built `./bin/olk` against a real account triggers a macOS Keychain access prompt (each build is a new identity). A human must click **"Always Allow"** — you (an agent) can't dismiss the dialog, so don't treat a first-run hang as a bug; ask the user to approve it.
+
 ## Architecture
 
 - **CLI framework**: `github.com/alecthomas/kong` — commands are Go structs with `Run(ctx *RunContext) error`

--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ go install github.com/rlrghb/olkcli/cmd/olk@latest
 brew install rlrghb/tap/olk
 ```
 
-On macOS, if you see "olk can't be opened because Apple cannot verify it", run:
+### macOS notes
 
-```bash
-xattr -d com.apple.quarantine $(brew --prefix)/bin/olk
-```
+Two macOS-specific things to know:
+
+- **Gatekeeper quarantine** — as of **v0.9.1** the Homebrew cask clears this on install automatically. On older versions (or a direct download from the [releases page](https://github.com/rlrghb/olkcli/releases)), if olk won't launch ("olk can't be opened because Apple cannot verify it", or a silent `killed: 9`), run:
+  ```bash
+  xattr -d com.apple.quarantine $(brew --prefix)/bin/olk
+  ```
+- **Keychain prompt after upgrades** — your tokens are stored in the macOS Keychain. The first time you run olk after an upgrade, macOS prompts for Keychain access. Click **"Always Allow"** (not "Allow") so it won't ask again until the next upgrade.
 
 ## Quick Start
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -320,5 +320,6 @@ Notes
 - Destructive commands (`delete`) require `--force` or will prompt for confirmation.
 - Confirm before sending mail or creating/deleting events.
 - If a command fails with an auth error, check `olk auth status` first.
+- **macOS keychain prompt (agents):** the first `olk` command **after an upgrade** can trigger a macOS Keychain dialog. It's a macOS prompt, not olk's — `--no-input` does not suppress it, and the command blocks until a **human** clicks **"Always Allow"**. If an `olk` call hangs or fails right after an update on macOS, surface "approve the Keychain prompt (Always Allow)" to the user rather than retrying.
 - Some features are enterprise-only (work/school accounts): out-of-office, inbox rules, find meeting times, and directory search. These require `olk auth login --enterprise`.
 - OneDrive commands require re-login (`olk auth login`) if you authenticated before OneDrive support was added.


### PR DESCRIPTION
On macOS, the first `olk` command **after an upgrade** (and the first run of any **freshly built** `./bin/olk` during local validation) triggers a Keychain access prompt — because each build is a new identity. Document the behavior and the action across all four docs:

- **README** (users) — new "macOS notes" section: click **"Always Allow"** (not "Allow") to stop it until the next upgrade. Also folds in the Gatekeeper-quarantine note and reflects that v0.9.1's cask clears quarantine automatically.
- **SKILL** (agents managing Outlook) — the dialog is macOS's, not olk's; `--no-input` won't suppress it; it blocks until a human clicks Always Allow, so an agent should surface it rather than hang/retry.
- **AGENTS** (contributors) + **CLAUDE** (Claude Code project context) — during local validation, each `make build` is a fresh identity, so the first run of the new binary against a real account prompts for Keychain access; an automated/agent run can't dismiss it, so a first-run hang is expected (not a bug) and needs manual "Always Allow".

Per earlier direction, the notes describe only the supported behavior + handling — no remedy/signing guidance.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)