### PR TITLE
chore(deps): build with Go 1.26.4 to clear stdlib advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.5.0
+          # Built with Go >= 1.26 so it can lint a module targeting go 1.26.x
+          # (golangci-lint refuses a target newer than its own build toolchain).
+          version: v2.11.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rlrghb/olkcli
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
Bumps the `go` directive `1.25.0` → **`1.26.4`** so CI (`go-version-file: go.mod`) and goreleaser build the test/release binaries with a patched standard library.

## Why
Closes the four remaining `govulncheck` findings from the security audit — all **DoS/panic class**, fixed only by a newer Go toolchain (not a module bump):
- **GO-2026-4918** — `net/http` HTTP/2 transport infinite loop
- **GO-2026-4971** — `net` Dial/LookupPort NUL-byte panic (Windows)
- **GO-2026-5039** — `net/textproto`
- **GO-2026-5037** — `crypto/x509`

After the bump, `govulncheck ./...` reports **"No vulnerabilities found."**

## Impact
- **End users** (brew / `npx olkcli` / prebuilt binaries): zero — they don't build from source; this only changes the toolchain that *compiles* releases.
- **CI / releases**: `setup-go` installs 1.26.4 and builds with the patched stdlib.
- **Contributors**: need Go ≥ 1.26.4 — auto-downloaded transparently under the default `GOTOOLCHAIN=auto` (verified: a local 1.26.2 auto-upgraded to 1.26.4).
- **Chose 1.26.4 over a 1.25.x patch** for local↔CI parity (the `go` directive is a floor — a 1.25 pin would leave newer local toolchains unpatched/mismatched) and a longer security-support runway.

No code changes — the tree already builds and tests on 1.26.x. `go build`, full `go test ./...`, `golangci-lint`, and `govulncheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)