### PR TITLE
docs: MCP tier-count summary + registry description

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ It's also published to the [MCP Registry](https://registry.modelcontextprotocol.
 
 Either way, run `olk auth login` once first so the server has a token to reuse.
 
+The curated surface is **61 tools across 4 tiers** — 38 read · 12 safe-write · 7 send · 4 destructive — but only the 38 reads are exposed by default; each mutation tier is a separate, explicit opt-in (see below).
+
 - **Read-only by default.** Starting the server with no flags exposes a curated set of 38 read tools and nothing else; every mutation is opt-in, per tier (safe writes, then send, then destructive — see below):
   - **Mail:** `mail_list`, `mail_get`, `mail_batch`, `mail_thread`, `mail_search`, `mail_folders_list`, `mail_attachments`, `mail_categories_list`, `mail_rules_list`, `mail_ooo_get`, `mail_delta`
   - **Calendar:** `calendar_events`, `calendar_view`, `calendar_get`, `calendar_calendars`, `calendar_availability`, `calendar_find_times`, `calendar_delta`

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.rlrghb/outlook",
-  "description": "Read-first Outlook & OneDrive MCP: personal & enterprise mail, calendar, contacts, tasks, files",
+  "description": "Outlook & OneDrive MCP: personal & enterprise tools for mail, calendar, contacts, tasks, files",
   "version": "0.9.5",
   "repository": {
     "url": "https://github.com/rlrghb/olkcli",


### PR DESCRIPTION
- **README**: adds a one-line summary of the curated MCP surface — **61 tools across 4 tiers** (38 read · 12 safe-write · 7 send · 4 destructive), with only the 38 reads exposed by default. Counts are verified against `curatedTools` in the registry.
- **server.json**: updates the MCP Registry description to `Outlook & OneDrive MCP: personal & enterprise tools for mail, calendar, contacts, tasks, files`.

Docs/metadata only.

> Note: the MCP Registry has no in-place edit, so the new `server.json` description takes effect on the **next release** (the version fields are CI-stamped from the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)