### PR TITLE
fix(security): guard 3 unguarded mutations + wrap all prose output as untrusted

### DIFF
--- a/internal/graphapi/availability.go
+++ b/internal/graphapi/availability.go
@@ -21,7 +21,7 @@ type ScheduleItem struct {
 	Status  string `json:"status"`
 	Start   string `json:"start"`
 	End     string `json:"end"`
-	Subject string `json:"subject,omitempty"`
+	Subject string `json:"subject,omitempty" untrusted:"true"`
 }
 
 // GetSchedule retrieves free/busy availability for the specified email addresses

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -26,7 +26,7 @@ type CalendarEvent struct {
 	Attendees   []string `json:"attendees,omitempty" untrusted:"true" concise:"omit"`
 	IsAllDay    bool     `json:"isAllDay"`
 	IsOnline    bool     `json:"isOnlineMeeting"`
-	OnlineURL   string   `json:"onlineMeetingUrl,omitempty"`
+	OnlineURL   string   `json:"onlineMeetingUrl,omitempty" untrusted:"true"`
 	Status      string   `json:"showAs"`
 	Recurrence  string   `json:"recurrence,omitempty"`
 	BodyPreview string   `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
@@ -36,9 +36,9 @@ type CalendarEvent struct {
 // CalendarInfo is a simplified calendar representation
 type CalendarInfo struct {
 	ID    string `json:"id"`
-	Name  string `json:"name"`
+	Name  string `json:"name" untrusted:"true"`
 	Color string `json:"color"`
-	Owner string `json:"owner"`
+	Owner string `json:"owner" untrusted:"true"`
 }
 
 // ListEvents returns calendar events in [startTime, endTime] from the target

--- a/internal/graphapi/categories.go
+++ b/internal/graphapi/categories.go
@@ -10,7 +10,7 @@ import (
 // Category is a simplified outlook category for output
 type Category struct {
 	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName" untrusted:"true"`
 	Color       string `json:"color"`
 }
 

--- a/internal/graphapi/drafts.go
+++ b/internal/graphapi/drafts.go
@@ -11,9 +11,9 @@ import (
 // DraftMessage is a simplified draft message for output
 type DraftMessage struct {
 	ID      string   `json:"id"`
-	Subject string   `json:"subject"`
-	To      []string `json:"to"`
-	Body    string   `json:"body,omitempty"`
+	Subject string   `json:"subject" untrusted:"true"`
+	To      []string `json:"to" untrusted:"true"`
+	Body    string   `json:"body,omitempty" untrusted:"true"`
 	Created string   `json:"createdDateTime"`
 }
 

--- a/internal/graphapi/drive.go
+++ b/internal/graphapi/drive.go
@@ -19,7 +19,7 @@ var safeDriveSearchQuery = regexp.MustCompile(`^[\p{L}\p{N} @._-]+$`)
 // DriveInfo is a simplified drive for output.
 type DriveInfo struct {
 	ID             string `json:"id"`
-	Name           string `json:"name"`
+	Name           string `json:"name" untrusted:"true"`
 	DriveType      string `json:"driveType"`
 	QuotaTotal     int64  `json:"quotaTotal"`
 	QuotaUsed      int64  `json:"quotaUsed"`
@@ -511,6 +511,9 @@ func (c *Client) CreateFolder(ctx context.Context, driveID, parentItemID, folder
 
 // CopyDriveItem initiates an async copy of an item to a new parent.
 func (c *Client) CopyDriveItem(ctx context.Context, driveID, itemID, destParentID, newName string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	if err := validateID(driveID, "drive ID"); err != nil {
 		return err
 	}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -45,7 +45,7 @@ type MailMessage struct {
 	ID             string   `json:"id"`
 	Subject        string   `json:"subject" untrusted:"true"`
 	From           string   `json:"from" untrusted:"true"`
-	To             []string `json:"to"`
+	To             []string `json:"to" untrusted:"true"`
 	ReceivedAt     string   `json:"receivedDateTime"`
 	IsRead         bool     `json:"isRead"`
 	HasAttachments bool     `json:"hasAttachments"`
@@ -66,7 +66,7 @@ var messageDetailSelect = []string{
 // MailFolder is a simplified folder representation
 type MailFolder struct {
 	ID             string `json:"id"`
-	DisplayName    string `json:"displayName"`
+	DisplayName    string `json:"displayName" untrusted:"true"`
 	TotalCount     int32  `json:"totalItemCount"`
 	UnreadCount    int32  `json:"unreadItemCount"`
 	ParentFolderID string `json:"parentFolderId,omitempty"`
@@ -363,6 +363,9 @@ func (c *Client) DeleteMessage(ctx context.Context, messageID string) error {
 }
 
 func (c *Client) MarkMessage(ctx context.Context, messageID string, isRead bool) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	if err := validateID(messageID, "message ID"); err != nil {
 		return err
 	}
@@ -497,7 +500,7 @@ func (c *Client) SearchMessages(ctx context.Context, target, query string, top i
 // Attachment represents a mail attachment
 type Attachment struct {
 	ID          string `json:"id"`
-	Name        string `json:"name"`
+	Name        string `json:"name" untrusted:"true"`
 	ContentType string `json:"contentType"`
 	Size        int32  `json:"size"`
 	Content     []byte `json:"-"`

--- a/internal/graphapi/mail_rules.go
+++ b/internal/graphapi/mail_rules.go
@@ -17,7 +17,7 @@ const (
 // MailRule is a simplified message rule for output
 type MailRule struct {
 	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName" untrusted:"true"`
 	Sequence    int32  `json:"sequence"`
 	IsEnabled   bool   `json:"isEnabled"`
 	Conditions  string `json:"conditions"`

--- a/internal/graphapi/people.go
+++ b/internal/graphapi/people.go
@@ -15,11 +15,11 @@ var safePeopleQuery = regexp.MustCompile(`^[\p{L}\p{N} @._-]+$`)
 
 // Person is a simplified person for output
 type Person struct {
-	DisplayName string `json:"displayName"`
-	Email       string `json:"email"`
-	JobTitle    string `json:"jobTitle,omitempty"`
-	Department  string `json:"department,omitempty"`
-	Company     string `json:"companyName,omitempty"`
+	DisplayName string `json:"displayName" untrusted:"true"`
+	Email       string `json:"email" untrusted:"true"`
+	JobTitle    string `json:"jobTitle,omitempty" untrusted:"true"`
+	Department  string `json:"department,omitempty" untrusted:"true"`
+	Company     string `json:"companyName,omitempty" untrusted:"true"`
 }
 
 func (c *Client) SearchPeople(ctx context.Context, query string, top int32) ([]Person, error) {

--- a/internal/graphapi/security_invariants_test.go
+++ b/internal/graphapi/security_invariants_test.go
@@ -1,0 +1,155 @@
+package graphapi
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// mutatingVerbs are the SDK request-builder methods that change server state.
+var mutatingVerbs = map[string]bool{"Post": true, "Patch": true, "Put": true, "Delete": true}
+
+// readOnlyMutationException lists *Client methods that call a "mutating" verb
+// but are actually read-only (e.g. a POST query). Add to this set ONLY with a
+// justification comment — never to silence a genuinely-mutating method.
+var readOnlyMutationException = map[string]bool{
+	"FindMeetingTimes": true, // POST /me/findMeetingTimes is a read-only query
+}
+
+// TestEveryMutationIsGuarded is a security invariant: every *Client method that
+// performs a mutating Graph call (Post/Patch/Put/Delete) must call
+// ensureWritable or ensureMaySend, so the --no-write / --no-send guarantee
+// cannot silently regress when a new mutation is added. This caught three
+// unguarded methods (MarkMessage, CopyDriveItem, ToggleChecklistItem).
+func TestEveryMutationIsGuarded(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !isClientMethod(fn) {
+				continue
+			}
+			var mutates, guards bool
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				switch {
+				case mutatingVerbs[sel.Sel.Name]:
+					mutates = true
+				case sel.Sel.Name == "ensureWritable" || sel.Sel.Name == "ensureMaySend":
+					guards = true
+				}
+				return true
+			})
+			if mutates && !guards && !readOnlyMutationException[fn.Name.Name] {
+				t.Errorf("%s (%s) performs a mutating Graph call but never calls ensureWritable/ensureMaySend — "+
+					"add the guard, or add it to readOnlyMutationException with justification", fn.Name.Name, file)
+			}
+		}
+	}
+}
+
+func isClientMethod(fn *ast.FuncDecl) bool {
+	if fn.Recv == nil || len(fn.Recv.List) != 1 {
+		return false
+	}
+	star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	id, ok := star.X.(*ast.Ident)
+	return ok && id.Name == "Client"
+}
+
+// proseFreeText is the set of result-struct json field names that carry
+// externally-authored prose (subjects, names, bodies, locations, …) and so MUST
+// be wrapped under --wrap-untrusted to defend an agent against prompt injection.
+var proseFreeText = map[string]bool{
+	"subject": true, "from": true, "to": true, "sender": true, "bodyPreview": true,
+	"body": true, "displayName": true, "givenName": true, "surname": true,
+	"middleName": true, "nickName": true, "name": true, "title": true,
+	"location": true, "organizer": true, "attendees": true, "companyName": true,
+	"jobTitle": true, "department": true, "officeLocation": true, "profession": true,
+	"manager": true, "assistantName": true, "personalNotes": true, "spouseName": true,
+	"children": true, "businessHomePage": true, "parentPath": true, "createdBy": true,
+	"modifiedBy": true, "owner": true,
+}
+
+var jsonNameRe = regexp.MustCompile(`json:"([^",]+)`)
+
+// TestProseFieldsAreUntrusted is a security invariant: every exported
+// string/[]string struct field in the graphapi package whose json name is a
+// known prose free-text name must carry `untrusted:"true"`. This prevents a new
+// result field (e.g. a new attachment/sender/subject) from reaching an agent
+// outside the [UNTRUSTED] markers. Input structs have no json tags, so they're
+// naturally excluded.
+func TestProseFieldsAreUntrusted(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			st, ok := n.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			for _, field := range st.Fields.List {
+				if field.Tag == nil || !isStringish(field.Type) {
+					continue
+				}
+				tag := field.Tag.Value
+				m := jsonNameRe.FindStringSubmatch(tag)
+				if len(m) < 2 || !proseFreeText[m[1]] {
+					continue
+				}
+				if !strings.Contains(reflect.StructTag(strings.Trim(tag, "`")).Get("untrusted"), "true") {
+					name := "?"
+					if len(field.Names) > 0 {
+						name = field.Names[0].Name
+					}
+					t.Errorf("%s: field %s (json:%q) is prose free-text but lacks untrusted:\"true\" — "+
+						"tag it so it's wrapped for agents", file, name, m[1])
+				}
+			}
+			return true
+		})
+	}
+}
+
+func isStringish(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "string"
+	case *ast.ArrayType:
+		id, ok := e.Elt.(*ast.Ident)
+		return ok && id.Name == "string"
+	}
+	return false
+}

--- a/internal/graphapi/todo.go
+++ b/internal/graphapi/todo.go
@@ -21,7 +21,7 @@ func parseDate(s string) (time.Time, error) {
 // TodoList is a simplified task list for output
 type TodoList struct {
 	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName" untrusted:"true"`
 	IsOwner     bool   `json:"isOwner"`
 }
 
@@ -46,7 +46,7 @@ type TodoTask struct {
 // TodoChecklistItem is a simplified checklist item for output
 type TodoChecklistItem struct {
 	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName" untrusted:"true"`
 	IsChecked   bool   `json:"isChecked"`
 	CreatedAt   string `json:"createdDateTime,omitempty"`
 }
@@ -54,7 +54,7 @@ type TodoChecklistItem struct {
 // TodoAttachment is a simplified attachment for output
 type TodoAttachment struct {
 	ID          string `json:"id"`
-	Name        string `json:"name"`
+	Name        string `json:"name" untrusted:"true"`
 	ContentType string `json:"contentType"`
 	Size        int32  `json:"size"`
 }
@@ -62,7 +62,7 @@ type TodoAttachment struct {
 // TodoLinkedResource is a simplified linked resource for output
 type TodoLinkedResource struct {
 	ID              string `json:"id"`
-	DisplayName     string `json:"displayName"`
+	DisplayName     string `json:"displayName" untrusted:"true"`
 	ApplicationName string `json:"applicationName"`
 	ExternalID      string `json:"externalId"`
 	WebURL          string `json:"webUrl"`
@@ -620,6 +620,9 @@ func (c *Client) DeleteChecklistItem(ctx context.Context, listID, taskID, itemID
 
 // ToggleChecklistItem toggles the IsChecked state of a checklist item.
 func (c *Client) ToggleChecklistItem(ctx context.Context, listID, taskID, itemID string) (*TodoChecklistItem, error) {
+	if err := c.ensureWritable(); err != nil {
+		return nil, err
+	}
 	if err := validateID(listID, "list ID"); err != nil {
 		return nil, err
 	}

--- a/internal/graphapi/user.go
+++ b/internal/graphapi/user.go
@@ -10,12 +10,12 @@ import (
 
 // UserProfile is a simplified user profile for output
 type UserProfile struct {
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName" untrusted:"true"`
 	Email       string `json:"mail"`
 	UPN         string `json:"userPrincipalName"`
-	JobTitle    string `json:"jobTitle,omitempty"`
-	Department  string `json:"department,omitempty"`
-	Office      string `json:"officeLocation,omitempty"`
+	JobTitle    string `json:"jobTitle,omitempty" untrusted:"true"`
+	Department  string `json:"department,omitempty" untrusted:"true"`
+	Office      string `json:"officeLocation,omitempty" untrusted:"true"`
 	Phone       string `json:"businessPhones,omitempty"`
 }
 


### PR DESCRIPTION
Closes the two highest findings from the security audit, each with a regression test.

## HIGH — `--no-write` bypass (3 unguarded mutations)
`MarkMessage`, `CopyDriveItem`, and `ToggleChecklistItem` issued PATCH/POST calls **without** `ensureWritable()`, so `OLK_NO_WRITE=1` was silently ignored for `mail mark`, `drive cp`, and `todo checklist toggle` on the CLI/script path (the documented "single enforcement point" guarantee was broken). Added the guard to each.

## MED — incomplete prompt-injection wrapping
Several externally-authored free-text fields reached agents **outside** the `[UNTRUSTED]` markers — most notably inbound **attachment filenames** (`mail_attachments`), plus message recipients, `people_search` results, and meeting URLs. Uniformly tagged every prose result field `untrusted:"true"` so all Graph-returned human text is wrapped under `--wrap-untrusted` (forced on under MCP). 26 fields total (the 8 audit-flagged + 18 for uniform coverage).

## Regression guards — `internal/graphapi/security_invariants_test.go`
- **`TestEveryMutationIsGuarded`** — AST-walks the package; fails if any `*Client` method performing a `Post`/`Patch`/`Put`/`Delete` call lacks `ensureWritable`/`ensureMaySend`. `FindMeetingTimes` (a read-only POST query) is the sole documented exception. This would have caught the HIGH finding and makes a future unguarded mutation a hard test failure.
- **`TestProseFieldsAreUntrusted`** — fails if any `string`/`[]string` result field with a known prose json name lacks `untrusted:"true"`.

`go build`, full `go test ./...`, and `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)