### PR TITLE
docs: document the release & distribution pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@
 - The `lint` job runs `golangci-lint` v2.5.0 against `.golangci.yml`.
 - Both jobs use pinned action SHAs to match `release.yml` style.
 
+## Release & Distribution
+
+- A `vX.Y.Z` tag triggers `release.yml`, publishing to three channels: **Homebrew** (goreleaser → `rlrghb/tap` cask, with a quarantine-strip postflight), **npm** (the `olkcli` package + six `olk-<os>-<arch>` per-platform packages under `npm/`; `scripts/build-npm.mjs` stamps + publishes), and the **MCP Registry** (`server.json` → `io.github.rlrghb/outlook`, published via `mcp-publisher`).
+- **No publish secrets:** npm uses **Trusted Publishing (OIDC)** (`id-token: write`, npm ≥ 11.5.1, SLSA provenance); the registry uses GitHub OIDC. The npm package is `olkcli`; the binary is `olk`.
+- The official MCP registry has no in-place edit — `server.json` description/version changes apply on the **next release** (versions are CI-stamped from the tag). `npm-publish`/`registry-publish` are gated on the `PUBLISH_NPM` repo variable.
+
 ## Key Design Decisions
 
 - **Raw OAuth2**: Uses `net/http` directly against Microsoft's OAuth2 endpoints (no MSAL dependency). Refresh tokens stored in OS keyring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,16 @@ Add `untrusted:"true"` to the struct tag of any externally-controlled free-text 
 ### Changing Graph API calls
 Edit files in `internal/graphapi/` — these wrap the verbose SDK calls into simple methods returning plain structs.
 
+## Release & distribution
+
+Pushing a `vX.Y.Z` tag triggers `.github/workflows/release.yml`, which fans out to three channels:
+
+- **Homebrew** — goreleaser builds the binaries and updates the `rlrghb/tap` cask (`homebrew_casks` in `.goreleaser.yaml`); a `hooks.post.install` strips the macOS quarantine xattr so the unsigned binary launches.
+- **npm** — the CLI also ships as an npm package for `npx`/cross-platform installs. `npm/olk/` is the main package **`olkcli`** (an esbuild-style launcher `bin/olk.js` that execs the matching `npm/olk-<os>-<arch>/` per-platform binary via `optionalDependencies`). `scripts/build-npm.mjs` stamps the tag version across all 7 packages and publishes them (idempotent — skips already-published versions). Publishing uses **npm Trusted Publishing (OIDC)** — no stored token: the `npm-publish` job has `id-token: write`, upgrades npm to ≥ 11.5.1, and each package has a trusted publisher configured (this repo + `release.yml`); every package gets a SLSA provenance attestation. The npm package is `olkcli`; the installed binary is `olk`.
+- **MCP Registry** — `server.json` (name `io.github.rlrghb/outlook`, `registryType: npm` → `olkcli`, `packageArguments: [{positional "mcp"}]`) is published by the `registry-publish` job via `mcp-publisher` using GitHub OIDC (no secret). `version` fields are placeholders CI stamps from the tag; the `mcpName` in `npm/olk/package.json` must equal the `server.json` name. The official registry has **no in-place edit**, so `server.json` description/metadata changes only take effect on the **next release**.
+
+Both `npm-publish` and `registry-publish` are gated on the `PUBLISH_NPM` repo variable. There are no long-lived publish secrets — npm and the registry both authenticate via OIDC.
+
 ## Dependencies
 
 The project uses `msgraph-sdk-go` v1.96.0 which has some naming quirks:


### PR DESCRIPTION
`CLAUDE.md` and `AGENTS.md` documented the MCP **server** but not how releases reach users. Adds a **Release & Distribution** section to both.

Covers the `vX.Y.Z` tag → three-channel fan-out:
- **Homebrew** — goreleaser → `rlrghb/tap` cask (+ quarantine-strip postflight)
- **npm** — `olkcli` + six `olk-<os>-<arch>` per-platform packages; published via **OIDC Trusted Publishing** (no token, npm ≥ 11.5.1, SLSA provenance)
- **MCP Registry** — `server.json` → `io.github.rlrghb/outlook` via `mcp-publisher` / GitHub OIDC

Also notes: no long-lived publish secrets, the `olkcli` package vs `olk` binary naming, that `mcpName` must equal the `server.json` name, and that the official registry has no in-place edit (so `server.json` changes apply on the next release).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)