### PR TITLE
feat(mcp): Phase 2 — delta sync (mail/calendar/contacts + changes digest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,13 +362,14 @@ It's also published to the [MCP Registry](https://registry.modelcontextprotocol.
 
 Either way, run `olk auth login` once first so the server has a token to reuse.
 
-- **Read-only by default.** A curated set of 32 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
-  - **Mail:** `mail_list`, `mail_get`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`
-  - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_calendars`, `calendar_availability`, `calendar_find_times`
-  - **Contacts:** `contacts_list`, `contacts_get`, `contacts_search`
+- **Read-only by default.** A curated set of 36 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
+  - **Mail:** `mail_list`, `mail_get`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`, `mail_delta`
+  - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_calendars`, `calendar_availability`, `calendar_find_times`, `calendar_delta`
+  - **Contacts:** `contacts_list`, `contacts_get`, `contacts_search`, `contacts_delta`
   - **OneDrive:** `drive_ls`, `drive_get`, `drive_info`, `drive_search`, `drive_recent`, `drive_shared`, `drive_versions` *(reads only — no upload/move/delete/share via MCP)*
   - **To Do:** `todo_lists_list`, `todo_list`, `todo_get`, `todo_checklist_list`, `todo_links_list`
-  - **Directory & meta:** `people_search`, `whoami`, `version`
+  - **Directory & meta:** `people_search`, `changes`, `whoami`, `version`
+- **Incremental sync (delta).** `mail_delta`, `calendar_delta`, and `contacts_delta` return only what changed since an opaque cursor token (the unified `changes` tool digests all three in one call, each with its own token). Pass an empty token for a fresh sync, then hand the returned token back next time; deletions come through as items with `"removed": true`. Tokens are validated to be Microsoft Graph URLs before reuse, so a model can't redirect an authenticated request elsewhere.
 - **Opt into safe writes per-tool** by naming each one: `olk mcp --allow-write mail_drafts_create` (repeatable, or `OLK_MCP_ALLOW_WRITE=mail_drafts_create,todo_create`). Only the curated, non-send/non-destructive writes — `mail_drafts_create` and `todo_create` — are eligible; nothing is exposed by default. Naming a write is a deliberate action separate from starting the server (defense in depth).
 - **Narrow the exposed set with `--allow-tool`** (`OLK_MCP_ALLOW_TOOL`, repeatable/csv). Selectors are an exact name (`mail_list`), a prefix glob (`mail_*`, or `mail.*`), or a category (`read`, `write`, `all`). E.g. `olk mcp --allow-tool 'mail.*' --allow-tool calendar_events` exposes only the mail tools plus that one calendar tool. This narrows tools by name; it never grants a write that `--allow-write` hasn't already enabled.
 - **Shrink responses with `concise`.** Every read tool accepts a `concise` boolean (maps to the global `--concise` / `OLK_CONCISE`) that drops large free-text — message/event/task bodies, previews, attendee lists — to cut token usage when an agent only needs headers/metadata.

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -10,6 +10,7 @@ import (
 
 type CalendarCmd struct {
 	Events       CalendarEventsCmd       `cmd:"" help:"List calendar events"`
+	Delta        CalendarDeltaCmd        `cmd:"" help:"Incremental sync of calendar events (delta)"`
 	Get          CalendarGetCmd          `cmd:"" help:"Get event details"`
 	Create       CalendarCreateCmd       `cmd:"" help:"Create a calendar event"`
 	Update       CalendarUpdateCmd       `cmd:"" help:"Update a calendar event"`

--- a/internal/cmd/calendar_delta.go
+++ b/internal/cmd/calendar_delta.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// CalendarDeltaCmd performs an incremental sync of calendar events via Graph's
+// calendarView delta endpoint. The window (--days/--after/--before) applies to
+// the initial sync only; on resume the token already encodes it.
+type CalendarDeltaCmd struct {
+	Days   int    `help:"Window size in days ahead for the initial sync" default:"30" short:"d"`
+	After  string `help:"Window start (ISO 8601); overrides --days start"`
+	Before string `help:"Window end (ISO 8601); overrides --days end"`
+	Token  string `help:"Delta token from a previous call (omit to start a fresh sync)"`
+	Top    int32  `help:"Max items per page" short:"n"`
+}
+
+func (c *CalendarDeltaCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	days := c.Days
+	if days <= 0 {
+		days = 30
+	}
+	start := time.Now()
+	end := start.AddDate(0, 0, days)
+	if c.After != "" {
+		if start, err = parseTime(c.After); err != nil {
+			return fmt.Errorf("invalid --after: %w", err)
+		}
+	}
+	if c.Before != "" {
+		if end, err = parseTime(c.Before); err != nil {
+			return fmt.Errorf("invalid --before: %w", err)
+		}
+	}
+
+	items, page, err := client.DeltaCalendarView(ctx.Ctx, target, c.Token, start, end, c.Top)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	loc, _ := ctx.Timezone()
+	headers := []string{"ID", "CHANGE", "SUBJECT", "START", "END", "LOCATION"}
+	rows := make([][]string, 0, len(items))
+	for i := range items {
+		e := &items[i]
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(e.ID), 15),
+			changeLabel(e.Removed),
+			outfmt.Truncate(outfmt.Sanitize(e.Subject), 40),
+			outfmt.Truncate(outfmt.Sanitize(outfmt.ConvertTime(e.Start, loc)), 16),
+			outfmt.Truncate(outfmt.Sanitize(outfmt.ConvertTime(e.End, loc)), 16),
+			outfmt.Truncate(outfmt.Sanitize(e.Location), 20),
+		})
+	}
+	return printer.PrintDelta(headers, rows, items, len(items), page.Token, page.Complete)
+}

--- a/internal/cmd/changes.go
+++ b/internal/cmd/changes.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// resourceChanges is one resource's slice of a unified changes digest: the
+// changed items plus that resource's own independent continuation token.
+type resourceChanges[T any] struct {
+	Items      []T    `json:"items"`
+	DeltaToken string `json:"deltaToken,omitempty"`
+	Complete   bool   `json:"complete"`
+}
+
+// changesDigest is the cross-resource delta snapshot (outlook-mcp's
+// changes_since): mail, calendar, and contacts each with an independent token.
+type changesDigest struct {
+	Mail     resourceChanges[graphapi.MailDelta]     `json:"mail"`
+	Calendar resourceChanges[graphapi.CalendarDelta] `json:"calendar"`
+	Contacts resourceChanges[graphapi.ContactDelta]  `json:"contacts"`
+}
+
+// ChangesCmd returns a unified digest of mail, calendar, and contacts changes in
+// one call, each with its own delta token. Omit a token for that resource's
+// initial sync; pass it back next time to get only what changed.
+type ChangesCmd struct {
+	MailToken     string `help:"Delta token for mail (omit for a fresh sync)" name:"mail-token"`
+	CalendarToken string `help:"Delta token for calendar (omit for a fresh sync)" name:"calendar-token"`
+	ContactsToken string `help:"Delta token for contacts (omit for a fresh sync)" name:"contacts-token"`
+	Days          int    `help:"Calendar window in days ahead for the initial sync" default:"30"`
+	Top           int32  `help:"Max items per resource page" short:"n"`
+}
+
+func (c *ChangesCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	var digest changesDigest
+
+	mail, mp, err := client.DeltaMessages(ctx.Ctx, target, "inbox", c.MailToken, c.Top)
+	if err != nil {
+		return fmt.Errorf("mail delta: %w", err)
+	}
+	digest.Mail = resourceChanges[graphapi.MailDelta]{Items: mail, DeltaToken: mp.Token, Complete: mp.Complete}
+
+	days := c.Days
+	if days <= 0 {
+		days = 30
+	}
+	start := time.Now()
+	events, cp, err := client.DeltaCalendarView(ctx.Ctx, target, c.CalendarToken, start, start.AddDate(0, 0, days), c.Top)
+	if err != nil {
+		return fmt.Errorf("calendar delta: %w", err)
+	}
+	digest.Calendar = resourceChanges[graphapi.CalendarDelta]{Items: events, DeltaToken: cp.Token, Complete: cp.Complete}
+
+	contacts, kp, err := client.DeltaContacts(ctx.Ctx, target, c.ContactsToken, c.Top)
+	if err != nil {
+		return fmt.Errorf("contacts delta: %w", err)
+	}
+	digest.Contacts = resourceChanges[graphapi.ContactDelta]{Items: contacts, DeltaToken: kp.Token, Complete: kp.Complete}
+
+	total := len(mail) + len(events) + len(contacts)
+	printer := ctx.Printer()
+	if ctx.Flags.JSON {
+		return printer.PrintJSON(digest, total, "")
+	}
+
+	// Human/table view: a compact (id, change, summary) section per resource,
+	// each followed by its token line.
+	loc, _ := ctx.Timezone()
+	mailRows := make([][]string, 0, len(mail))
+	for i := range mail {
+		m := &mail[i]
+		mailRows = append(mailRows, []string{outfmt.Truncate(outfmt.Sanitize(m.ID), 15), changeLabel(m.Removed), outfmt.Truncate(outfmt.Sanitize(m.Subject), 50)})
+	}
+	if err := printChangesSection(printer, "MAIL", mailRows, mp); err != nil {
+		return err
+	}
+	evRows := make([][]string, 0, len(events))
+	for i := range events {
+		e := &events[i]
+		summary := outfmt.Sanitize(e.Subject) + " @ " + outfmt.Sanitize(outfmt.ConvertTime(e.Start, loc))
+		evRows = append(evRows, []string{outfmt.Truncate(outfmt.Sanitize(e.ID), 15), changeLabel(e.Removed), outfmt.Truncate(summary, 50)})
+	}
+	if err := printChangesSection(printer, "CALENDAR", evRows, cp); err != nil {
+		return err
+	}
+	ctRows := make([][]string, 0, len(contacts))
+	for i := range contacts {
+		ct := &contacts[i]
+		summary := outfmt.Sanitize(ct.DisplayName) + " " + outfmt.Sanitize(strings.Join(ct.Emails, ", "))
+		ctRows = append(ctRows, []string{outfmt.Truncate(outfmt.Sanitize(ct.ID), 15), changeLabel(ct.Removed), outfmt.Truncate(summary, 50)})
+	}
+	return printChangesSection(printer, "CONTACTS", ctRows, kp)
+}
+
+// printChangesSection renders one resource's table plus its token line.
+func printChangesSection(printer *outfmt.Printer, title string, rows [][]string, page graphapi.DeltaPage) error {
+	fmt.Printf("== %s (%d) ==\n", title, len(rows))
+	if err := printer.Print([]string{"ID", "CHANGE", "SUMMARY"}, rows, nil, len(rows), ""); err != nil {
+		return err
+	}
+	fmt.Printf("token: %s  complete: %v\n\n", page.Token, page.Complete)
+	return nil
+}

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -45,6 +45,7 @@ func bestPhone(ct *graphapi.Contact) string {
 
 type ContactsCmd struct {
 	List   ContactsListCmd   `cmd:"" help:"List contacts"`
+	Delta  ContactsDeltaCmd  `cmd:"" help:"Incremental sync of contacts (delta)"`
 	Get    ContactsGetCmd    `cmd:"" help:"Get contact details"`
 	Create ContactsCreateCmd `cmd:"" help:"Create a contact"`
 	Update ContactsUpdateCmd `cmd:"" help:"Update a contact"`

--- a/internal/cmd/contacts_delta.go
+++ b/internal/cmd/contacts_delta.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/rlrghb/olkcli/internal/outfmt"
+)
+
+// ContactsDeltaCmd performs an incremental sync of contacts via Graph's delta
+// endpoint. Omit --token for a fresh sync; pass the returned token next time.
+type ContactsDeltaCmd struct {
+	Token string `help:"Delta token from a previous call (omit to start a fresh sync)"`
+	Top   int32  `help:"Max items per page" short:"n"`
+}
+
+func (c *ContactsDeltaCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	items, page, err := client.DeltaContacts(ctx.Ctx, target, c.Token, c.Top)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	headers := []string{"ID", "CHANGE", "NAME", "EMAILS"}
+	rows := make([][]string, 0, len(items))
+	for i := range items {
+		ct := &items[i]
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(ct.ID), 15),
+			changeLabel(ct.Removed),
+			outfmt.Truncate(outfmt.Sanitize(ct.DisplayName), 30),
+			outfmt.Truncate(outfmt.Sanitize(strings.Join(ct.Emails, ", ")), 40),
+		})
+	}
+	return printer.PrintDelta(headers, rows, items, len(items), page.Token, page.Complete)
+}

--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -2,6 +2,7 @@ package cmd
 
 type MailCmd struct {
 	List        MailListCmd        `cmd:"" help:"List messages in inbox"`
+	Delta       MailDeltaCmd       `cmd:"" help:"Incremental sync of a mail folder (delta)"`
 	Get         MailGetCmd         `cmd:"" help:"Get a message"`
 	Send        MailSendCmd        `cmd:"" help:"Send a message"`
 	Search      MailSearchCmd      `cmd:"" help:"Search messages"`

--- a/internal/cmd/mail_delta.go
+++ b/internal/cmd/mail_delta.go
@@ -1,0 +1,52 @@
+package cmd
+
+import "github.com/rlrghb/olkcli/internal/outfmt"
+
+// MailDeltaCmd performs an incremental sync of a mail folder via Graph's delta
+// endpoint. Omit --token for a fresh sync; pass the returned token next time to
+// get only what changed since.
+type MailDeltaCmd struct {
+	Folder string `help:"Mail folder ID or well-known name" short:"f" default:"inbox"`
+	Token  string `help:"Delta token from a previous call (omit to start a fresh sync)"`
+	Top    int32  `help:"Max items per page" short:"n"`
+}
+
+func (c *MailDeltaCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	items, page, err := client.DeltaMessages(ctx.Ctx, target, c.Folder, c.Token, c.Top)
+	if err != nil {
+		return err
+	}
+
+	printer := ctx.Printer()
+	loc, _ := ctx.Timezone()
+	headers := []string{"ID", "CHANGE", "FROM", "SUBJECT", "DATE"}
+	rows := make([][]string, 0, len(items))
+	for i := range items {
+		m := &items[i]
+		rows = append(rows, []string{
+			outfmt.Truncate(outfmt.Sanitize(m.ID), 15),
+			changeLabel(m.Removed),
+			outfmt.Truncate(outfmt.Sanitize(m.From), 25),
+			outfmt.Truncate(outfmt.Sanitize(m.Subject), 40),
+			outfmt.Truncate(outfmt.Sanitize(outfmt.ConvertTime(m.ReceivedAt, loc)), 16),
+		})
+	}
+	return printer.PrintDelta(headers, rows, items, len(items), page.Token, page.Complete)
+}
+
+// changeLabel renders a delta item's change kind for table output.
+func changeLabel(removed bool) string {
+	if removed {
+		return "removed"
+	}
+	return "upsert"
+}

--- a/internal/cmd/mcp_server.go
+++ b/internal/cmd/mcp_server.go
@@ -33,6 +33,7 @@ var curatedTools = []curatedTool{
 	{"mail_categories_list", []string{"mail", "categories", "list"}, false},
 	{"mail_rules_list", []string{"mail", "rules", "list"}, false},
 	{"mail_ooo_get", []string{"mail", "ooo", "get"}, false},
+	{"mail_delta", []string{"mail", "delta"}, false},
 	// Calendar (read)
 	{"calendar_events", []string{"calendar", "events"}, false},
 	{"calendar_view", []string{"calendar", "view"}, false},
@@ -40,10 +41,12 @@ var curatedTools = []curatedTool{
 	{"calendar_calendars", []string{"calendar", "calendars"}, false},
 	{"calendar_availability", []string{"calendar", "availability"}, false},
 	{"calendar_find_times", []string{"calendar", "find-times"}, false},
+	{"calendar_delta", []string{"calendar", "delta"}, false},
 	// Contacts (read)
 	{"contacts_list", []string{"contacts", "list"}, false},
 	{"contacts_get", []string{"contacts", "get"}, false},
 	{"contacts_search", []string{"contacts", "search"}, false},
+	{"contacts_delta", []string{"contacts", "delta"}, false},
 	// Drive (read)
 	{"drive_ls", []string{"drive", "ls"}, false},
 	{"drive_get", []string{"drive", "get"}, false},
@@ -60,6 +63,7 @@ var curatedTools = []curatedTool{
 	{"todo_links_list", []string{"todo", "links", "list"}, false},
 	// Directory + meta (read)
 	{"people_search", []string{"people", "search"}, false},
+	{"changes", []string{"changes"}, false},
 	{"whoami", []string{"whoami"}, false},
 	{"version", []string{"version"}, false},
 	// Safe writes (opt-in: --allow-write, non-send and non-destructive)

--- a/internal/cmd/mcp_server_test.go
+++ b/internal/cmd/mcp_server_test.go
@@ -211,7 +211,7 @@ func TestToolSchema_ConciseInjectedForReadOnly(t *testing.T) {
 // "N read tools" figure in README.md can't silently drift. If you add or remove
 // a read tool, update both this number and the README.
 func TestCuratedReadToolCount(t *testing.T) {
-	const documentedReadTools = 32
+	const documentedReadTools = 36
 	if got := len(buildBindings(t)); got != documentedReadTools {
 		t.Errorf("default read-only registry has %d tools; expected %d — update README.md and this constant in lockstep", got, documentedReadTools)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -191,6 +191,7 @@ type CLI struct {
 	MCP      MCPCmd      `cmd:"" name:"mcp" help:"Run an MCP server exposing olk as tools (stdio)"`
 	Version  VersionCmd  `cmd:"" help:"Show version information"`
 	Whoami   WhoamiCmd   `cmd:"" help:"Show current user profile"`
+	Changes  ChangesCmd  `cmd:"" help:"Unified delta digest across mail, calendar, and contacts"`
 
 	// Desire path shortcuts
 	Send   SendCmd   `cmd:"" help:"Send an email (shortcut for mail send)" hidden:""`

--- a/internal/graphapi/delta.go
+++ b/internal/graphapi/delta.go
@@ -1,0 +1,192 @@
+package graphapi
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	abs "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
+)
+
+// maxPageSizeHeaders expresses a delta page-size preference. The /delta
+// endpoints reject the $top query option (page size can't be guaranteed across
+// change tracking), so the size is requested via the Prefer header instead.
+func maxPageSizeHeaders(top int32) *abs.RequestHeaders {
+	if top <= 0 {
+		return nil
+	}
+	h := abs.NewRequestHeaders()
+	h.Add("Prefer", fmt.Sprintf("odata.maxpagesize=%d", top))
+	return h
+}
+
+// Delta sync wraps Microsoft Graph's /delta endpoints for mail, calendar, and
+// contacts. Each call returns the changes since a prior opaque token plus a new
+// token to use next time — stateless, agent-driven, no server state (mirroring
+// outlook-mcp's cursor model). One call returns one page: when Complete is
+// false a nextLink token is returned (more changes available right now); when
+// Complete is true the token is a deltaLink (caught up — store it for the next
+// sync). An item with Removed=true is a deletion (only its ID is populated).
+
+// DeltaPage is the continuation cursor returned by a delta call.
+type DeltaPage struct {
+	Token    string `json:"deltaToken,omitempty"` // opaque cursor; pass back to fetch the next page/changes
+	Complete bool   `json:"complete"`             // true when caught up (token is a deltaLink); false = more pages now
+}
+
+// MailDelta is a changed message; Removed marks a deletion.
+type MailDelta struct {
+	MailMessage
+	Removed bool `json:"removed,omitempty"`
+}
+
+// CalendarDelta is a changed event; Removed marks a deletion.
+type CalendarDelta struct {
+	CalendarEvent
+	Removed bool `json:"removed,omitempty"`
+}
+
+// ContactDelta is a changed contact; Removed marks a deletion.
+type ContactDelta struct {
+	Contact
+	Removed bool `json:"removed,omitempty"`
+}
+
+// deltaLinker is satisfied by every delta GET response (via the SDK's
+// BaseDeltaFunctionResponse) and exposes the continuation links.
+type deltaLinker interface {
+	GetOdataDeltaLink() *string
+	GetOdataNextLink() *string
+}
+
+// deltaPageFrom picks the continuation token: a deltaLink means caught up, a
+// nextLink means more pages remain now.
+func deltaPageFrom(r deltaLinker) DeltaPage {
+	if dl := r.GetOdataDeltaLink(); dl != nil && *dl != "" {
+		return DeltaPage{Token: *dl, Complete: true}
+	}
+	if nl := r.GetOdataNextLink(); nl != nil && *nl != "" {
+		return DeltaPage{Token: *nl, Complete: false}
+	}
+	return DeltaPage{Complete: true}
+}
+
+// graphAPIHosts are the Microsoft Graph endpoints a delta continuation token may
+// target. A token is a full Graph URL replayed with the authenticated adapter,
+// so it must be validated before use to avoid sending the bearer token to an
+// attacker-supplied host (SSRF / token exfiltration).
+var graphAPIHosts = map[string]bool{
+	"graph.microsoft.com":             true,
+	"graph.microsoft.us":              true, // US Government L4
+	"dod-graph.microsoft.us":          true, // US Government L5 (DOD)
+	"microsoftgraph.chinacloudapi.cn": true, // 21Vianet (China)
+}
+
+// validateDeltaToken rejects a continuation token that isn't an HTTPS Microsoft
+// Graph URL, so a model can't redirect an authenticated request elsewhere.
+func validateDeltaToken(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid delta token")
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return fmt.Errorf("refusing non-HTTPS delta token")
+	}
+	if !graphAPIHosts[strings.ToLower(u.Hostname())] {
+		return fmt.Errorf("refusing delta token for untrusted host %q", u.Hostname())
+	}
+	return nil
+}
+
+func isRemoved(additionalData map[string]any) bool {
+	if additionalData == nil {
+		return false
+	}
+	_, ok := additionalData["@removed"]
+	return ok
+}
+
+// DeltaMessages returns message changes in a mail folder (default "inbox")
+// since token. Pass an empty token to start a fresh sync.
+func (c *Client) DeltaMessages(ctx context.Context, target, folderID, token string, top int32) ([]MailDelta, DeltaPage, error) {
+	if folderID == "" {
+		folderID = "inbox"
+	}
+	var resp users.ItemMailFoldersItemMessagesDeltaGetResponseable
+	var err error
+	if token == "" {
+		cfg := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{Headers: maxPageSizeHeaders(top)}
+		resp, err = c.targetUser(target).MailFolders().ByMailFolderId(folderID).Messages().Delta().GetAsDeltaGetResponse(ctx, cfg)
+	} else {
+		if err := validateDeltaToken(token); err != nil {
+			return nil, DeltaPage{}, err
+		}
+		rb := users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(token, c.inner.GetAdapter())
+		resp, err = rb.GetAsDeltaGetResponse(ctx, nil)
+	}
+	if err != nil {
+		return nil, DeltaPage{}, err
+	}
+	items := make([]MailDelta, 0, len(resp.GetValue()))
+	for _, m := range resp.GetValue() {
+		items = append(items, MailDelta{MailMessage: convertMessage(m), Removed: isRemoved(m.GetAdditionalData())})
+	}
+	return items, deltaPageFrom(resp), nil
+}
+
+// DeltaCalendarView returns event changes in [start, end] since token. The
+// window is required for the initial sync; on resume the token already encodes
+// it, so start/end are ignored. Pass an empty token to start a fresh sync.
+func (c *Client) DeltaCalendarView(ctx context.Context, target, token string, start, end time.Time, top int32) ([]CalendarDelta, DeltaPage, error) {
+	var resp users.ItemCalendarViewDeltaGetResponseable
+	var err error
+	if token == "" {
+		s := start.UTC().Format(time.RFC3339)
+		e := end.UTC().Format(time.RFC3339)
+		qp := &users.ItemCalendarViewDeltaRequestBuilderGetQueryParameters{StartDateTime: &s, EndDateTime: &e}
+		cfg := &users.ItemCalendarViewDeltaRequestBuilderGetRequestConfiguration{QueryParameters: qp, Headers: maxPageSizeHeaders(top)}
+		resp, err = c.targetUser(target).CalendarView().Delta().GetAsDeltaGetResponse(ctx, cfg)
+	} else {
+		if err := validateDeltaToken(token); err != nil {
+			return nil, DeltaPage{}, err
+		}
+		rb := users.NewItemCalendarViewDeltaRequestBuilder(token, c.inner.GetAdapter())
+		resp, err = rb.GetAsDeltaGetResponse(ctx, nil)
+	}
+	if err != nil {
+		return nil, DeltaPage{}, err
+	}
+	items := make([]CalendarDelta, 0, len(resp.GetValue()))
+	for _, e := range resp.GetValue() {
+		items = append(items, CalendarDelta{CalendarEvent: convertEvent(e), Removed: isRemoved(e.GetAdditionalData())})
+	}
+	return items, deltaPageFrom(resp), nil
+}
+
+// DeltaContacts returns contact changes since token. Pass an empty token to
+// start a fresh sync.
+func (c *Client) DeltaContacts(ctx context.Context, target, token string, top int32) ([]ContactDelta, DeltaPage, error) {
+	var resp users.ItemContactsDeltaGetResponseable
+	var err error
+	if token == "" {
+		cfg := &users.ItemContactsDeltaRequestBuilderGetRequestConfiguration{Headers: maxPageSizeHeaders(top)}
+		resp, err = c.targetUser(target).Contacts().Delta().GetAsDeltaGetResponse(ctx, cfg)
+	} else {
+		if err := validateDeltaToken(token); err != nil {
+			return nil, DeltaPage{}, err
+		}
+		rb := users.NewItemContactsDeltaRequestBuilder(token, c.inner.GetAdapter())
+		resp, err = rb.GetAsDeltaGetResponse(ctx, nil)
+	}
+	if err != nil {
+		return nil, DeltaPage{}, err
+	}
+	items := make([]ContactDelta, 0, len(resp.GetValue()))
+	for _, ct := range resp.GetValue() {
+		items = append(items, ContactDelta{Contact: convertContact(ct), Removed: isRemoved(ct.GetAdditionalData())})
+	}
+	return items, deltaPageFrom(resp), nil
+}

--- a/internal/graphapi/delta_test.go
+++ b/internal/graphapi/delta_test.go
@@ -1,0 +1,39 @@
+package graphapi
+
+import "testing"
+
+func TestValidateDeltaToken(t *testing.T) {
+	ok := []string{
+		"https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=abc",
+		"https://graph.microsoft.us/v1.0/me/contacts/delta?$skiptoken=xyz",
+		"https://microsoftgraph.chinacloudapi.cn/v1.0/me/calendarView/delta?$deltatoken=q",
+	}
+	for _, u := range ok {
+		if err := validateDeltaToken(u); err != nil {
+			t.Errorf("expected %q to be accepted, got %v", u, err)
+		}
+	}
+	bad := []string{
+		"http://graph.microsoft.com/v1.0/me/messages/delta",        // non-https
+		"https://evil.example.com/v1.0/me/messages/delta?$token=x", // untrusted host
+		"https://graph.microsoft.com.evil.com/delta",               // suffix trick
+		"::not a url", // unparseable
+	}
+	for _, u := range bad {
+		if err := validateDeltaToken(u); err == nil {
+			t.Errorf("expected %q to be rejected", u)
+		}
+	}
+}
+
+func TestIsRemoved(t *testing.T) {
+	if isRemoved(nil) {
+		t.Error("nil additionalData should not be removed")
+	}
+	if isRemoved(map[string]any{"foo": "bar"}) {
+		t.Error("absent @removed should not be removed")
+	}
+	if !isRemoved(map[string]any{"@removed": map[string]any{"reason": "deleted"}}) {
+		t.Error("@removed present should be removed")
+	}
+}

--- a/internal/outfmt/concise.go
+++ b/internal/outfmt/concise.go
@@ -55,18 +55,41 @@ func dropConcise(v any) any {
 }
 
 // scrubConcise zeroes fields tagged concise:"omit" on an addressable struct
-// value. Non-struct values are left untouched.
+// value, recursing into nested and embedded structs, struct pointers, and
+// slices so a tagged field is dropped wherever it sits (e.g. a Body inside an
+// embedded MailMessage). Non-struct values are left untouched.
 func scrubConcise(sv reflect.Value) {
 	if sv.Kind() != reflect.Struct {
 		return
 	}
 	t := sv.Type()
 	for i := 0; i < t.NumField(); i++ {
-		if t.Field(i).Tag.Get(conciseTagKey) != "omit" {
+		f := sv.Field(i)
+		if !f.CanSet() {
 			continue
 		}
-		if f := sv.Field(i); f.CanSet() {
+		if t.Field(i).Tag.Get(conciseTagKey) == "omit" {
 			f.Set(reflect.Zero(f.Type()))
+			continue
+		}
+		switch f.Kind() { //nolint:exhaustive // only nested struct-bearing kinds need recursion
+		case reflect.Struct:
+			scrubConcise(f)
+		case reflect.Pointer:
+			if !f.IsNil() && f.Elem().Kind() == reflect.Struct {
+				scrubConcise(f.Elem())
+			}
+		case reflect.Slice:
+			for j := 0; j < f.Len(); j++ {
+				switch el := f.Index(j); el.Kind() { //nolint:exhaustive // only struct elements recurse
+				case reflect.Struct:
+					scrubConcise(el)
+				case reflect.Pointer:
+					if !el.IsNil() && el.Elem().Kind() == reflect.Struct {
+						scrubConcise(el.Elem())
+					}
+				}
+			}
 		}
 	}
 }

--- a/internal/outfmt/concise_test.go
+++ b/internal/outfmt/concise_test.go
@@ -58,3 +58,43 @@ func TestPrintJSON_ConciseDropsBody(t *testing.T) {
 		t.Errorf("concise output dropped non-omitted field:\n%s", out)
 	}
 }
+
+// EmbedSample mimics a delta item: a wrapper embedding a struct whose Body is
+// tagged concise:"omit". Concise must reach through the embedding.
+type EmbedInner struct {
+	ID   string `json:"id"`
+	Body string `json:"body,omitempty" concise:"omit"`
+}
+type EmbedSample struct {
+	EmbedInner
+	Removed bool `json:"removed,omitempty"`
+}
+
+func TestDropConcise_RecursesIntoEmbedded(t *testing.T) {
+	in := []EmbedSample{{EmbedInner: EmbedInner{ID: "1", Body: "huge body"}, Removed: false}}
+	out := dropConcise(in).([]EmbedSample)
+	if out[0].Body != "" {
+		t.Errorf("embedded Body not scrubbed: %q", out[0].Body)
+	}
+	if out[0].ID != "1" {
+		t.Errorf("embedded ID wrongly cleared: %q", out[0].ID)
+	}
+	if in[0].Body == "" {
+		t.Error("dropConcise mutated caller data")
+	}
+}
+
+func TestPrintDelta_JSONEnvelope(t *testing.T) {
+	var sb strings.Builder
+	p := &Printer{Format: FormatJSON, Writer: &sb}
+	if err := p.PrintDelta(nil, nil, []EmbedSample{{EmbedInner: EmbedInner{ID: "1"}}}, 1, "TOKEN123", true); err != nil {
+		t.Fatalf("PrintDelta: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, `"deltaToken": "TOKEN123"`) {
+		t.Errorf("missing deltaToken:\n%s", out)
+	}
+	if !strings.Contains(out, `"deltaComplete": true`) {
+		t.Errorf("missing deltaComplete:\n%s", out)
+	}
+}

--- a/internal/outfmt/outfmt.go
+++ b/internal/outfmt/outfmt.go
@@ -27,7 +27,12 @@ type Envelope struct {
 	Results         interface{} `json:"results"`
 	Count           int         `json:"count"`
 	NextLink        string      `json:"nextLink,omitempty"`
-	Timezone        string      `json:"timezone,omitempty"`
+	// Delta-sync continuation (set only by delta/changes commands). DeltaToken is
+	// the opaque cursor to pass back next time; DeltaComplete reports whether the
+	// caller is caught up (token is a deltaLink) or more pages remain now.
+	DeltaToken    string `json:"deltaToken,omitempty"`
+	DeltaComplete *bool  `json:"deltaComplete,omitempty"`
+	Timezone      string `json:"timezone,omitempty"`
 }
 
 // Printer handles output formatting
@@ -87,6 +92,48 @@ func (p *Printer) PrintJSON(results interface{}, count int, nextLink string) err
 		NextLink:        nextLink,
 		Timezone:        p.Timezone,
 	})
+}
+
+// PrintDelta renders a delta-sync page: in JSON mode it emits the envelope with
+// the continuation token and completeness (results still wrapped/concised like
+// PrintJSON); in table/plain mode it prints the rows followed by the token and
+// complete flag so a human/script can resume.
+func (p *Printer) PrintDelta(headers []string, rows [][]string, jsonData interface{}, count int, token string, complete bool) error {
+	if p.Format == FormatJSON {
+		results := jsonData
+		if p.Concise {
+			results = dropConcise(results)
+		}
+		notice := ""
+		if p.WrapUntrusted {
+			id := newUntrustedID()
+			results = wrapUntrusted(results, id)
+			notice = untrustedNotice(id)
+		}
+		enc := json.NewEncoder(p.Writer)
+		enc.SetIndent("", "  ")
+		if p.ResultsOnly {
+			return enc.Encode(results)
+		}
+		return enc.Encode(Envelope{
+			UntrustedNotice: notice,
+			Results:         results,
+			Count:           count,
+			DeltaToken:      token,
+			DeltaComplete:   &complete,
+			Timezone:        p.Timezone,
+		})
+	}
+
+	if p.Format == FormatPlain {
+		if err := p.PrintPlain(headers, rows); err != nil {
+			return err
+		}
+	} else if err := p.PrintTable(headers, rows); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(p.Writer, "\nDelta token: %s\nComplete: %v\n", token, complete)
+	return err
 }
 
 // PrintTable outputs data as an aligned table


### PR DESCRIPTION
## Context

Phase 2 of the MCP roadmap: **incremental change tracking (delta sync)** — the marquee capability gap that neither gog nor outlook-mcp's safe tier closes for olk. Branches off `main` (Phases 0–1 already merged).

## What's new

**graphapi** (`internal/graphapi/delta.go`)
- `DeltaMessages`, `DeltaCalendarView`, `DeltaContacts` wrap Graph's `/delta` endpoints. Each returns the changes since an opaque token plus a fresh token, **one page per call**: `Complete=true` → caught up (deltaLink, store for next sync); `Complete=false` → more pages now (nextLink). Deletions surface as items with `removed: true`.
- Page size goes through the `Prefer: odata.maxpagesize` header — `$top` is rejected on delta endpoints (caught in live testing).
- **Security:** continuation tokens are validated to be Microsoft Graph URLs before reuse, so a model can't redirect an authenticated request to another host (SSRF / bearer-token exfiltration guard).

**CLI**: `mail delta`, `calendar delta`, `contacts delta`, and a unified `changes` command digesting all three in one call with independent tokens (outlook-mcp's `changes_since`). Delta items embed the existing result structs, so output matches `list`/`get` plus a `removed` flag.

**outfmt**: `PrintDelta` carries the cursor + completeness in the JSON envelope (`deltaToken`/`deltaComplete`) while keeping untrusted-wrapping and concise. `scrubConcise` now recurses into nested/embedded structs, so `--concise` reaches a `Body` inside an embedded `MailMessage`.

**MCP**: `mail_delta`, `calendar_delta`, `contacts_delta`, `changes` registered as read tools (registry 32 → **36**). Count tripwire + README updated.

## Validation
Unit tests: delta-token validator (incl. host-spoof rejection), `isRemoved`, concise recursion through embedding, `PrintDelta` envelope. `go build`, `go vet`, full `go test ./...`, `golangci-lint` all clean.

Live (real account): initial sync + resume round-trip (resume → 0 changes, complete), contacts pagination (`complete:false`), `changes` digest with three tokens, `--concise` dropping bodies through embedding (bodyPreview 2→0), the SSRF guard rejecting a non-Graph token, and an MCP `mail_delta` `tools/call` returning `deltaToken`/`deltaComplete` with untrusted wrapping forced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)