### PR TITLE
docs(mcp): scrub competitor name + add general strengths highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,13 @@ These capability guards apply to **every** entry path — the bare CLI, scripts/
 
 `olk mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io) server over **stdio**, exposing a **curated, read-first** set of tools to MCP clients (Claude Desktop, IDEs, agents). It reuses your existing olk login — no separate auth.
 
+**Why this server stands out:**
+- **Read-first with tiered, per-tool opt-in.** Reads work out of the box; every mutation is off by default, and four separate escalating gates (`--allow-write` → `--allow-send` → `--allow-destructive`) mean granting reads or safe edits never silently grants the ability to send mail or delete data.
+- **Guarantees that hold everywhere.** `--no-write`/`--no-send` are enforced once at the API layer, so the same safety promise covers the CLI, scripts, and MCP — a disabled capability is never even advertised as a tool.
+- **Built-in prompt-injection defense.** External free text (subjects, bodies, sender names, file names) is wrapped in per-response, forge-resistant markers with an inline directive telling the agent to treat it as data, not instructions.
+- **Broad and efficient.** Mail, calendar, contacts, tasks, **and** OneDrive files plus directory/people search — with incremental delta sync, `$batch` fetches, conversation threading, a token-saving concise mode, output caps, and structured `{code, message, action}` errors agents can branch on.
+- **Personal *and* enterprise accounts**, a single static binary, and no networked HTTP surface (stdio only).
+
 ```jsonc
 // Claude Desktop / MCP client config
 {

--- a/internal/cmd/changes.go
+++ b/internal/cmd/changes.go
@@ -17,8 +17,8 @@ type resourceChanges[T any] struct {
 	Complete   bool   `json:"complete"`
 }
 
-// changesDigest is the cross-resource delta snapshot (outlook-mcp's
-// changes_since): mail, calendar, and contacts each with an independent token.
+// changesDigest is the cross-resource delta snapshot: mail, calendar, and
+// contacts changes in one call, each with its own independent token.
 type changesDigest struct {
 	Mail     resourceChanges[graphapi.MailDelta]     `json:"mail"`
 	Calendar resourceChanges[graphapi.CalendarDelta] `json:"calendar"`

--- a/internal/cmd/mcp_invoke.go
+++ b/internal/cmd/mcp_invoke.go
@@ -136,8 +136,8 @@ func capText(s string, limit int) string {
 }
 
 // errorResult builds an IsError tool result as a {code, message, action} JSON
-// envelope (outlook-mcp's structured-error shape) so an agent gets a machine
-// classification plus an actionable next step, not just a raw Graph error.
+// envelope so an agent gets a machine classification plus an actionable next
+// step, not just a raw Graph error.
 func errorResult(msg string) *mcp.CallToolResult {
 	code, action := classifyError(msg)
 	env := map[string]string{"code": code, "message": msg}

--- a/internal/graphapi/delta.go
+++ b/internal/graphapi/delta.go
@@ -25,8 +25,8 @@ func maxPageSizeHeaders(top int32) *abs.RequestHeaders {
 
 // Delta sync wraps Microsoft Graph's /delta endpoints for mail, calendar, and
 // contacts. Each call returns the changes since a prior opaque token plus a new
-// token to use next time — stateless, agent-driven, no server state (mirroring
-// outlook-mcp's cursor model). One call returns one page: when Complete is
+// token to use next time — stateless and agent-driven, with no server state
+// (an opaque cursor model). One call returns one page: when Complete is
 // false a nextLink token is returned (more changes available right now); when
 // Complete is true the token is a deltaLink (caught up — store it for the next
 // sync). An item with Removed=true is a deletion (only its ID is populated).


### PR DESCRIPTION
## Context

Removes the three third-party-product references that had crept into code comments and replaces them with neutral descriptions, and adds a general "what makes this strong" highlight to the README's MCP section — framed on its own merits, without naming any other project.

## Changes
- **Code comments** (`changes.go`, `mcp_invoke.go`, `delta.go`): same intent, neutral wording (e.g. "an opaque cursor model" instead of naming a product).
- **README** — new "Why this server stands out" block under *MCP Server*: tiered per-tool opt-in writes, API-layer guarantees that hold across CLI/scripts/MCP, prompt-injection wrapping, breadth (mail/calendar/contacts/tasks/files + delta/batch/threading/concise/structured errors), and personal + enterprise support.

Docs/comments only — no behavior change. `go build` and `go test ./internal/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)