### PR TITLE
feat(registry): rename MCP server to io.github.rlrghb/outlook

### DIFF
--- a/npm/olk/package.json
+++ b/npm/olk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "olkcli",
   "version": "0.0.0",
-  "mcpName": "io.github.rlrghb/olk",
+  "mcpName": "io.github.rlrghb/outlook",
   "description": "CLI for Microsoft Outlook and OneDrive via the Microsoft Graph API (mail, calendar, contacts, tasks, files) — and an MCP server for AI agents (olk mcp).",
   "bin": {
     "olk": "bin/olk.js"

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.rlrghb/olk",
+  "name": "io.github.rlrghb/outlook",
   "description": "Microsoft Outlook & OneDrive: curated read-first mail, calendar, contacts & file tools for agents",
-  "version": "0.9.1",
+  "version": "0.9.5",
   "repository": {
     "url": "https://github.com/rlrghb/olkcli",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "olkcli",
-      "version": "0.9.1",
+      "version": "0.9.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why
The MCP Registry's `search` matches on the server **`name` only** — not the description. Our entry is `io.github.rlrghb/olk`, so searching **"outlook"** returns 0 hits for us (verified against the live registry), even though the description says "Microsoft Outlook & OneDrive…". To be discoverable under "outlook", the name must contain it.

## What changed
- **`server.json`** → `name: io.github.rlrghb/outlook`. Also bumped the stale `version` placeholder `0.9.1` → `0.9.5` (CI `jq`-stamps it from the tag regardless, this just stops it reading as stale).
- **`npm/olk/package.json`** → `mcpName: io.github.rlrghb/outlook`. The registry verifies the published npm package's `mcpName` equals the server name, so `olkcli` must carry the new value.

## Unchanged (brand stays `olk`)
CLI binary `olk`, `brew install rlrghb/tap/olk`, and the npm package name `olkcli` are all untouched — only the registry **discovery name** changes.

## Rollout
1. Merge this.
2. Cut **v0.9.5** → CI republishes `olkcli@0.9.5` (new `mcpName`), then publishes the new `io.github.rlrghb/outlook` registry entry (same GitHub-OIDC auth; `outlook` is in the `io.github.rlrghb/*` namespace).
3. **Delete** the old `io.github.rlrghb/olk` entry via the registry status API (`PATCH /v0.1/servers/{name}/status` → `deleted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)