### PR TITLE
docs(registry): update server.json description

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.rlrghb/outlook",
-  "description": "Microsoft Outlook & OneDrive: curated read-first mail, calendar, contacts & file tools for agents",
+  "description": "Read-first Outlook & OneDrive MCP: personal & enterprise mail, calendar, contacts, tasks, files",
   "version": "0.9.5",
   "repository": {
     "url": "https://github.com/rlrghb/olkcli",


### PR DESCRIPTION
Rewords the MCP Registry description in `server.json`:

> **Read-first Outlook & OneDrive MCP: personal & enterprise mail, calendar, contacts, tasks, files** *(95 chars, under the 100 limit)*

More accurate than the prior copy — **read-first** (not read-only; two safe writes are opt-in), and it surfaces **personal & enterprise** and **tasks**.

The official registry doesn't implement in-place version edits, so this applies whenever the **next release** republishes the registry entry — no separate release is cut just for the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)