### PR TITLE
feat(mcp): expand read tools + agent ergonomics (errors, output cap, strict args)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,12 +362,12 @@ It's also published to the [MCP Registry](https://registry.modelcontextprotocol.
 
 Either way, run `olk auth login` once first so the server has a token to reuse.
 
-- **Read-only by default.** A curated set of 23 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
-  - **Mail:** `mail_list`, `mail_get`, `mail_search`, `mail_folders_list`
-  - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_availability`, `calendar_find_times`
+- **Read-only by default.** A curated set of 30 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
+  - **Mail:** `mail_list`, `mail_get`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`
+  - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_calendars`, `calendar_availability`, `calendar_find_times`
   - **Contacts:** `contacts_list`, `contacts_get`, `contacts_search`
-  - **OneDrive:** `drive_ls`, `drive_get`, `drive_search`, `drive_recent`, `drive_shared` *(reads only — no upload/download/move/delete/share via MCP)*
-  - **To Do:** `todo_lists_list`, `todo_list`, `todo_get`
+  - **OneDrive:** `drive_ls`, `drive_get`, `drive_info`, `drive_search`, `drive_recent`, `drive_shared`, `drive_versions` *(reads only — no upload/move/delete/share via MCP)*
+  - **To Do:** `todo_lists_list`, `todo_list`, `todo_get`, `todo_checklist_list`, `todo_links_list`
   - **Directory & meta:** `people_search`, `whoami`, `version`
 - **Opt into safe writes per-tool** by naming each one: `olk mcp --allow-write mail_drafts_create` (repeatable, or `OLK_MCP_ALLOW_WRITE=mail_drafts_create,todo_create`). Only the curated, non-send/non-destructive writes — `mail_drafts_create` and `todo_create` — are eligible; nothing is exposed by default. Naming a write is a deliberate action separate from starting the server (defense in depth).
 - **Prompt-injection defense.** Tool output is emitted with `--wrap-untrusted` forced on: externally-controlled fields (email bodies, subjects, sender names, file names…) are wrapped in `[UNTRUSTED:<id>]…[/UNTRUSTED:<id>]` markers, and each response carries a self-describing `untrustedNotice` that tells the agent to treat marked content as data, never instructions. The marker `id` is random per response, so malicious content can't forge a closing marker to escape the wrapper. No out-of-band briefing needed — the directive travels in the data.

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -21,7 +21,8 @@ import (
 // Tool calls are executed in-process and serialized (one at a time), because
 // capturing command output requires temporarily redirecting the process stdout.
 type MCPCmd struct {
-	AllowWrite []string `help:"Expose these curated write tools by name (e.g. mail_drafts_create, todo_create). Repeatable; default exposes none." name:"allow-write" env:"OLK_MCP_ALLOW_WRITE"`
+	AllowWrite     []string `help:"Expose these curated write tools by name (e.g. mail_drafts_create, todo_create). Repeatable; default exposes none." name:"allow-write" env:"OLK_MCP_ALLOW_WRITE"`
+	MaxOutputBytes int      `help:"Cap a single tool call's output text in bytes (truncated past this; 0 uses the built-in default)." name:"max-output-bytes" env:"OLK_MCP_MAX_OUTPUT_BYTES"`
 }
 
 func (c *MCPCmd) Run(ctx *RunContext) error {
@@ -46,8 +47,9 @@ func (c *MCPCmd) Run(ctx *RunContext) error {
 
 	flags := ctx.Flags
 	srv, _, err := buildMCPServer(mcpConfig{
-		allowWrite: allowWrite,
-		allowed:    func(path []string) bool { return commandAllowed(flags, path) },
+		allowWrite:     allowWrite,
+		allowed:        func(path []string) bool { return commandAllowed(flags, path) },
+		maxOutputBytes: c.MaxOutputBytes,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/mcp_invoke.go
+++ b/internal/cmd/mcp_invoke.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/alecthomas/kong"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -23,6 +24,12 @@ func makeHandler(b *toolBinding) mcp.ToolHandler {
 			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
 				return errorResult(fmt.Sprintf("invalid arguments: %v", err)), nil
 			}
+		}
+
+		// Reject arguments the tool doesn't declare (gog's "unknown fields
+		// rejected" contract) so a model can't smuggle in unvetted flags.
+		if err := rejectUnknownArgs(b, args); err != nil {
+			return errorResult(err.Error()), nil
 		}
 
 		argv, err := buildArgv(b, args)
@@ -78,36 +85,103 @@ func makeHandler(b *toolBinding) mcp.ToolHandler {
 		if s := strings.TrimSpace(stderr); s != "" {
 			text = strings.TrimRight(stdout, "\n") + "\n[stderr]\n" + s
 		}
+		text = capText(text, b.maxOutputBytes)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		}, nil
 	}
 }
 
+// rejectUnknownArgs fails the call if args carries a key the tool's schema does
+// not declare, matching gog's fixed-schema contract.
+func rejectUnknownArgs(b *toolBinding, args map[string]any) error {
+	if len(args) == 0 {
+		return nil
+	}
+	known := map[string]bool{}
+	for _, f := range b.node.Flags {
+		if f.Hidden || f.Name == helpFlagName {
+			continue
+		}
+		known[f.Name] = true
+	}
+	for _, p := range b.node.Positional {
+		known[p.Name] = true
+	}
+	for k := range args {
+		if !known[k] {
+			return fmt.Errorf("unknown argument %q for tool %q", k, b.name)
+		}
+	}
+	return nil
+}
+
+// capText truncates s to at most limit bytes (on a UTF-8 boundary), appending a
+// notice so the agent knows output was clipped rather than silently complete.
+func capText(s string, limit int) string {
+	if limit <= 0 {
+		limit = defaultMaxOutputBytes
+	}
+	if len(s) <= limit {
+		return s
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + fmt.Sprintf("\n[output truncated at %d bytes; refine the query or raise --max-output-bytes]", limit)
+}
+
+// errorResult builds an IsError tool result as a {code, message, action} JSON
+// envelope (outlook-mcp's structured-error shape) so an agent gets a machine
+// classification plus an actionable next step, not just a raw Graph error.
 func errorResult(msg string) *mcp.CallToolResult {
-	if h := hintFor(msg); h != "" {
-		msg = msg + "\nhint: " + h
+	code, action := classifyError(msg)
+	env := map[string]string{"code": code, "message": msg}
+	if action != "" {
+		env["action"] = action
+	}
+	body, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		body = []byte(msg)
 	}
 	return &mcp.CallToolResult{
 		IsError: true,
-		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+		Content: []mcp.Content{&mcp.TextContent{Text: string(body)}},
 	}
 }
 
-// hintFor returns a short recovery action for common failure modes, so an agent
-// gets an actionable next step rather than a bare Graph error (a lightweight
-// take on outlook-mcp's {code,message,action} envelopes).
-func hintFor(msg string) string {
+// classifyError maps a free-text error into a stable code and a recovery action.
+// Codes mirror common Graph failure modes (auth/scope/not-found/throttling) so
+// agents can branch on `code` instead of pattern-matching prose.
+func classifyError(msg string) (code, action string) {
 	switch {
-	case strings.Contains(msg, "no account configured"):
-		return "run `olk auth login` first"
+	case strings.Contains(msg, "no account configured"),
+		strings.Contains(msg, "no account"),
+		strings.Contains(msg, "InvalidAuthenticationToken"),
+		strings.Contains(msg, "401"):
+		return "unauthenticated", "run `olk auth login` first (or re-run it if the token expired)"
 	case strings.Contains(msg, "Read.Shared"),
 		strings.Contains(msg, "InsufficientScope"),
 		strings.Contains(msg, "ErrorAccessDenied"),
-		strings.Contains(msg, "Forbidden"):
-		return "the signed-in token may lack a required scope; re-run `olk auth login --scope <Scope>`"
+		strings.Contains(msg, "Forbidden"),
+		strings.Contains(msg, "403"):
+		return "forbidden", "the signed-in token may lack a required scope; re-run `olk auth login --scope <Scope>` (add --enterprise for work/school-only scopes)"
+	case strings.Contains(msg, "ErrorItemNotFound"),
+		strings.Contains(msg, "ResourceNotFound"),
+		strings.Contains(msg, "404"):
+		return "not_found", "the id may be stale; re-list to get a current id"
+	case strings.Contains(msg, "TooManyRequests"),
+		strings.Contains(msg, "throttl"),
+		strings.Contains(msg, "429"):
+		return "rate_limited", "back off and retry after a short delay"
+	case strings.Contains(msg, "unknown argument"),
+		strings.Contains(msg, "invalid arguments"),
+		strings.Contains(msg, "parse error"),
+		strings.Contains(msg, "missing required argument"):
+		return "invalid_input", "check the tool's input schema and retry with valid arguments"
 	}
-	return ""
+	return "error", ""
 }
 
 // buildArgv reconstructs a CLI argv from a tool's arguments. Ordering is
@@ -117,7 +191,7 @@ func buildArgv(b *toolBinding, args map[string]any) ([]string, error) {
 	argv := append([]string{}, b.path...)
 
 	for _, f := range b.node.Flags {
-		if f.Hidden || f.Name == "help" {
+		if f.Hidden || f.Name == helpFlagName {
 			continue
 		}
 		v, ok := args[f.Name]

--- a/internal/cmd/mcp_invoke_test.go
+++ b/internal/cmd/mcp_invoke_test.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
 
 func TestBuildArgv_AlwaysAppendsJSON(t *testing.T) {
 	b := testBinding(t, "mail", "list")
@@ -128,4 +134,72 @@ func indexOf(ss []string, s string) int {
 		}
 	}
 	return -1
+}
+
+func TestRejectUnknownArgs(t *testing.T) {
+	b := testBinding(t, "mail", "list")
+	// A declared flag is accepted.
+	if err := rejectUnknownArgs(b, map[string]any{"top": float64(5)}); err != nil {
+		t.Errorf("declared flag rejected: %v", err)
+	}
+	// An undeclared key is rejected (gog fixed-schema contract).
+	if err := rejectUnknownArgs(b, map[string]any{"bogus": "x"}); err == nil {
+		t.Error("expected error for unknown argument, got nil")
+	}
+	// A declared positional is accepted.
+	get := testBinding(t, "mail", "get")
+	if err := rejectUnknownArgs(get, map[string]any{"id": "AAA"}); err != nil {
+		t.Errorf("declared positional rejected: %v", err)
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	cases := []struct {
+		msg      string
+		wantCode string
+	}{
+		{"no account configured", "unauthenticated"},
+		{"error: InsufficientScope: Read.Shared required", "forbidden"},
+		{"ErrorItemNotFound", "not_found"},
+		{"TooManyRequests", "rate_limited"},
+		{"unknown argument \"x\"", "invalid_input"},
+		{"some other failure", "error"},
+	}
+	for _, tc := range cases {
+		if code, _ := classifyError(tc.msg); code != tc.wantCode {
+			t.Errorf("classifyError(%q) code = %q, want %q", tc.msg, code, tc.wantCode)
+		}
+	}
+}
+
+func TestErrorResult_StructuredEnvelope(t *testing.T) {
+	res := errorResult("no account configured")
+	if !res.IsError {
+		t.Fatal("expected IsError")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	var env map[string]string
+	if err := json.Unmarshal([]byte(tc.Text), &env); err != nil {
+		t.Fatalf("error body is not JSON: %v\n%s", err, tc.Text)
+	}
+	if env["code"] != "unauthenticated" {
+		t.Errorf("code = %q, want unauthenticated", env["code"])
+	}
+	if env["action"] == "" {
+		t.Error("expected a non-empty action")
+	}
+}
+
+func TestCapText(t *testing.T) {
+	if got := capText("short", 100); got != "short" {
+		t.Errorf("under-cap text mutated: %q", got)
+	}
+	long := strings.Repeat("a", 500)
+	got := capText(long, 100)
+	if len(got) <= 100 || !strings.Contains(got, "truncated") {
+		t.Errorf("expected truncation notice; len=%d", len(got))
+	}
 }

--- a/internal/cmd/mcp_server.go
+++ b/internal/cmd/mcp_server.go
@@ -29,10 +29,15 @@ var curatedTools = []curatedTool{
 	{"mail_get", []string{"mail", "get"}, false},
 	{"mail_search", []string{"mail", "search"}, false},
 	{"mail_folders_list", []string{"mail", "folders", "list"}, false},
+	{"mail_attachments", []string{"mail", "attachments"}, false},
+	{"mail_categories_list", []string{"mail", "categories", "list"}, false},
+	{"mail_rules_list", []string{"mail", "rules", "list"}, false},
+	{"mail_ooo_get", []string{"mail", "ooo", "get"}, false},
 	// Calendar (read)
 	{"calendar_events", []string{"calendar", "events"}, false},
 	{"calendar_view", []string{"calendar", "view"}, false},
 	{"calendar_get", []string{"calendar", "get"}, false},
+	{"calendar_calendars", []string{"calendar", "calendars"}, false},
 	{"calendar_availability", []string{"calendar", "availability"}, false},
 	{"calendar_find_times", []string{"calendar", "find-times"}, false},
 	// Contacts (read)
@@ -42,13 +47,17 @@ var curatedTools = []curatedTool{
 	// Drive (read)
 	{"drive_ls", []string{"drive", "ls"}, false},
 	{"drive_get", []string{"drive", "get"}, false},
+	{"drive_info", []string{"drive", "info"}, false},
 	{"drive_search", []string{"drive", "search"}, false},
 	{"drive_recent", []string{"drive", "recent"}, false},
 	{"drive_shared", []string{"drive", "shared"}, false},
+	{"drive_versions", []string{"drive", "versions"}, false},
 	// To Do (read)
 	{"todo_lists_list", []string{"todo", "lists", "list"}, false},
 	{"todo_list", []string{"todo", "list"}, false},
 	{"todo_get", []string{"todo", "get"}, false},
+	{"todo_checklist_list", []string{"todo", "checklist", "list"}, false},
+	{"todo_links_list", []string{"todo", "links", "list"}, false},
 	// Directory + meta (read)
 	{"people_search", []string{"people", "search"}, false},
 	{"whoami", []string{"whoami"}, false},
@@ -60,9 +69,19 @@ var curatedTools = []curatedTool{
 
 // mcpConfig controls which curated tools a server exposes.
 type mcpConfig struct {
-	allowWrite map[string]bool          // set of curated write tool names to expose (nil/empty = none)
-	allowed    func(path []string) bool // nil = allow all; else command allow/deny lists
+	allowWrite     map[string]bool          // set of curated write tool names to expose (nil/empty = none)
+	allowed        func(path []string) bool // nil = allow all; else command allow/deny lists
+	maxOutputBytes int                      // cap on a single tool call's output text (<=0 = defaultMaxOutputBytes)
 }
+
+// defaultMaxOutputBytes bounds a single tool call's returned text so a runaway
+// list can't flood the agent's context or the stdio transport (gog's
+// --max-output-bytes default).
+const defaultMaxOutputBytes = 100_000
+
+// helpFlagName is kong's auto-injected --help flag, skipped when projecting a
+// command's flags into an MCP schema or argv.
+const helpFlagName = "help"
 
 // writeToolNames returns the set of curated write tool names (the only tools
 // eligible to be exposed via --allow-write).
@@ -87,10 +106,11 @@ func sortedKeys(m map[string]bool) []string {
 
 // toolBinding ties a generated MCP tool name back to the kong command it runs.
 type toolBinding struct {
-	name     string
-	path     []string
-	node     *kong.Node
-	readOnly bool
+	name           string
+	path           []string
+	node           *kong.Node
+	readOnly       bool
+	maxOutputBytes int
 }
 
 // newKongParser builds a kong parser over the full CLI grammar, mirroring the
@@ -117,6 +137,11 @@ func buildMCPServer(cfg mcpConfig) (*mcp.Server, []*toolBinding, error) {
 
 	srv := mcp.NewServer(&mcp.Implementation{Name: "olk", Version: Version}, nil)
 
+	maxOut := cfg.maxOutputBytes
+	if maxOut <= 0 {
+		maxOut = defaultMaxOutputBytes
+	}
+
 	bindings := make([]*toolBinding, 0, len(curatedTools))
 	for _, ct := range curatedTools {
 		if ct.write && !cfg.allowWrite[ct.name] {
@@ -129,7 +154,7 @@ func buildMCPServer(cfg mcpConfig) (*mcp.Server, []*toolBinding, error) {
 		if !ok {
 			return nil, nil, fmt.Errorf("curated MCP tool %q maps to unknown command %q", ct.name, strings.Join(ct.path, " "))
 		}
-		b := &toolBinding{name: ct.name, path: ct.path, node: node, readOnly: !ct.write}
+		b := &toolBinding{name: ct.name, path: ct.path, node: node, readOnly: !ct.write, maxOutputBytes: maxOut}
 		registerTool(srv, b)
 		bindings = append(bindings, b)
 	}
@@ -189,7 +214,7 @@ func flagSchema(node *kong.Node) *jsonschema.Schema {
 	var required []string
 
 	for _, f := range node.Flags {
-		if f.Hidden || f.Name == "help" {
+		if f.Hidden || f.Name == helpFlagName {
 			continue
 		}
 		s.Properties[f.Name] = valueSchema(f.Value)


### PR DESCRIPTION
## Context

Roadmap to make olk's MCP server **meet and exceed** outlook-mcp while staying true to its gog lineage (full teardown + phased plan lives in the planning notes). This PR lands **Phase 0** and the first 3 items of **Phase 1**.

## Phase 0 — read-tool exposure
Adds 7 existing read commands to the curated MCP registry (23 → **30 read tools**), registry-only (commands/graphapi already existed):
`mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`, `calendar_calendars`, `drive_info`, `drive_versions`, `todo_checklist_list`, `todo_links_list`. README inventory updated.

## Phase 1 — agent ergonomics (3 of 5)
- **Structured errors** — tool failures now return a `{code, message, action}` JSON envelope. `classifyError` maps auth / scope / not-found / throttle / invalid-input to stable codes plus a recovery action (outlook-mcp's structured-error shape).
- **Output cap** — `--max-output-bytes` (`OLK_MCP_MAX_OUTPUT_BYTES`, default 100KB) truncates runaway output on a UTF-8 boundary with a notice (gog `--max-output-bytes` parity).
- **Strict args** — `rejectUnknownArgs` enforces gog's fixed-schema contract; any argument a tool doesn't declare is rejected.

Deferred to follow-ups: `--concise` mode, `--allow-tool` wildcard/category DSL (rest of Phase 1), then delta sync, batch/threading, and the write/send tiers (Phases 2–6).

## Tests & validation
New tests for unknown-arg rejection, `classifyError` mapping, the structured envelope, and `capText` truncation. `go build`, `go vet`, full `go test ./...`, and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)