### PR TITLE
docs: remove external-project references; document new commands/flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Ent
 - **Inbox rules**: list, create, and delete server-side mail rules *(enterprise only)*
 - **Focused Inbox**: filter by `--focused` or `--other` classification
 - **Read receipts**: request read receipts with `--read-receipt`
+- **Sync & threads**: incremental delta sync (`mail delta`), batch-fetch up to 20 messages by id in one request (`mail batch`), and full conversation threads (`mail thread`)
 
 ### Calendar
 - **List events** with configurable date ranges (default: 7 days ahead)
@@ -32,10 +33,12 @@ Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Ent
 - **List calendars** across your account
 - **Check availability** / free-busy lookup for one or more users
 - **Find meeting times** — suggest available slots for multiple attendees *(enterprise only)*
+- **Incremental sync** of event changes (`calendar delta`)
 
 ### Contacts
 - **List, search, create, update, delete** contacts with sorting and pagination
 - Fields: name, multiple emails, phone, company, job title, department, manager, birthday, notes, addresses, categories, and more
+- **Incremental sync** of contact changes (`contacts delta`)
 
 ### Tasks (Microsoft To Do)
 - **Manage task lists**: list, create, delete task lists
@@ -55,6 +58,10 @@ Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Ent
 
 ### People / Directory
 - **Search** people by name — returns name, email, job title, department, company. Personal accounts search known contacts; enterprise accounts also search the organization directory
+
+### Sync
+- **`olk changes`** — one call returns a unified delta digest across mail, calendar, and contacts, each with its own resume token
+- Per-resource delta commands (`mail delta`, `calendar delta`, `contacts delta`) return only what changed since an opaque cursor token; deletions are reported as `removed` items
 
 ### User Profile
 - **`olk whoami`** — display current user info (name, email, job title, department)
@@ -319,11 +326,13 @@ For common workflows, `olk` provides top-level shortcuts:
 | `--json` | `OLK_JSON` | JSON output |
 | `--plain` | `OLK_PLAIN` | TSV output |
 | `--account EMAIL` | `OLK_ACCOUNT` | Account to use |
+| `--mailbox EMAIL` | `OLK_MAILBOX` | Target another user's mailbox via delegated access (requires `Mail.Read.Shared` at login) |
 | `-v, --verbose` | `OLK_VERBOSE` | Verbose output |
 | `--dry-run` | `OLK_DRY_RUN` | Dry run mode |
 | `--force` | `OLK_FORCE` | Skip confirmations |
 | `--color auto\|never\|always` | `OLK_COLOR` | Color mode |
-| `--select FIELDS` | `OLK_SELECT` | Field projection |
+| `--select FIELDS` | `OLK_SELECT` | Field projection (table/plain output) |
+| `--concise` | `OLK_CONCISE` | Drop large free-text (bodies, previews, attendee lists) from JSON output |
 | `--results-only` | `OLK_RESULTS_ONLY` | Unwrap JSON envelope |
 | `--tz TIMEZONE` | `OLK_TIMEZONE` | IANA time zone for display (e.g. `America/New_York`) |
 | `--no-write` | `OLK_NO_WRITE` | Refuse any mutating operation (hard guarantee, all surfaces) |
@@ -340,13 +349,6 @@ These capability guards apply to **every** entry path — the bare CLI, scripts/
 ## MCP Server (AI agents)
 
 `olk mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io) server over **stdio**, exposing a **curated, read-first** set of tools to MCP clients (Claude Desktop, IDEs, agents). It reuses your existing olk login — no separate auth.
-
-**Why this server stands out:**
-- **Read-first with tiered, per-tool opt-in.** Reads work out of the box; every mutation is off by default, and four separate escalating gates (`--allow-write` → `--allow-send` → `--allow-destructive`) mean granting reads or safe edits never silently grants the ability to send mail or delete data.
-- **Guarantees that hold everywhere.** `--no-write`/`--no-send` are enforced once at the API layer, so the same safety promise covers the CLI, scripts, and MCP — a disabled capability is never even advertised as a tool.
-- **Built-in prompt-injection defense.** External free text (subjects, bodies, sender names, file names) is wrapped in per-response, forge-resistant markers with an inline directive telling the agent to treat it as data, not instructions.
-- **Broad and efficient.** Mail, calendar, contacts, tasks, **and** OneDrive files plus directory/people search — with incremental delta sync, `$batch` fetches, conversation threading, a token-saving concise mode, output caps, and structured `{code, message, action}` errors agents can branch on.
-- **Personal *and* enterprise accounts**, a single static binary, and no networked HTTP surface (stdio only).
 
 ```jsonc
 // Claude Desktop / MCP client config
@@ -369,7 +371,7 @@ It's also published to the [MCP Registry](https://registry.modelcontextprotocol.
 
 Either way, run `olk auth login` once first so the server has a token to reuse.
 
-- **Read-only by default.** A curated set of 38 read tools is exposed; destructive and send commands have **no** MCP exposure path at all:
+- **Read-only by default.** Starting the server with no flags exposes a curated set of 38 read tools and nothing else; every mutation is opt-in, per tier (safe writes, then send, then destructive — see below):
   - **Mail:** `mail_list`, `mail_get`, `mail_batch`, `mail_thread`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`, `mail_delta`
   - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_calendars`, `calendar_availability`, `calendar_find_times`, `calendar_delta`
   - **Contacts:** `contacts_list`, `contacts_get`, `contacts_search`, `contacts_delta`
@@ -417,6 +419,9 @@ olk auth status                                      Check token validity
 ```
 olk mail list [-n 25] [-f FOLDER] [-u] [--from X] [--after DATE] [--before DATE] [--focused] [--other]
 olk mail get <ID> [--format full|text|html]
+olk mail batch --id <ID> [--id <ID>]...                  Fetch up to 20 messages in one $batch request
+olk mail thread <CONVERSATION_ID> [-n 50]                List all messages in a conversation
+olk mail delta [-f FOLDER] [--token TOKEN] [-n N]        Incremental sync; returns changes + next token
 olk mail send --to X --subject Y [--body Z] [--cc X] [--bcc X] [--html] [--attach FILE] [--importance low|normal|high] [--read-receipt]
 olk mail search <QUERY> [-n 25]
 olk mail reply <ID> --body X [--reply-all]
@@ -454,6 +459,7 @@ olk mail rules delete <ID> --force                   Delete an inbox rule
 ```
 olk calendar events [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 25]
 olk calendar view [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 50]
+olk calendar delta [-d 30] [--after DATE] [--before DATE] [--token TOKEN] [-n N]  Incremental sync of events
 olk calendar get <ID>
 olk calendar create --subject X --start Y --end Z [--location L] [--attendees A] [--all-day] [--online-meeting] [-r daily|weekdays|weekly|monthly|yearly]
 olk calendar update <ID> [--subject X] [--start Y] [--end Z] [--location L]
@@ -475,6 +481,7 @@ olk people search <QUERY> [-n 25]
 ```
 olk contacts list [-n 25] [--skip N] [--sort displayName|givenName|surname]
 olk contacts get <ID>
+olk contacts delta [--token TOKEN] [-n N]            Incremental sync of contacts
 olk contacts create --first-name X --last-name Y [-e EMAIL]... [-p MOBILE] [--business-phone P] [--home-phone P] [--company C] [--title T] [--department D] [--manager M] [--birthday YYYY-MM-DD] [--notes N] [--middle-name M] [--nickname N] [-g CATEGORY]... [--street S] [--city C] [--state S] [--postal-code P] [--country C] [--address-type business|home|other]
 olk contacts update <ID> [--first-name X] [--last-name Y] [-e EMAIL]... [-p MOBILE] [--business-phone P] [--home-phone P] [--company C] [--title T] [--department D] [--manager M] [--birthday YYYY-MM-DD] [--notes N] [--middle-name M] [--nickname N] [-g CATEGORY]... [--street S] [--city C] [--state S] [--postal-code P] [--country C] [--address-type business|home|other]
 olk contacts delete <ID> [--force]
@@ -528,6 +535,14 @@ olk drive versions <ID> [--drive-id ID]              List version history
 ```
 
 If `--drive-id` is omitted, your primary drive is used.
+
+### Sync (delta)
+
+```
+olk changes [--mail-token T] [--calendar-token T] [--contacts-token T] [--days 30] [-n N]   Unified delta digest across mail, calendar, and contacts (each with its own token)
+```
+
+Per-resource delta commands live under their service: `olk mail delta`, `olk calendar delta`, `olk contacts delta`. Omit a token for a fresh sync, then pass the returned token next time to get only what changed; deletions are reported as `removed` items.
 
 ### Configuration
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -22,7 +22,7 @@ func selectedCommandPath(kctx *kong.Context) []string {
 }
 
 // commandAllowed reports whether a command path may run under the active
-// allow/deny lists. Semantics mirror gog:
+// allow/deny lists:
 //   - --disable-commands blocks a path or any descendant (overrides allows).
 //   - --enable-commands allows a prefix and its descendants.
 //   - --enable-commands-exact allows only that exact path (no descendants).
@@ -59,8 +59,8 @@ func commandAllowed(flags *RootFlags, path []string) bool {
 	return false
 }
 
-// toolSelectorPredicate compiles gog-style --allow-tool selectors into a
-// predicate over (tool name, readOnly). Selectors narrow the curated set by
+// toolSelectorPredicate compiles --allow-tool selectors into a predicate over
+// (tool name, readOnly). Selectors narrow the curated set by
 // tool name; they never grant a write tool that --allow-write hasn't already
 // enabled. Returns nil when no selectors are given (allow all). Supported
 // forms, matched case-insensitively with '.' treated as '_':

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -12,11 +12,10 @@ import (
 )
 
 // MCPCmd runs a stdio MCP server exposing a curated, read-first set of olk
-// commands as tools (mirroring gog's "typed tools, no arbitrary command
-// bridge" model). The server is read-only by default; write tools are exposed
-// only when named explicitly via --allow-write (defense in depth: opting into
-// MCP and naming each write tool are two separate, conscious actions). There is
-// intentionally no HTTP transport.
+// commands as typed tools — there is no arbitrary command bridge. The server is
+// read-only by default; write tools are exposed only when named explicitly via
+// --allow-write (defense in depth: opting into MCP and naming each write tool
+// are two separate, conscious actions). There is intentionally no HTTP transport.
 //
 // Tool calls are executed in-process and serialized (one at a time), because
 // capturing command output requires temporarily redirecting the process stdout.

--- a/internal/cmd/mcp_invoke.go
+++ b/internal/cmd/mcp_invoke.go
@@ -26,8 +26,8 @@ func makeHandler(b *toolBinding) mcp.ToolHandler {
 			}
 		}
 
-		// Reject arguments the tool doesn't declare (gog's "unknown fields
-		// rejected" contract) so a model can't smuggle in unvetted flags.
+		// Reject arguments the tool doesn't declare (fixed-schema contract) so a
+		// model can't smuggle in unvetted flags.
 		if err := rejectUnknownArgs(b, args); err != nil {
 			return errorResult(err.Error()), nil
 		}
@@ -93,7 +93,7 @@ func makeHandler(b *toolBinding) mcp.ToolHandler {
 }
 
 // rejectUnknownArgs fails the call if args carries a key the tool's schema does
-// not declare, matching gog's fixed-schema contract.
+// not declare (fixed-schema contract).
 func rejectUnknownArgs(b *toolBinding, args map[string]any) error {
 	if len(args) == 0 {
 		return nil

--- a/internal/cmd/mcp_invoke_test.go
+++ b/internal/cmd/mcp_invoke_test.go
@@ -142,7 +142,7 @@ func TestRejectUnknownArgs(t *testing.T) {
 	if err := rejectUnknownArgs(b, map[string]any{"top": float64(5)}); err != nil {
 		t.Errorf("declared flag rejected: %v", err)
 	}
-	// An undeclared key is rejected (gog fixed-schema contract).
+	// An undeclared key is rejected (fixed-schema contract).
 	if err := rejectUnknownArgs(b, map[string]any{"bogus": "x"}); err == nil {
 		t.Error("expected error for unknown argument, got nil")
 	}

--- a/internal/cmd/mcp_server.go
+++ b/internal/cmd/mcp_server.go
@@ -25,8 +25,8 @@ const (
 )
 
 // curatedTool maps an MCP tool name to the olk leaf command it runs. The set is
-// hand-picked and read-first (gog's model) rather than reflecting the whole CLI,
-// so a new command is never auto-exposed to an agent.
+// hand-picked and read-first rather than reflecting the whole CLI, so a new
+// command is never auto-exposed to an agent.
 type curatedTool struct {
 	name string
 	path []string
@@ -145,8 +145,7 @@ func (cfg mcpConfig) exposes(ct curatedTool) bool {
 }
 
 // defaultMaxOutputBytes bounds a single tool call's returned text so a runaway
-// list can't flood the agent's context or the stdio transport (gog's
-// --max-output-bytes default).
+// list can't flood the agent's context or the stdio transport.
 const defaultMaxOutputBytes = 100_000
 
 // helpFlagName is kong's auto-injected --help flag, skipped when projecting a

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,7 +46,7 @@ type RootFlags struct {
 	NoInput       bool `help:"Fail instead of prompting (headless/agent safety)" env:"OLK_NO_INPUT"`
 	WrapUntrusted bool `help:"Wrap external free-text in untrusted-content markers (JSON/plain output)" env:"OLK_WRAP_UNTRUSTED"`
 
-	// Command-scoping (gog-style allow/deny lists, comma-separated dotted paths).
+	// Command-scoping allow/deny lists (comma-separated dotted paths).
 	EnableCommands      string `help:"Allow only these command prefixes (csv; e.g. mail,calendar)" env:"OLK_ENABLE_COMMANDS"`
 	EnableCommandsExact string `help:"Allow only these exact command paths (csv; e.g. mail.list,mail.get)" env:"OLK_ENABLE_COMMANDS_EXACT"`
 	DisableCommands     string `help:"Block these command paths (csv; overrides allows)" env:"OLK_DISABLE_COMMANDS"`
@@ -233,8 +233,8 @@ func Execute() int {
 		Flags: &cli.RootFlags,
 	}
 
-	// Command allow/deny lists gate dispatch (gog-style). Applies to the bare
-	// CLI; the MCP server reuses the same predicate to filter its tool registry.
+	// Command allow/deny lists gate dispatch. Applies to the bare CLI; the MCP
+	// server reuses the same predicate to filter its tool registry.
 	if path := selectedCommandPath(ctx); !commandAllowed(&cli.RootFlags, path) {
 		fmt.Fprintf(os.Stderr, "Error: command %q is not allowed by --enable-commands/--disable-commands\n", strings.Join(path, " "))
 		return 1


### PR DESCRIPTION
## Context

Two cleanups: scrub the remaining external-project references from the repo, and bring the README fully in line with the current feature set.

## Changes
- **Neutral comments** — remove the remaining third-party-project references from code comments (`commands.go`, `mcp.go`, `mcp_invoke.go`, `mcp_server.go`, `root.go`, one test); same behavior, neutral wording. The repo now has zero references to any other project (`git grep` confirms).
- **Remove** the "Why this server stands out" block from the README.
- **README accuracy pass:**
  - Fix the MCP intro that still claimed send/delete have "no MCP exposure path" — they are now opt-in per tier (safe-write → send → destructive).
  - Add delta sync, `mail batch`, and conversation threading to **Key Capabilities**; add a **Sync** section for `olk changes`.
  - Add `--mailbox` and `--concise` to the **Global Flags** table.
  - Add `mail batch`/`thread`/`delta`, `calendar delta`, `contacts delta`, and `olk changes` to the **Commands Reference**.

Docs/comments only — no behavior change. `go build`, full `go test ./...`, and `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)