### PR TITLE
feat(mcp): Phase 3 — batch message fetch + conversation threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,14 +362,15 @@ It's also published to the [MCP Registry](https://registry.modelcontextprotocol.
 
 Either way, run `olk auth login` once first so the server has a token to reuse.
 
-- **Read-only by default.** A curated set of 36 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
-  - **Mail:** `mail_list`, `mail_get`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`, `mail_delta`
+- **Read-only by default.** A curated set of 38 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
+  - **Mail:** `mail_list`, `mail_get`, `mail_batch`, `mail_thread`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`, `mail_delta`
   - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_calendars`, `calendar_availability`, `calendar_find_times`, `calendar_delta`
   - **Contacts:** `contacts_list`, `contacts_get`, `contacts_search`, `contacts_delta`
   - **OneDrive:** `drive_ls`, `drive_get`, `drive_info`, `drive_search`, `drive_recent`, `drive_shared`, `drive_versions` *(reads only — no upload/move/delete/share via MCP)*
   - **To Do:** `todo_lists_list`, `todo_list`, `todo_get`, `todo_checklist_list`, `todo_links_list`
   - **Directory & meta:** `people_search`, `changes`, `whoami`, `version`
 - **Incremental sync (delta).** `mail_delta`, `calendar_delta`, and `contacts_delta` return only what changed since an opaque cursor token (the unified `changes` tool digests all three in one call, each with its own token). Pass an empty token for a fresh sync, then hand the returned token back next time; deletions come through as items with `"removed": true`. Tokens are validated to be Microsoft Graph URLs before reuse, so a model can't redirect an authenticated request elsewhere.
+- **Batch & threading.** `mail_batch` fetches up to 20 messages by id in a single Graph `$batch` round-trip (best-effort — an id that fails is omitted). `mail_thread` returns every message in a conversation (oldest first) given a `conversationId`, which `mail_list`/`mail_get` now include in their output.
 - **Opt into safe writes per-tool** by naming each one: `olk mcp --allow-write mail_drafts_create` (repeatable, or `OLK_MCP_ALLOW_WRITE=mail_drafts_create,todo_create`). Only the curated, non-send/non-destructive writes — `mail_drafts_create` and `todo_create` — are eligible; nothing is exposed by default. Naming a write is a deliberate action separate from starting the server (defense in depth).
 - **Narrow the exposed set with `--allow-tool`** (`OLK_MCP_ALLOW_TOOL`, repeatable/csv). Selectors are an exact name (`mail_list`), a prefix glob (`mail_*`, or `mail.*`), or a category (`read`, `write`, `all`). E.g. `olk mcp --allow-tool 'mail.*' --allow-tool calendar_events` exposes only the mail tools plus that one calendar tool. This narrows tools by name; it never grants a write that `--allow-write` hasn't already enabled.
 - **Shrink responses with `concise`.** Every read tool accepts a `concise` boolean (maps to the global `--concise` / `OLK_CONCISE`) that drops large free-text — message/event/task bodies, previews, attendee lists — to cut token usage when an agent only needs headers/metadata.

--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -4,6 +4,8 @@ type MailCmd struct {
 	List        MailListCmd        `cmd:"" help:"List messages in inbox"`
 	Delta       MailDeltaCmd       `cmd:"" help:"Incremental sync of a mail folder (delta)"`
 	Get         MailGetCmd         `cmd:"" help:"Get a message"`
+	Batch       MailBatchCmd       `cmd:"" help:"Fetch up to 20 messages by ID in one request ($batch)"`
+	Thread      MailThreadCmd      `cmd:"" help:"List all messages in a conversation thread"`
 	Send        MailSendCmd        `cmd:"" help:"Send a message"`
 	Search      MailSearchCmd      `cmd:"" help:"Search messages"`
 	Reply       MailReplyCmd       `cmd:"" help:"Reply to a message"`

--- a/internal/cmd/mail_batch.go
+++ b/internal/cmd/mail_batch.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "fmt"
+
+// MailBatchCmd fetches up to 20 messages by ID in one Graph $batch round-trip.
+type MailBatchCmd struct {
+	ID []string `help:"Message ID to fetch (repeatable, max 20)" name:"id"`
+}
+
+func (c *MailBatchCmd) Run(ctx *RunContext) error {
+	if len(c.ID) == 0 {
+		return fmt.Errorf("provide at least one --id")
+	}
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	messages, err := client.GetMessagesBatch(ctx.Ctx, target, c.ID)
+	if err != nil {
+		return err
+	}
+	return printMessageList(ctx, messages)
+}

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -61,6 +61,12 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	return printMessageList(ctx, messages)
+}
+
+// printMessageList renders a slice of messages as JSON (full structs) or an
+// aligned table, shared by mail list, mail batch, and mail thread.
+func printMessageList(ctx *RunContext, messages []graphapi.MailMessage) error {
 	printer := ctx.Printer()
 	if ctx.Flags.JSON {
 		return printer.PrintJSON(messages, len(messages), "")

--- a/internal/cmd/mail_thread.go
+++ b/internal/cmd/mail_thread.go
@@ -1,0 +1,26 @@
+package cmd
+
+// MailThreadCmd returns every message in a conversation, oldest first. The
+// conversation id comes from a message's conversationId field (shown by mail
+// list and mail get).
+type MailThreadCmd struct {
+	ConversationID string `arg:"" help:"Conversation ID (a message's conversationId)" name:"conversation-id"`
+	Top            int32  `help:"Max messages to return" default:"50" short:"n"`
+}
+
+func (c *MailThreadCmd) Run(ctx *RunContext) error {
+	client, err := ctx.GraphClient()
+	if err != nil {
+		return err
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	messages, err := client.ListThread(ctx.Ctx, target, c.ConversationID, c.Top)
+	if err != nil {
+		return err
+	}
+	return printMessageList(ctx, messages)
+}

--- a/internal/cmd/mcp_server.go
+++ b/internal/cmd/mcp_server.go
@@ -27,6 +27,8 @@ var curatedTools = []curatedTool{
 	// Mail (read)
 	{"mail_list", []string{"mail", "list"}, false},
 	{"mail_get", []string{"mail", "get"}, false},
+	{"mail_batch", []string{"mail", "batch"}, false},
+	{"mail_thread", []string{"mail", "thread"}, false},
 	{"mail_search", []string{"mail", "search"}, false},
 	{"mail_folders_list", []string{"mail", "folders", "list"}, false},
 	{"mail_attachments", []string{"mail", "attachments"}, false},

--- a/internal/cmd/mcp_server_test.go
+++ b/internal/cmd/mcp_server_test.go
@@ -211,7 +211,7 @@ func TestToolSchema_ConciseInjectedForReadOnly(t *testing.T) {
 // "N read tools" figure in README.md can't silently drift. If you add or remove
 // a read tool, update both this number and the README.
 func TestCuratedReadToolCount(t *testing.T) {
-	const documentedReadTools = 36
+	const documentedReadTools = 38
 	if got := len(buildBindings(t)); got != documentedReadTools {
 		t.Errorf("default read-only registry has %d tools; expected %d — update README.md and this constant in lockstep", got, documentedReadTools)
 	}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -53,6 +53,14 @@ type MailMessage struct {
 	Body           string   `json:"body,omitempty" untrusted:"true" concise:"omit"`
 	BodyType       string   `json:"bodyType,omitempty"`
 	Categories     []string `json:"categories,omitempty"`
+	ConversationID string   `json:"conversationId,omitempty"`
+}
+
+// messageDetailSelect is the $select field set for a full single message (used by
+// GetMessage and the batch fetch) — includes the body and conversation id.
+var messageDetailSelect = []string{
+	"id", "subject", "from", "toRecipients", "ccRecipients", "bccRecipients",
+	"receivedDateTime", "isRead", "hasAttachments", "body", "bodyPreview", "conversationId",
 }
 
 // MailFolder is a simplified folder representation
@@ -99,8 +107,11 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	queryParams := &users.ItemMessagesRequestBuilderGetQueryParameters{
 		Top: &top,
 	}
-	// Microsoft Graph does not support $orderBy combined with $search or inferenceClassification filter.
-	skipOrderBy := opts.Search != "" || strings.Contains(opts.Filter, "inferenceClassification")
+	// Microsoft Graph does not support $orderBy combined with $search, an
+	// inferenceClassification filter, or a conversationId filter ("restriction or
+	// sort order is too complex"). Callers that need ordering in those cases sort
+	// client-side.
+	skipOrderBy := opts.Search != "" || strings.Contains(opts.Filter, "inferenceClassification") || strings.Contains(opts.Filter, "conversationId")
 	if !skipOrderBy {
 		queryParams.Orderby = []string{orderBy}
 	}
@@ -118,7 +129,7 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		}
 		queryParams.Select = opts.Select
 	} else {
-		queryParams.Select = []string{"id", "subject", "from", "toRecipients", "receivedDateTime", "isRead", "hasAttachments", "bodyPreview", "categories"}
+		queryParams.Select = []string{"id", "subject", "from", "toRecipients", "receivedDateTime", "isRead", "hasAttachments", "bodyPreview", "categories", "conversationId"}
 	}
 
 	config = &users.ItemMessagesRequestBuilderGetRequestConfiguration{
@@ -174,23 +185,14 @@ func (c *Client) GetMessage(ctx context.Context, target, messageID string) (*Mai
 	}
 	msg, err := c.targetUser(target).Messages().ByMessageId(messageID).Get(ctx, &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemMessagesMessageItemRequestBuilderGetQueryParameters{
-			Select: []string{"id", "subject", "from", "toRecipients", "ccRecipients", "bccRecipients", "receivedDateTime", "isRead", "hasAttachments", "body", "bodyPreview"},
+			Select: messageDetailSelect,
 		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("getting message: %w", err)
 	}
 	m := convertMessage(msg)
-	if msg.GetBody() != nil {
-		content := msg.GetBody().GetContent()
-		if content != nil {
-			m.Body = *content
-		}
-		ct := msg.GetBody().GetContentType()
-		if ct != nil {
-			m.BodyType = ct.String()
-		}
-	}
+	fillBody(&m, msg)
 	return &m, nil
 }
 
@@ -688,7 +690,24 @@ func convertMessage(msg models.Messageable) MailMessage {
 	if cats := msg.GetCategories(); len(cats) > 0 {
 		m.Categories = cats
 	}
+	if msg.GetConversationId() != nil {
+		m.ConversationID = *msg.GetConversationId()
+	}
 	return m
+}
+
+// fillBody copies a message's body content and type into m (convertMessage only
+// sets the preview, since list responses don't include the full body).
+func fillBody(m *MailMessage, msg models.Messageable) {
+	if msg.GetBody() == nil {
+		return
+	}
+	if content := msg.GetBody().GetContent(); content != nil {
+		m.Body = *content
+	}
+	if ct := msg.GetBody().GetContentType(); ct != nil {
+		m.BodyType = ct.String()
+	}
 }
 
 func makeRecipients(emails []string) ([]models.Recipientable, error) {

--- a/internal/graphapi/mail_batch.go
+++ b/internal/graphapi/mail_batch.go
@@ -1,0 +1,95 @@
+package graphapi
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	graphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
+)
+
+// maxBatchMessages is Graph's per-$batch request limit.
+const maxBatchMessages = 20
+
+// GetMessagesBatch fetches several messages in a single Graph $batch round-trip
+// (up to maxBatchMessages), instead of one request each. It is best-effort: an
+// id that fails (not found / no access) is omitted from the result rather than
+// failing the whole call, so a missing id in the output means that fetch failed.
+func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []string) ([]MailMessage, error) {
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no message IDs provided")
+	}
+	if len(ids) > maxBatchMessages {
+		return nil, fmt.Errorf("too many message IDs: %d (max %d per batch)", len(ids), maxBatchMessages)
+	}
+	for _, id := range ids {
+		if err := validateID(id, "message ID"); err != nil {
+			return nil, err
+		}
+	}
+
+	adapter := c.inner.GetAdapter()
+	batch := graphcore.NewBatchRequest(adapter)
+	cfg := &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.ItemMessagesMessageItemRequestBuilderGetQueryParameters{
+			Select: messageDetailSelect,
+		},
+	}
+
+	// Preserve request order and map each step id back to its result.
+	stepIDs := make([]string, 0, len(ids))
+	for _, id := range ids {
+		reqInfo, err := c.targetUser(target).Messages().ByMessageId(id).ToGetRequestInformation(ctx, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("building batch request: %w", err)
+		}
+		item, err := batch.AddBatchRequestStep(*reqInfo)
+		if err != nil {
+			return nil, fmt.Errorf("adding batch step: %w", err)
+		}
+		stepIDs = append(stepIDs, *item.GetId())
+	}
+
+	resp, err := batch.Send(ctx, adapter)
+	if err != nil {
+		return nil, fmt.Errorf("sending batch request: %w", err)
+	}
+
+	out := make([]MailMessage, 0, len(stepIDs))
+	for _, stepID := range stepIDs {
+		msg, err := graphcore.GetBatchResponseById[models.Messageable](resp, stepID, models.CreateMessageFromDiscriminatorValue)
+		if err != nil {
+			continue // best-effort: skip ids that failed (not found / no access)
+		}
+		m := convertMessage(msg)
+		fillBody(&m, msg)
+		out = append(out, m)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no messages returned (all %d ids failed or were not found)", len(ids))
+	}
+	return out, nil
+}
+
+// ListThread returns every message in a conversation, oldest first. The
+// conversation id comes from a message's conversationId field (now included in
+// list/get output). Messages are matched across all folders (inbox, sent, …).
+func (c *Client) ListThread(ctx context.Context, target, conversationID string, top int32) ([]MailMessage, error) {
+	if err := validateID(conversationID, "conversation ID"); err != nil {
+		return nil, err
+	}
+	// validateID's character set excludes quotes, so the id can't break out of
+	// the OData string literal — the filter is injection-safe. Graph rejects
+	// $orderby alongside a conversationId filter, so order client-side.
+	filter := fmt.Sprintf("conversationId eq '%s'", conversationID)
+	messages, err := c.ListMessages(ctx, target, &ListMessagesOptions{Filter: filter, Top: top})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(messages, func(i, j int) bool {
+		return messages[i].ReceivedAt < messages[j].ReceivedAt // RFC3339 Z strings sort chronologically
+	})
+	return messages, nil
+}

--- a/internal/graphapi/mail_batch_test.go
+++ b/internal/graphapi/mail_batch_test.go
@@ -1,0 +1,40 @@
+package graphapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// These exercise the input-validation paths, which run before any network call,
+// so a zero Client (nil inner) is sufficient.
+
+func TestGetMessagesBatch_Validation(t *testing.T) {
+	c := &Client{}
+	ctx := context.Background()
+
+	if _, err := c.GetMessagesBatch(ctx, "", nil); err == nil {
+		t.Error("expected error for empty id list")
+	}
+	many := make([]string, maxBatchMessages+1)
+	for i := range many {
+		many[i] = "AAA"
+	}
+	if _, err := c.GetMessagesBatch(ctx, "", many); err == nil || !strings.Contains(err.Error(), "max") {
+		t.Errorf("expected max-batch error, got %v", err)
+	}
+	if _, err := c.GetMessagesBatch(ctx, "", []string{"bad id with spaces"}); err == nil {
+		t.Error("expected invalid-id error")
+	}
+}
+
+func TestListThread_Validation(t *testing.T) {
+	c := &Client{}
+	if _, err := c.ListThread(context.Background(), "", "", 50); err == nil {
+		t.Error("expected error for empty conversation id")
+	}
+	// A quote can't pass validateID, so OData injection is impossible.
+	if _, err := c.ListThread(context.Background(), "", "x' or '1'='1", 50); err == nil {
+		t.Error("expected invalid-id error for quote-bearing conversation id")
+	}
+}


### PR DESCRIPTION
## Context

Phase 3 of the MCP roadmap: two pure read wins (no send/delete decision needed), exposed via **both CLI and MCP**. Branches off `main` (Phases 0–2 merged).

## What's new

**`mail batch` / `mail_batch`** — fetches up to 20 messages by id in a single Graph `$batch` round-trip instead of one request each. Best-effort: an id that fails (not found / no access) is omitted rather than failing the whole call. The repeatable `--id` flag maps to an `array` arg in the MCP schema.

**`mail thread` / `mail_thread`** — returns every message in a conversation, oldest first, given a `conversationId`. Matches across all folders. Graph rejects `$orderby` alongside a `conversationId` filter ("restriction or sort order is too complex"), so `ListMessages` skips server-side ordering for that filter and the thread is sorted client-side.

**`conversationId` now surfaced** — `MailMessage` carries it (set in `convertMessage`, included in `list`/`get`/`batch` output) so an agent has the thread key. `GetMessage` and the batch fetch now share `messageDetailSelect` + a `fillBody` helper.

## Security
`GetMessagesBatch` and `ListThread` validate every id up front; the validated charset excludes quotes, so the OData `conversationId` filter is injection-safe.

## Validation
Unit tests: batch validation (empty / >20 / bad id), thread validation (empty / quote-bearing id). `go build`, `go vet`, full `go test ./...`, `golangci-lint` all clean.

Live (real account): batch fetch of 2 ids (body + conversationId present), >20-id rejection, thread retrieval (ascending, single conversation), `conversationId` surfaced in list output, and MCP `tools/call` for both `mail_batch` (id array, `concise` drops body) and `mail_thread` with untrusted wrapping forced. Registry 36 → **38** (tripwire + README updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)