### PR TITLE
fix(registry): shorten server.json description to <=100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.rlrghb/olk",
-  "description": "Microsoft Outlook & OneDrive (mail, calendar, contacts, tasks, files) as curated, read-first tools for AI agents. Requires a one-time `olk auth login` first.",
+  "description": "Microsoft Outlook & OneDrive: curated read-first mail, calendar, contacts & file tools for agents",
   "version": "0.9.1",
   "repository": {
     "url": "https://github.com/rlrghb/olkcli",


### PR DESCRIPTION
The v0.9.3 release published the npm packages successfully (`olkcli` is live), but `registry-publish` failed validation: the MCP Registry caps `description` at 100 chars (mine was ~155).

Trim to a 97-char tagline. The `olk auth login` prerequisite stays in the README (the registry entry links to the repo).

After merge, cut **v0.9.4** to complete the registry publish (npm idempotency means platform packages just republish at the new version). The rapid 0.9.2→0.9.4 versions are one-time pipeline bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)