### PR TITLE
fix(dist): rename npm package olk -> olkcli; idempotent publish

### DIFF
--- a/npm/olk/package.json
+++ b/npm/olk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "olk",
+  "name": "olkcli",
   "version": "0.0.0",
   "mcpName": "io.github.rlrghb/olk",
   "description": "CLI for Microsoft Outlook and OneDrive via the Microsoft Graph API (mail, calendar, contacts, tasks, files) — and an MCP server for AI agents (olk mcp).",

--- a/scripts/build-npm.mjs
+++ b/scripts/build-npm.mjs
@@ -49,8 +49,31 @@ if (!publish) {
   process.exit(0);
 }
 
+function pkgName(pkgDir) {
+  return JSON.parse(readFileSync(path.join(npmDir, pkgDir, "package.json"), "utf8")).name;
+}
+
+// Idempotent: skip a package@version that already exists on npm, so re-running
+// a partially-failed release (e.g. the registry step failed) does not error on
+// "cannot publish over previously published version".
+function alreadyPublished(name) {
+  try {
+    return execFileSync("npm", ["view", `${name}@${version}`, "version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim() === version;
+  } catch {
+    return false;
+  }
+}
+
 function npmPublish(pkgDir) {
-  console.log(`publishing ${pkgDir}@${version} ...`);
+  const name = pkgName(pkgDir);
+  if (alreadyPublished(name)) {
+    console.log(`skip ${name}@${version} (already published)`);
+    return;
+  }
+  console.log(`publishing ${name}@${version} ...`);
   execFileSync("npm", ["publish", "--access", "public"], {
     cwd: path.join(npmDir, pkgDir),
     stdio: "inherit",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "olk",
+      "identifier": "olkcli",
       "version": "0.9.1",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
The v0.9.2 release's `npm-publish` job got the 6 per-platform packages published, but the **main `olk` package was rejected** by npm's name-similarity check:

> `403 - PUT .../olk - Package name too similar to existing packages ol,os,ow,ora,opn,walk,cli,bl,hoek,dlv`

(`olk` was *available* as a name but is blocked at publish time as too-similar to short existing names.)

## Fix
- **Rename the main npm package `olk` → `olkcli`** (matches the repo; `npm i -g olkcli` / `npx olkcli`). **The CLI command stays `olk`** — it's set by the `bin` field, independent of the package name. `server.json` `identifier` → `olkcli`; `mcpName` still equals the server name `io.github.rlrghb/olk`.
- **Idempotent publish** in `scripts/build-npm.mjs`: skip any `package@version` already on npm, so re-running a partially-failed release doesn't error on "cannot republish over existing version" (the 6 platform packages are already live at 0.9.2).

After merge, cut **v0.9.3** to publish `olkcli` + the platform packages and the registry listing. (The orphaned `olk-*@0.9.2` platform packages are harmless; can be unpublished within 72h if desired.)

Docs only-ish (packaging metadata + script); no Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)