### PR TITLE
feat(auth): add browser-based authorization-code + PKCE login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,14 @@
 
 - `cmd/olk/`: CLI entrypoint — minimal, delegates to `internal/cmd.Execute()`.
 - `internal/cmd/`: Command implementations using kong structs. Each command group has its own file(s): `mail_*.go`, `calendar*.go`, `todo.go`, `todo_checklist.go`, `todo_attachments.go`, `todo_links.go`, `whoami.go`, etc.
-- `internal/msauth/`: Microsoft OAuth2 implementation — device code flow, token refresh, credential bridge.
+- `internal/msauth/`: Microsoft OAuth2 implementation — device code flow, authorization-code + PKCE browser flow (loopback listener), token refresh, credential bridge.
 - `internal/graphapi/`: Microsoft Graph API wrapper — mail, calendar, contacts, todo (tasks, checklist items, attachments, linked resources), availability, mailbox settings, mail rules, people. Includes the `targetUser` helper that routes reads to `/me` or `/users/{id}` for delegated mailbox access, and error-shaping helpers (`graphErrorMessage`, `enterpriseError`, `scopeUpgradeError`) in `validate.go`.
-- `internal/config/`: Configuration and XDG paths (`~/.config/olk/`).
+- `internal/config/`: Configuration paths via `os.UserConfigDir` (`~/.config/olk/` on Linux, `~/Library/Application Support/olk/` on macOS, `%AppData%\olk\` on Windows).
 - `internal/secrets/`: OS keyring integration via `99designs/keyring`.
 - `internal/outfmt/`: Output formatting — JSON envelope, aligned tables, TSV, timezone conversion via `ConvertTime()`.
 - `SKILL.md`: [Agent Skills](https://agentskills.io) standard file — teaches AI assistants (Claude Code, OpenClaw, etc.) how to use `olk` commands.
+- `docs/`: user-facing guides — `enterprise-setup.md` walks tenant admins through creating an Entra app registration for `--browser`.
+- `contrib/`: helper scripts — `create-entra-app.sh` automates the Entra app registration, admin consent, and assignment via the `az` CLI.
 - `bin/`: build outputs (gitignored).
 
 ## Build, Test, and Development Commands
@@ -79,8 +81,9 @@
 
 - Never commit OAuth tokens or client secrets.
 - Prefer OS keychain backends; the file fallback is for headless environments only. Set `OLK_KEYRING_PASSWORD` for non-interactive file-backend access.
-- Config dir (`~/.config/olk/`) uses 0700 permissions; token files use 0600.
+- Config dir (`os.UserConfigDir()` + `/olk` — `~/.config/olk/` on Linux, `~/Library/Application Support/olk/` on macOS) uses 0700 permissions; token files use 0600.
 - Device code flow uses PKCE (RFC 7636) — `code_challenge` sent with device code request, `code_verifier` sent during token polling.
+- Browser flow (`--browser`) uses authorization-code + PKCE with a `state` CSRF token; the redirect URI is `http://localhost:{port}` (port-ignored matching is documented for localhost only), the listener binds both loopback families (`127.0.0.1` required, `::1` best-effort) on a dynamic port, validates `state` before accepting any result, and serves generic HTML pages that never echo server-provided strings.
 - Token refresh is serialized per-email via `sync.Map` of mutexes in `internal/msauth/auth.go` to prevent race conditions.
 - KQL search queries are always wrapped in double quotes (Graph `$search` parameter requirement). Property restrictions (`from:`, `subject:`, etc.) and boolean operators work inside the quotes. Literal double-quote characters are stripped from user input to prevent breaking the wrapper. See `internal/graphapi/mail.go`.
 - See `SECURITY.md` for vulnerability disclosure policy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ go mod tidy         # After changing dependencies
 ## Architecture
 
 - **CLI framework**: `github.com/alecthomas/kong` — commands are Go structs with `Run(ctx *RunContext) error`
-- **Auth**: Raw OAuth2 device code flow with PKCE (RFC 7636) against `login.microsoftonline.com` — no MSAL. Scopes defined in `internal/msauth/scopes.go`. Enterprise-only scopes (`MailboxSettings.ReadWrite`, `User.ReadBasic.All`) are only requested with `--enterprise` flag — personal accounts cannot consent to them. Token refresh is serialized per-email via `sync.Map` of mutexes to prevent race conditions
+- **Auth**: Raw OAuth2 against `login.microsoftonline.com` — no MSAL. Two flows: device code (default) and authorization-code + PKCE via system browser with a loopback listener (`--browser`, in `internal/msauth/authcode.go`) for tenants whose Conditional Access requires a compliant device or blocks device code. Both use PKCE (RFC 7636). Scopes defined in `internal/msauth/scopes.go`. Enterprise-only scopes (`MailboxSettings.ReadWrite`, `User.ReadBasic.All`) are only requested with `--enterprise` flag — personal accounts cannot consent to them. Token refresh is serialized per-email via `sync.Map` of mutexes to prevent race conditions
 - **API**: Official `msgraph-sdk-go` wrapped in `internal/graphapi/` for ergonomic access
 - **Secrets**: OS keyring via `github.com/99designs/keyring` (macOS Keychain, Linux Secret Service, Windows WinCred). File-backend password prompt writes to stderr (not stdout) to avoid corrupting piped output. Set `OLK_KEYRING_PASSWORD` for headless/non-interactive use
 - **Output**: JSON envelope (`--json`), aligned table (default), TSV (`--plain`)
@@ -34,7 +34,7 @@ go mod tidy         # After changing dependencies
 - Graph SDK uses pointer types everywhere — always nil-check: `if x.GetFoo() != nil { *x.GetFoo() }`
 - Each command is in its own file: `mail_list.go`, `mail_get.go`, etc.
 - Desire paths in `desire_paths.go` delegate to real commands (e.g. `SendCmd` creates `MailSendCmd`)
-- Config lives at `~/.config/olk/`, tokens in OS keyring keyed by `olk:token:<email>`
+- Config lives under `os.UserConfigDir()` (`~/.config/olk/` on Linux, `~/Library/Application Support/olk/` on macOS), tokens in OS keyring keyed by `olk:token:<email>`
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ Uses an embedded public client ID with device-code flow. The `--enterprise` flag
 
 > **Note:** If you upgrade to a version that adds new features (e.g. OneDrive support), you may need to re-run `olk auth login` to grant the new permissions. If you see "access denied" errors, re-login to refresh your token scopes.
 
+### Browser Sign-In (Auth-Code + PKCE)
+
+```bash
+olk auth login --browser [--client-id YOUR_CLIENT_ID --tenant-id YOUR_TENANT_ID]
+```
+
+`--browser` signs in through your system browser using the OAuth2 authorization-code flow with PKCE and a loopback redirect, instead of device code. Use it when your tenant's Conditional Access policies require a compliant/managed device or block device code flow: the browser session can carry device identity (via Platform SSO or Windows SSO on managed devices), so sign-in satisfies device-based policies that device code flow cannot.
+
+This flow requires the app registration to have a loopback redirect URI (see [Custom App Registration](#custom-app-registration) step 4). If the browser shows error **AADSTS50011** ("redirect URI mismatch") and the CLI times out, the app registration is missing the redirect URI — use `--client-id` with your own registration.
+
 ### Custom App Registration
 
 If your organization blocks the default client ID, or your admin requires apps to be registered under your tenant, you'll need to create your own app registration:
@@ -204,8 +214,11 @@ If your organization blocks the default client ID, or your admin requires apps t
 1. Go to [Azure Portal > App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) and click **New registration**
 2. Set **Supported account types** to match your needs — use **"Personal Microsoft accounts only"** for outlook.com/hotmail.com, **"Accounts in any organizational directory and personal Microsoft accounts"** for both, or single-tenant for org-only
 3. Under **Authentication > Advanced settings**, set **Allow public client flows** to **Yes** (required for device-code flow)
-4. Under **API permissions**, add **Microsoft Graph** delegated permissions: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`, `Files.ReadWrite`, `People.Read`, `User.Read`, `User.ReadBasic.All`, `MailboxSettings.ReadWrite`, `offline_access` (use `Files.Read` instead of `Files.ReadWrite` for read-only access)
-5. Copy the **Application (client) ID** from the app's Overview page
+4. For browser sign-in (`--browser`), register the loopback redirect URI: under **Authentication > Add a platform > Mobile and desktop applications**, add `http://localhost/callback`. Entra ignores the port when matching `http://localhost` redirect URIs, so no port is needed — `olk` picks a free port at login time. Device-code flow needs only step 3.
+5. Under **API permissions**, add **Microsoft Graph** delegated permissions: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`, `Files.ReadWrite`, `People.Read`, `User.Read`, `User.ReadBasic.All`, `MailboxSettings.ReadWrite`, `offline_access` (use `Files.Read` instead of `Files.ReadWrite` for read-only access)
+6. Copy the **Application (client) ID** from the app's Overview page
+
+Tenant admins who prefer to script the whole thing — registration, permission GUIDs, admin consent, user/group assignment — can use [`contrib/create-entra-app.sh`](contrib/create-entra-app.sh); [docs/enterprise-setup.md](docs/enterprise-setup.md) walks through what it does and the roles each step needs.
 
 Then use it:
 
@@ -409,7 +422,7 @@ See [Global Flags](#global-flags) for the full guard list (`--no-write`, `--no-s
 ### Auth
 
 ```
-olk auth login [--enterprise] [--client-id ID] [--tenant-id ID]  Login via device code
+olk auth login [--browser] [--enterprise] [--client-id ID] [--tenant-id ID]  Login via device code (or browser PKCE)
 olk auth logout [EMAIL]                              Remove stored credentials
 olk auth clean --force                               Remove ALL accounts and tokens
 olk auth list                                        List authenticated accounts
@@ -561,10 +574,10 @@ olk whoami                                           Display current user info
 
 ## Configuration
 
-Config is stored at `~/.config/olk/`:
+Config is stored in your OS's user-config directory: `~/.config/olk/` on Linux, `~/Library/Application Support/olk/` on macOS, `%AppData%\olk\` on Windows:
 
 ```
-~/.config/olk/
+<config-dir>/
 ├── config.json          # Default account, client IDs
 └── accounts/            # Account metadata (email, display name)
     └── user@example.com.json

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,6 +50,7 @@ Always get IDs from a `list` / `search` first — never invent them.
 
 ```bash
 olk auth login                                  # device-code OAuth2 (personal; opens browser)
+olk auth login --browser                        # browser auth-code+PKCE; use when Conditional Access requires a compliant device or blocks device code
 olk auth login --enterprise                     # enterprise scopes (OOO, inbox rules, directory search)
 olk auth login --client-id ID --tenant-id ID    # enterprise custom app registration
 olk auth login --scope Mail.Read.Shared --scope Calendars.Read.Shared --scope Contacts.Read.Shared

--- a/contrib/create-entra-app.sh
+++ b/contrib/create-entra-app.sh
@@ -13,8 +13,10 @@ set -euo pipefail
 #   SCOPES           space-separated scopes   (default: full olk --enterprise set)
 #   GROUP_OBJECT_ID  group object ID to assign
 #   ASSIGN_USERS     space-separated user UPNs (or object IDs) to assign
+#   ALLOW_ALL_TENANT_USERS=1 to intentionally allow any tenant user to sign in
 # Providing either assignment variable also sets appRoleAssignmentRequired=true,
-# so ONLY the assigned principals can sign in through the app.
+# so ONLY the assigned principals can sign in through the app. Without an
+# assignment, ALLOW_ALL_TENANT_USERS=1 is required as an explicit opt-in.
 #
 # Finding IDs:
 #   your own UPN:      az ad signed-in-user show --query userPrincipalName -o tsv
@@ -28,6 +30,15 @@ TENANT_ID="${TENANT_ID:?Set TENANT_ID=<your directory (tenant) ID>}"
 APP_NAME="${APP_NAME:-olk CLI}"
 SCOPES="${SCOPES:-offline_access User.Read Mail.ReadWrite Mail.Send Calendars.ReadWrite Contacts.ReadWrite Tasks.ReadWrite Files.ReadWrite People.Read User.ReadBasic.All MailboxSettings.ReadWrite}"
 GRAPH_SP="00000003-0000-0000-c000-000000000000"
+
+if [ -z "${GROUP_OBJECT_ID:-}" ] &&
+  [ -z "${ASSIGN_USERS:-}" ] &&
+  [ "${ALLOW_ALL_TENANT_USERS:-}" != "1" ]; then
+  echo "error: no user or group assignment configured." >&2
+  echo "Set GROUP_OBJECT_ID or ASSIGN_USERS to restrict access." >&2
+  echo "To intentionally allow every tenant user, set ALLOW_ALL_TENANT_USERS=1." >&2
+  exit 1
+fi
 
 current_tenant=$(az account show --query tenantId -o tsv 2>/dev/null || true)
 if [ "$current_tenant" != "$TENANT_ID" ]; then
@@ -103,7 +114,7 @@ if [ -n "${GROUP_OBJECT_ID:-}" ] || [ -n "${ASSIGN_USERS:-}" ]; then
     assign_principal "$user_id"
   done
 else
-  echo "==> Skipping assignment: any tenant user can sign in through this app."
+  echo "==> Explicitly allowing any tenant user to sign in through this app."
   echo "    Restrict later with GROUP_OBJECT_ID=<guid> or ASSIGN_USERS=\"a@x.com b@x.com\","
   echo "    or in one line per user:"
   echo "    az ad sp update --id $APP_ID --set appRoleAssignmentRequired=true"

--- a/contrib/create-entra-app.sh
+++ b/contrib/create-entra-app.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates the "olk CLI" Entra app registration + service principal, adds the
+# delegated Graph permissions, grants admin consent, and (optionally) requires
+# and performs group assignment. See docs/enterprise-setup.md for the walkthrough.
+#
+# Usage:
+#   TENANT_ID=<tenant-guid> ./contrib/create-entra-app.sh
+#
+# Optional environment overrides:
+#   APP_NAME         display name             (default: "olk CLI")
+#   SCOPES           space-separated scopes   (default: full olk --enterprise set)
+#   GROUP_OBJECT_ID  group object ID to assign
+#   ASSIGN_USERS     space-separated user UPNs (or object IDs) to assign
+# Providing either assignment variable also sets appRoleAssignmentRequired=true,
+# so ONLY the assigned principals can sign in through the app.
+#
+# Finding IDs:
+#   your own UPN:      az ad signed-in-user show --query userPrincipalName -o tsv
+#   a group's ID:      az ad group show --group "<display name>" --query id -o tsv
+#   browse groups:     az ad group list --query "[].{name:displayName,id:id}" -o table
+#
+# Requires: az CLI, logged in (az login --tenant $TENANT_ID) as a user who can
+# create applications; admin consent additionally needs Global Administrator.
+
+TENANT_ID="${TENANT_ID:?Set TENANT_ID=<your directory (tenant) ID>}"
+APP_NAME="${APP_NAME:-olk CLI}"
+SCOPES="${SCOPES:-offline_access User.Read Mail.ReadWrite Mail.Send Calendars.ReadWrite Contacts.ReadWrite Tasks.ReadWrite Files.ReadWrite People.Read User.ReadBasic.All MailboxSettings.ReadWrite}"
+GRAPH_SP="00000003-0000-0000-c000-000000000000"
+
+current_tenant=$(az account show --query tenantId -o tsv 2>/dev/null || true)
+if [ "$current_tenant" != "$TENANT_ID" ]; then
+  echo "error: az is logged into tenant '${current_tenant:-none}', expected '$TENANT_ID'." >&2
+  echo "Run: az login --tenant $TENANT_ID" >&2
+  exit 1
+fi
+
+echo "==> Creating app registration '$APP_NAME' (single-tenant public client)"
+APP_ID=$(az ad app create \
+  --display-name "$APP_NAME" \
+  --sign-in-audience AzureADMyOrg \
+  --public-client-redirect-uris "http://localhost/callback" \
+  --is-fallback-public-client true \
+  --query appId -o tsv)
+echo "    appId: $APP_ID"
+
+echo "==> Resolving Graph delegated-permission IDs for: $SCOPES"
+perms=()
+for scope in $SCOPES; do
+  perm_id=$(az ad sp show --id "$GRAPH_SP" \
+    --query "oauth2PermissionScopes[?value=='$scope'].id | [0]" -o tsv)
+  if [ -z "$perm_id" ] || [ "$perm_id" = "None" ]; then
+    echo "error: could not resolve Graph delegated scope '$scope'" >&2
+    exit 1
+  fi
+  echo "    $scope = $perm_id"
+  perms+=("$perm_id=Scope")
+done
+
+echo "==> Adding API permissions to the app registration"
+az ad app permission add --id "$APP_ID" --api "$GRAPH_SP" --api-permissions "${perms[@]}" \
+  --only-show-errors
+
+echo "==> Creating service principal (Enterprise application)"
+SP_ID=$(az ad sp create --id "$APP_ID" --query id -o tsv)
+echo "    servicePrincipal objectId: $SP_ID"
+
+echo "==> Granting admin consent (requires Global Administrator)"
+# Directory writes propagate asynchronously; retry briefly before failing.
+for attempt in 1 2 3 4 5; do
+  if az ad app permission admin-consent --id "$APP_ID" --only-show-errors; then
+    break
+  fi
+  if [ "$attempt" = 5 ]; then
+    echo "error: admin consent failed after $attempt attempts." >&2
+    echo "Retry manually: az ad app permission admin-consent --id $APP_ID" >&2
+    exit 1
+  fi
+  echo "    not ready yet (attempt $attempt), retrying in 10s..."
+  sleep 10
+done
+
+# assign_principal grants a user or group the default access role on the app.
+assign_principal() {
+  az rest --method POST \
+    --url "https://graph.microsoft.com/v1.0/servicePrincipals/$SP_ID/appRoleAssignedTo" \
+    --body "{\"principalId\":\"$1\",\"resourceId\":\"$SP_ID\",\"appRoleId\":\"00000000-0000-0000-0000-000000000000\"}" \
+    --only-show-errors >/dev/null
+}
+
+if [ -n "${GROUP_OBJECT_ID:-}" ] || [ -n "${ASSIGN_USERS:-}" ]; then
+  echo "==> Requiring assignment (only assigned principals may use the app)"
+  az ad sp update --id "$APP_ID" --set appRoleAssignmentRequired=true
+
+  if [ -n "${GROUP_OBJECT_ID:-}" ]; then
+    echo "    assigning group $GROUP_OBJECT_ID"
+    assign_principal "$GROUP_OBJECT_ID"
+  fi
+  for upn in ${ASSIGN_USERS:-}; do
+    user_id=$(az ad user show --id "$upn" --query id -o tsv)
+    echo "    assigning user $upn ($user_id)"
+    assign_principal "$user_id"
+  done
+else
+  echo "==> Skipping assignment: any tenant user can sign in through this app."
+  echo "    Restrict later with GROUP_OBJECT_ID=<guid> or ASSIGN_USERS=\"a@x.com b@x.com\","
+  echo "    or in one line per user:"
+  echo "    az ad sp update --id $APP_ID --set appRoleAssignmentRequired=true"
+fi
+
+echo
+echo "==> Done. Verify consent:"
+echo "    az ad app permission list-grants --id $APP_ID --show-resource-name -o table"
+echo
+echo "==> Log in with:"
+echo "    olk auth login --browser --enterprise --client-id $APP_ID --tenant-id $TENANT_ID"

--- a/docs/enterprise-setup.md
+++ b/docs/enterprise-setup.md
@@ -48,7 +48,21 @@ Role requirements:
 Everything below is automated in [`contrib/create-entra-app.sh`](../contrib/create-entra-app.sh):
 
 ```bash
-TENANT_ID=<your-tenant-id> ./contrib/create-entra-app.sh
+# Recommended: restrict the app to a group
+TENANT_ID=<your-tenant-id> GROUP_OBJECT_ID=<group-object-id> \
+  ./contrib/create-entra-app.sh
+
+# Or restrict it to individual users
+TENANT_ID=<your-tenant-id> ASSIGN_USERS="alice@example.com bob@example.com" \
+  ./contrib/create-entra-app.sh
+```
+
+The script refuses to create an unrestricted app by accident. To intentionally
+allow every tenant user to sign in, explicitly set `ALLOW_ALL_TENANT_USERS=1`:
+
+```bash
+TENANT_ID=<your-tenant-id> ALLOW_ALL_TENANT_USERS=1 \
+  ./contrib/create-entra-app.sh
 ```
 
 What it does, step by step (so you can audit or cherry-pick):
@@ -123,9 +137,11 @@ What it does, step by step (so you can audit or cherry-pick):
    az ad group list --query "[].{name:displayName,id:id}" -o table
    ```
 
-   If you provide neither, assignment is not required and any tenant user can
-   sign in through the app (CA policies still apply). Per-user is fine to start;
-   switch to a group later without recreating anything.
+   If you provide neither assignment variable, the script exits before creating
+   any resources unless `ALLOW_ALL_TENANT_USERS=1` explicitly opts into an
+   unrestricted app. In that mode, any tenant user can sign in (CA policies still
+   apply). Per-user is fine to start; switch to a group later without recreating
+   anything.
 
 ## 3. Verify and test
 

--- a/docs/enterprise-setup.md
+++ b/docs/enterprise-setup.md
@@ -1,0 +1,176 @@
+# Enterprise setup: creating an olk Entra app registration (CLI-first, no click-ops)
+
+Goal: a tenant-controlled **public client** app registration for `olk`, with delegated
+Microsoft Graph permissions pre-approved by admin consent, optionally restricted to
+assigned users or a group, usable as:
+
+```bash
+olk auth login --browser --enterprise --client-id <APP_ID> --tenant-id <TENANT_ID>
+```
+
+Terminology decoder (Microsoft uses three names for two objects):
+
+| Object | Where it lives | What it holds |
+|---|---|---|
+| **App registration** (`application`) | App registrations blade / `az ad app` | Redirect URIs, requested permissions, public-client setting |
+| **Enterprise application** (`servicePrincipal`) | Enterprise applications blade / `az ad sp` | Admin-consent grants, user/group assignment, the sign-in kill switch |
+
+Creating the registration and then `az ad sp create` gives you both. "Roles" are not
+involved — olk uses **delegated permissions (scopes)**, approved via **admin consent**.
+App roles only apply to app-only/daemon identities, which olk deliberately does not use.
+
+## 0. Install the Azure CLI
+
+```bash
+brew install azure-cli
+az version
+```
+
+(A PowerShell alternative exists — see the bottom — but `az` covers everything here
+with less ceremony.)
+
+## 1. Sign in with an adequate role
+
+```bash
+az login --tenant <TENANT_ID>
+```
+
+Role requirements:
+
+- **Create the app + service principal**: Application Administrator (or Cloud
+  Application Administrator, or Global Administrator).
+- **Grant admin consent** (`az ad app permission admin-consent`): Global
+  Administrator (Application Administrator alone is not sufficient for Graph
+  delegated consent via this command).
+
+## 2. Run the script
+
+Everything below is automated in [`contrib/create-entra-app.sh`](../contrib/create-entra-app.sh):
+
+```bash
+TENANT_ID=<your-tenant-id> ./contrib/create-entra-app.sh
+```
+
+What it does, step by step (so you can audit or cherry-pick):
+
+1. **Create the app registration** — single-tenant public client with the loopback
+   redirect URI:
+
+   ```bash
+   az ad app create --display-name "olk CLI" \
+     --sign-in-audience AzureADMyOrg \
+     --public-client-redirect-uris "http://localhost/callback" \
+     --is-fallback-public-client true
+   ```
+
+   - `--public-client-redirect-uris` = the portal's "Mobile and desktop applications"
+     platform. Entra ignores the **port** when matching `http://localhost` redirect
+     URIs, so the portless registration matches olk's random login-time port.
+   - `--is-fallback-public-client true` = the portal's "Allow public client flows =
+     Yes" (needed for the device-code fallback).
+   - No secret, no certificate — a public client never has one.
+
+2. **Resolve the Graph delegated-permission IDs dynamically** — permission GUIDs are
+   looked up from the Microsoft Graph service principal
+   (`00000003-0000-0000-c000-000000000000`) by scope name, so no hardcoded GUIDs:
+
+   ```bash
+   az ad sp show --id 00000003-0000-0000-c000-000000000000 \
+     --query "oauth2PermissionScopes[?value=='Mail.ReadWrite'].id | [0]" -o tsv
+   ```
+
+3. **Add the delegated permissions** (`az ad app permission add ... "GUID=Scope"`).
+   Scope set requested:
+
+   - Core: `offline_access`, `User.Read`, `Mail.ReadWrite`, `Mail.Send`,
+     `Calendars.ReadWrite`, `Contacts.ReadWrite`, `Tasks.ReadWrite`,
+     `Files.ReadWrite`, `People.Read`
+   - `--enterprise` extras: `User.ReadBasic.All`, `MailboxSettings.ReadWrite`
+
+   For a read-only agent app, run the script with
+   `SCOPES="offline_access User.Read Mail.Read Calendars.Read Contacts.Read Tasks.Read Files.Read People.Read User.ReadBasic.All MailboxSettings.Read"`
+   and log in with `--read-only`.
+
+4. **Create the service principal** (the "Enterprise application"):
+   `az ad sp create --id <APP_ID>`.
+
+5. **Grant admin consent** — the "approve" step:
+   `az ad app permission admin-consent --id <APP_ID>`. All requested delegated
+   scopes get a tenant-wide grant; users never see a consent prompt. Reminder:
+   delegated tokens are always the *intersection* of these scopes and the signed-in
+   user's own rights — this app grants nobody access to mailboxes they can't
+   already touch.
+
+6. **Require assignment** (who may use the app at all):
+   `az ad sp update --id <APP_ID> --set appRoleAssignmentRequired=true`.
+   Then assign principals — a **group or individual users, both work identically**
+   (the Graph `appRoleAssignedTo` call takes any principal with the default access
+   role, the all-zeros GUID):
+
+   ```bash
+   az rest --method POST \
+     --url "https://graph.microsoft.com/v1.0/servicePrincipals/<SP_OBJECT_ID>/appRoleAssignedTo" \
+     --body '{"principalId":"<USER_OR_GROUP_OBJECT_ID>","resourceId":"<SP_OBJECT_ID>","appRoleId":"00000000-0000-0000-0000-000000000000"}'
+   ```
+
+   The script automates both: `GROUP_OBJECT_ID=<guid>` for a group and/or
+   `ASSIGN_USERS="alice@x.com bob@x.com"` for per-user assignment (UPNs are
+   resolved automatically). Discovery commands:
+
+   ```bash
+   az ad signed-in-user show --query userPrincipalName -o tsv    # your own UPN
+   az ad group show --group "<display name>" --query id -o tsv   # a group's ID
+   az ad group list --query "[].{name:displayName,id:id}" -o table
+   ```
+
+   If you provide neither, assignment is not required and any tenant user can
+   sign in through the app (CA policies still apply). Per-user is fine to start;
+   switch to a group later without recreating anything.
+
+## 3. Verify and test
+
+```bash
+az ad app permission list-grants --id <APP_ID> --show-resource-name -o table   # consent landed
+olk auth login --browser --enterprise --client-id <APP_ID> --tenant-id <TENANT_ID>
+```
+
+Success = browser opens → corporate sign-in (CA policies and all) → "Sign-in
+complete" page → terminal prints `Logged in as …`. Then confirm Graph access:
+`olk mail list -n 3`.
+
+Afterwards, check **Entra → Sign-in logs** for the event: the client app should be
+"olk CLI", and if the browser session came from a compliant device your
+require-compliant-device CA policy should show **satisfied** (device code flow can
+never do this — that's the point of `--browser`).
+
+## Operational notes
+
+- **Kill switch**: `az ad sp update --id <APP_ID> --set accountEnabled=false`
+  blocks all sign-ins through the app instantly.
+- **Revoke a user's tokens**: `az rest --method POST --url "https://graph.microsoft.com/v1.0/users/<UPN>/revokeSignInSessions"`
+  (refresh tokens die immediately; access tokens age out within ~60–90 min).
+- **Audit usage**: Sign-in logs filter → Application = "olk CLI".
+- The app registration is inert without a user: no secret exists, and the client ID
+  is not a credential.
+
+## Portal fallback (if you must)
+
+Entra admin center → **App registrations** → New registration → name `olk CLI`,
+single tenant, platform **Public client/native (mobile & desktop)** with URI
+`http://localhost/callback` → Register. Then: **Authentication** → Advanced →
+Allow public client flows = Yes → Save. **API permissions** → Add a permission →
+Microsoft Graph → Delegated → add the scope list above → **Grant admin consent
+for <tenant>**. **Enterprise applications** → olk CLI → Properties → Assignment
+required = Yes → Users and groups → add your group.
+
+## PowerShell alternative (for completeness)
+
+```powershell
+Install-Module Microsoft.Graph.Applications -Scope CurrentUser
+Connect-MgGraph -Scopes "Application.ReadWrite.All","DelegatedPermissionGrant.ReadWrite.All","AppRoleAssignment.ReadWrite.All"
+```
+
+Then `New-MgApplication` (with `PublicClient.RedirectUris` and
+`RequiredResourceAccess`), `New-MgServicePrincipal`, and
+`New-MgOauth2PermissionGrant` for the consent. It works, but it's three times the
+code for the same result — use `az` unless your org standardizes on Graph PowerShell.

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -26,6 +26,7 @@ type AuthLoginCmd struct {
 	TenantID   string   `help:"Azure AD tenant ID" env:"OLK_TENANT_ID" default:"common"`
 	ReadOnly   bool     `help:"Request read-only permissions"`
 	Enterprise bool     `help:"Request enterprise scopes (work/school accounts)" env:"OLK_ENTERPRISE"`
+	Browser    bool     `help:"Sign in via the system browser (auth-code + PKCE) instead of device code" env:"OLK_BROWSER"`
 	Scope      []string `help:"Additional OAuth scopes to request (repeatable, e.g. --scope Mail.Read.Shared)" name:"scope"`
 }
 
@@ -66,7 +67,12 @@ func (c *AuthLoginCmd) Run(ctx *RunContext) error {
 	// open a browser and enter the code.
 	loginCtx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
-	info, err := auth.LoginDeviceCode(loginCtx, scopes, ctx.Flags.Verbose)
+	var info *msauth.AccountInfo
+	if c.Browser {
+		info, err = auth.LoginAuthCode(loginCtx, scopes, ctx.Flags.Verbose)
+	} else {
+		info, err = auth.LoginDeviceCode(loginCtx, scopes, ctx.Flags.Verbose)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/msauth/auth.go
+++ b/internal/msauth/auth.go
@@ -20,6 +20,9 @@ import (
 	"github.com/rlrghb/olkcli/internal/secrets"
 )
 
+// windowsOS is the runtime.GOOS value for Windows.
+const windowsOS = "windows"
+
 // refreshMu guards per-email token refresh to prevent concurrent refreshes
 // from racing on the same keyring entry.
 var (
@@ -114,13 +117,27 @@ func (a *Authenticator) LoginDeviceCode(ctx context.Context, scopes []string, ve
 	// Clear any stray escape sequences that accumulated during polling.
 	fmt.Fprint(os.Stderr, "\r\033[K")
 
-	// Step 4: Fetch user profile from Microsoft Graph.
+	return a.finishLogin(ctx, tokenResp)
+}
+
+// finishLogin completes a login flow after tokens have been obtained: it
+// fetches the user profile and persists the token and account info. This is
+// the shared tail of every login flow.
+func (a *Authenticator) finishLogin(ctx context.Context, tokenResp *TokenResponse) (*AccountInfo, error) {
+	// Only the refresh token is persisted (StoreToken), and LoadToken rejects
+	// an empty one — a login without it would appear to succeed and then fail
+	// on first use, so reject it up front.
+	if tokenResp.RefreshToken == "" {
+		return nil, fmt.Errorf("no refresh token returned — ensure the offline_access scope was granted")
+	}
+
+	// Fetch user profile from Microsoft Graph.
 	email, displayName, err := fetchUserProfile(ctx, tokenResp.AccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("fetching user profile: %w", err)
 	}
 
-	// Step 5: Store refresh token in keyring.
+	// Store refresh token in keyring.
 	expiresAt := time.Now().Add(time.Duration(safeExpiresIn(tokenResp.ExpiresIn)) * time.Second)
 	tokenData := &TokenData{
 		AccessToken:  tokenResp.AccessToken,
@@ -132,7 +149,7 @@ func (a *Authenticator) LoginDeviceCode(ctx context.Context, scopes []string, ve
 		return nil, fmt.Errorf("storing token: %w", err)
 	}
 
-	// Step 6: Save AccountInfo to disk.
+	// Save AccountInfo to disk.
 	acctInfo := &AccountInfo{
 		Email:       email,
 		DisplayName: displayName,
@@ -216,7 +233,7 @@ func (a *Authenticator) ListAccounts() ([]AccountInfo, error) {
 
 	// Harden directory permissions on every read — fixes drift from
 	// umask changes or manual edits.
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != windowsOS {
 		_ = os.Chmod(acctDir, 0o700)
 	}
 
@@ -229,7 +246,7 @@ func (a *Authenticator) ListAccounts() ([]AccountInfo, error) {
 		filePath := filepath.Join(acctDir, entry.Name())
 
 		// Harden file permissions if too open.
-		if runtime.GOOS != "windows" {
+		if runtime.GOOS != windowsOS {
 			if info, err := entry.Info(); err == nil && info.Mode().Perm()&0o077 != 0 {
 				fmt.Fprintf(os.Stderr, "warning: fixing permissions on %q (was %o)\n", entry.Name(), info.Mode().Perm())
 				_ = os.Chmod(filePath, 0o600)
@@ -253,10 +270,15 @@ func (a *Authenticator) ListAccounts() ([]AccountInfo, error) {
 	return accounts, nil
 }
 
+// graphMeURL is the Microsoft Graph profile endpoint. It is a var (not a
+// const) so in-package tests can point the profile fetch at a local httptest
+// server.
+var graphMeURL = "https://graph.microsoft.com/v1.0/me"
+
 // fetchUserProfile retrieves the email and display name from the Microsoft
 // Graph /me endpoint.
 func fetchUserProfile(ctx context.Context, accessToken string) (email, displayName string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://graph.microsoft.com/v1.0/me", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, graphMeURL, http.NoBody)
 	if err != nil {
 		return "", "", fmt.Errorf("creating profile request: %w", err)
 	}

--- a/internal/msauth/authcode.go
+++ b/internal/msauth/authcode.go
@@ -1,0 +1,301 @@
+package msauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Self-contained pages served to the browser after the redirect. No
+// server-provided strings are ever interpolated — detailed errors travel only
+// through the returned Go error — so there is no injection surface here.
+const (
+	callbackSuccessHTML = `<!DOCTYPE html><html><head><title>olk</title></head><body>
+<h2>Sign-in complete</h2><p>You can close this window and return to the terminal.</p>
+</body></html>`
+	callbackErrorHTML = `<!DOCTYPE html><html><head><title>olk</title></head><body>
+<h2>Sign-in failed</h2><p>Return to the terminal for details.</p>
+</body></html>`
+	callbackDoneHTML = `<!DOCTYPE html><html><head><title>olk</title></head><body>
+<h2>Login already completed</h2><p>You can close this window.</p>
+</body></html>`
+)
+
+// authCodeResult carries the outcome of the loopback redirect callback.
+type authCodeResult struct {
+	code string
+	err  error
+}
+
+// authorizeURL returns the authorization endpoint for the given tenant.
+func authorizeURL(tenantID string) string {
+	return fmt.Sprintf("%s/%s/oauth2/v2.0/authorize", authorityBase, tenantID)
+}
+
+// generateState creates a random CSRF token for the authorization request:
+// 16 random bytes, base64url-encoded.
+func generateState() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generating state parameter: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// buildAuthorizeURL assembles the full /authorize URL for the
+// authorization-code + PKCE flow (RFC 6749 §4.1.1, RFC 7636 §4.3).
+func buildAuthorizeURL(clientID, tenantID, redirectURI, state, codeChallenge string, scopes []string) string {
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {strings.Join(scopes, " ")},
+		"state":                 {state},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+	return authorizeURL(tenantID) + "?" + q.Encode()
+}
+
+// newCallbackHandler returns the handler for the loopback redirect listener.
+// It serves only /callback, validates the state parameter before anything
+// else, and delivers exactly one result on resultCh. Requests with a missing
+// or mismatched state never touch the channel, so a stray or forged local
+// request cannot consume a pending login.
+func newCallbackHandler(expectedState string, resultCh chan<- authCodeResult) http.Handler {
+	// A buffered channel alone is not single-use: once the orchestrator
+	// drains the first result, a replayed callback could send again. The
+	// CompareAndSwap makes delivery exactly-once.
+	var delivered atomic.Bool
+
+	serve := func(w http.ResponseWriter, status int, page string) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(status)
+		fmt.Fprint(w, page)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		// State is a per-login random value; only Microsoft's redirect of
+		// this specific authorization request can know it. Entra includes it
+		// on error redirects too, so genuine denials pass this check.
+		if q.Get("state") != expectedState {
+			serve(w, http.StatusBadRequest, callbackErrorHTML)
+			return
+		}
+
+		var res authCodeResult
+		switch {
+		case q.Get("error") != "":
+			res.err = fmt.Errorf("authorization failed: %s: %s",
+				sanitizeStr(q.Get("error")), sanitizeStr(q.Get("error_description")))
+		case q.Get("code") == "":
+			res.err = fmt.Errorf("authorization redirect contained no code")
+		default:
+			res.code = q.Get("code")
+		}
+
+		if !delivered.CompareAndSwap(false, true) {
+			serve(w, http.StatusOK, callbackDoneHTML)
+			return
+		}
+		resultCh <- res
+
+		if res.err != nil {
+			serve(w, http.StatusOK, callbackErrorHTML)
+			return
+		}
+		serve(w, http.StatusOK, callbackSuccessHTML)
+	})
+	return mux
+}
+
+// exchangeCode redeems an authorization code for tokens
+// (RFC 6749 §4.1.3 with the PKCE verifier from RFC 7636 §4.5).
+func exchangeCode(ctx context.Context, clientID, tenantID, code, redirectURI, codeVerifier string, scopes []string) (*TokenResponse, error) {
+	if err := validateClientID(clientID); err != nil {
+		return nil, err
+	}
+	if err := validateTenantID(tenantID); err != nil {
+		return nil, err
+	}
+
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {clientID},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"code_verifier": {codeVerifier},
+		"scope":         {strings.Join(scopes, " ")},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL(tenantID), strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating code exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("exchanging authorization code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 100<<10)) // 100 KB limit for OAuth responses
+	if err != nil {
+		return nil, fmt.Errorf("reading code exchange response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp ErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("code exchange failed: %s: %s", sanitizeStr(errResp.Error), sanitizeStr(errResp.ErrorDescription))
+		}
+		return nil, fmt.Errorf("code exchange failed with status %d", resp.StatusCode)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("decoding code exchange response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("code exchange response contained empty access token")
+	}
+
+	return &tokenResp, nil
+}
+
+// openBrowser launches the system default browser at the given URL. It is a
+// var so tests can stub the browser interaction. The child is reaped in a
+// goroutine so no zombie lingers while the login wait (up to 15 minutes) runs.
+var openBrowser = func(u string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", u)
+	case windowsOS:
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", u)
+	default:
+		cmd = exec.Command("xdg-open", u)
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() { _ = cmd.Wait() }()
+	return nil
+}
+
+// LoginAuthCode performs the OAuth2 authorization-code + PKCE flow via the
+// system browser and a loopback redirect listener, then persists the tokens
+// and account information. Unlike device code flow, the browser session can
+// carry device identity, so this flow works in tenants whose Conditional
+// Access policies require a compliant device or block device code flow.
+func (a *Authenticator) LoginAuthCode(ctx context.Context, scopes []string, verbose bool) (*AccountInfo, error) {
+	if err := validateClientID(a.ClientID); err != nil {
+		return nil, err
+	}
+	if err := validateTenantID(a.TenantID); err != nil {
+		return nil, err
+	}
+
+	// Defensive deadline in case the caller supplied an unbounded context.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 15*time.Minute)
+		defer cancel()
+	}
+
+	codeVerifier, codeChallenge, err := generatePKCE()
+	if err != nil {
+		return nil, err
+	}
+	state, err := generateState()
+	if err != nil {
+		return nil, err
+	}
+
+	// The redirect URI uses localhost because Entra documents port-ignored
+	// matching for http://localhost only — a registered http://localhost/callback
+	// matches any dynamic port, and a fixed port would collide with other
+	// local services. The browser may resolve localhost to 127.0.0.1 or ::1,
+	// so listen on both loopback families: IPv4 is required, IPv6 on the same
+	// port is best-effort (browsers fall back to the other family on
+	// connection-refused, but listening on both avoids relying on that).
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("starting loopback listener for browser login: %w (rerun without --browser to use device code flow)", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln6, err6 := net.Listen("tcp6", fmt.Sprintf("[::1]:%d", port))
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", port)
+
+	resultCh := make(chan authCodeResult, 1)
+	serveErrCh := make(chan error, 2)
+	srv := &http.Server{
+		Handler:           newCallbackHandler(state, resultCh),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() { serveErrCh <- srv.Serve(ln) }()
+	if err6 == nil {
+		go func() { serveErrCh <- srv.Serve(ln6) }()
+	}
+	// Graceful shutdown lets an in-flight success page finish flushing.
+	defer func() {
+		sdCtx, sdCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer sdCancel()
+		_ = srv.Shutdown(sdCtx)
+	}()
+
+	authURL := buildAuthorizeURL(a.ClientID, a.TenantID, redirectURI, state, codeChallenge, scopes)
+
+	if verbose {
+		ipv6 := "yes"
+		if err6 != nil {
+			ipv6 = "no"
+		}
+		fmt.Fprintf(os.Stderr, "[verbose] loopback listener on port %d (ipv6: %s)\n", port, ipv6)
+		fmt.Fprintf(os.Stderr, "[verbose] client_id=%s tenant=%s scopes=%s\n", a.ClientID, a.TenantID, strings.Join(scopes, " "))
+	}
+
+	fmt.Fprintf(os.Stderr, "\nOpening your browser to sign in. If it does not open, visit:\n  %s\n\nWaiting for authentication...\n", authURL)
+	if err := openBrowser(authURL); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not open browser: %v\n", err)
+	}
+
+	var res authCodeResult
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("timed out waiting for browser authentication: %w — if the browser showed error AADSTS50011, the app registration is missing the http://localhost/callback redirect URI (see README \"Custom App Registration\"); or rerun without --browser to use device code flow", ctx.Err())
+	case err := <-serveErrCh:
+		if !errors.Is(err, http.ErrServerClosed) {
+			return nil, fmt.Errorf("loopback callback server failed: %w", err)
+		}
+		return nil, fmt.Errorf("loopback callback server closed unexpectedly")
+	case res = <-resultCh:
+		if res.err != nil {
+			return nil, res.err
+		}
+	}
+
+	tokenResp, err := exchangeCode(ctx, a.ClientID, a.TenantID, res.code, redirectURI, codeVerifier, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.finishLogin(ctx, tokenResp)
+}

--- a/internal/msauth/authcode_test.go
+++ b/internal/msauth/authcode_test.go
@@ -1,0 +1,458 @@
+package msauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testClientID = "11111111-2222-3333-4444-555555555555"
+	testTenantID = "common"
+)
+
+func TestGenerateState(t *testing.T) {
+	s1, err := generateState()
+	if err != nil {
+		t.Fatalf("generateState: %v", err)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s1)
+	if err != nil {
+		t.Fatalf("state is not base64url: %v", err)
+	}
+	if len(raw) != 16 {
+		t.Errorf("state decodes to %d bytes, want 16", len(raw))
+	}
+	s2, err := generateState()
+	if err != nil {
+		t.Fatalf("generateState: %v", err)
+	}
+	if s1 == s2 {
+		t.Error("two generated states are identical")
+	}
+}
+
+func TestBuildAuthorizeURL(t *testing.T) {
+	scopes := []string{"offline_access", "User.Read", "Mail.ReadWrite"}
+	got := buildAuthorizeURL(testClientID, testTenantID, "http://localhost:12345/callback", "st4te", "ch4llenge", scopes)
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parsing authorize URL: %v", err)
+	}
+	if u.Host != "login.microsoftonline.com" {
+		t.Errorf("host = %q, want login.microsoftonline.com", u.Host)
+	}
+	if u.Path != "/common/oauth2/v2.0/authorize" {
+		t.Errorf("path = %q, want /common/oauth2/v2.0/authorize", u.Path)
+	}
+
+	q := u.Query()
+	want := map[string]string{
+		"client_id":             testClientID,
+		"response_type":         "code",
+		"redirect_uri":          "http://localhost:12345/callback",
+		"scope":                 "offline_access User.Read Mail.ReadWrite",
+		"state":                 "st4te",
+		"code_challenge":        "ch4llenge",
+		"code_challenge_method": "S256",
+	}
+	for k, v := range want {
+		if q.Get(k) != v {
+			t.Errorf("query %s = %q, want %q", k, q.Get(k), v)
+		}
+	}
+	for _, absent := range []string{"response_mode", "prompt", "nonce"} {
+		if q.Has(absent) {
+			t.Errorf("query unexpectedly contains %s", absent)
+		}
+	}
+}
+
+// callbackGet routes a GET through the handler and returns the recorder.
+func callbackGet(t *testing.T, h http.Handler, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestCallbackHandlerSuccess(t *testing.T) {
+	ch := make(chan authCodeResult, 1)
+	h := newCallbackHandler("good-state", ch)
+
+	w := callbackGet(t, h, "/callback?code=abc123&state=good-state")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v", res.err)
+		}
+		if res.code != "abc123" {
+			t.Errorf("code = %q, want abc123", res.code)
+		}
+	default:
+		t.Fatal("no result delivered")
+	}
+}
+
+func TestCallbackHandlerStateMismatch(t *testing.T) {
+	ch := make(chan authCodeResult, 1)
+	h := newCallbackHandler("good-state", ch)
+
+	for _, target := range []string{
+		"/callback?code=abc123&state=evil-state",
+		"/callback?code=abc123",
+		"/callback?error=access_denied&error_description=forged",
+	} {
+		w := callbackGet(t, h, target)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", target, w.Code)
+		}
+		select {
+		case res := <-ch:
+			t.Errorf("%s: flow consumed by invalid request: %+v", target, res)
+		default:
+		}
+	}
+
+	// The pending login must still be completable after invalid hits.
+	callbackGet(t, h, "/callback?code=real&state=good-state")
+	select {
+	case res := <-ch:
+		if res.code != "real" {
+			t.Errorf("code = %q, want real", res.code)
+		}
+	default:
+		t.Fatal("valid callback after invalid hits was not delivered")
+	}
+}
+
+func TestCallbackHandlerAccessDenied(t *testing.T) {
+	ch := make(chan authCodeResult, 1)
+	h := newCallbackHandler("good-state", ch)
+
+	desc := "user declined \x1b[31mconsent"
+	w := callbackGet(t, h, "/callback?error=access_denied&error_description="+url.QueryEscape(desc)+"&state=good-state")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "access_denied") || strings.Contains(w.Body.String(), "declined") {
+		t.Error("server-provided strings leaked into the HTML response")
+	}
+	select {
+	case res := <-ch:
+		if res.err == nil {
+			t.Fatal("expected error result")
+		}
+		if !strings.Contains(res.err.Error(), "access_denied") {
+			t.Errorf("error %q does not mention access_denied", res.err)
+		}
+		if strings.Contains(res.err.Error(), "\x1b") {
+			t.Error("error contains unsanitized escape sequence")
+		}
+	default:
+		t.Fatal("denial was not delivered")
+	}
+}
+
+func TestCallbackHandlerWrongPath(t *testing.T) {
+	ch := make(chan authCodeResult, 1)
+	h := newCallbackHandler("good-state", ch)
+
+	w := callbackGet(t, h, "/favicon.ico")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	select {
+	case res := <-ch:
+		t.Errorf("flow consumed by wrong-path request: %+v", res)
+	default:
+	}
+}
+
+func TestCallbackHandlerSingleUse(t *testing.T) {
+	ch := make(chan authCodeResult, 1)
+	h := newCallbackHandler("good-state", ch)
+
+	callbackGet(t, h, "/callback?code=first&state=good-state")
+	// Drain, simulating the orchestrator receiving the result. A bare
+	// buffered channel would accept a second send after this.
+	res := <-ch
+	if res.code != "first" {
+		t.Fatalf("code = %q, want first", res.code)
+	}
+
+	w := callbackGet(t, h, "/callback?code=second&state=good-state")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "already completed") {
+		t.Error("replayed callback did not get the already-completed page")
+	}
+	select {
+	case res := <-ch:
+		t.Errorf("replayed callback delivered a second result: %+v", res)
+	default:
+	}
+}
+
+// overrideAuthority points authorityBase at a test server for the duration of
+// the test. Tests using it must not run in parallel.
+func overrideAuthority(t *testing.T, base string) {
+	t.Helper()
+	prev := authorityBase
+	authorityBase = base
+	t.Cleanup(func() { authorityBase = prev })
+}
+
+func TestExchangeCode(t *testing.T) {
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parsing form: %v", err)
+		}
+		gotForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"at","refresh_token":"rt","expires_in":3600,"token_type":"Bearer"}`)
+	}))
+	defer srv.Close()
+	overrideAuthority(t, srv.URL)
+
+	resp, err := exchangeCode(context.Background(), testClientID, testTenantID,
+		"the-code", "http://127.0.0.1:9/callback", "the-verifier", []string{"offline_access", "User.Read"})
+	if err != nil {
+		t.Fatalf("exchangeCode: %v", err)
+	}
+	if resp.AccessToken != "at" || resp.RefreshToken != "rt" {
+		t.Errorf("unexpected token response: %+v", resp)
+	}
+
+	want := map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     testClientID,
+		"code":          "the-code",
+		"redirect_uri":  "http://127.0.0.1:9/callback",
+		"code_verifier": "the-verifier",
+		"scope":         "offline_access User.Read",
+	}
+	for k, v := range want {
+		if gotForm.Get(k) != v {
+			t.Errorf("form %s = %q, want %q", k, gotForm.Get(k), v)
+		}
+	}
+	if gotForm.Has("client_secret") {
+		t.Error("public client must not send client_secret")
+	}
+}
+
+func TestExchangeCodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant","error_description":"AADSTS70008: expired"}`)
+	}))
+	defer srv.Close()
+	overrideAuthority(t, srv.URL)
+
+	_, err := exchangeCode(context.Background(), testClientID, testTenantID,
+		"bad-code", "http://127.0.0.1:9/callback", "v", []string{"User.Read"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") || !strings.Contains(err.Error(), "AADSTS70008") {
+		t.Errorf("error %q missing OAuth error details", err)
+	}
+}
+
+// memStore is an in-memory secrets.Store for tests.
+type memStore struct {
+	m map[string]string
+}
+
+func newMemStore() *memStore { return &memStore{m: make(map[string]string)} }
+
+func (s *memStore) Set(key, value string) error { s.m[key] = value; return nil }
+
+func (s *memStore) Get(key string) (string, error) {
+	v, ok := s.m[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found", key)
+	}
+	return v, nil
+}
+
+func (s *memStore) Delete(key string) error { delete(s.m, key); return nil }
+
+func (s *memStore) Keys() ([]string, error) {
+	keys := make([]string, 0, len(s.m))
+	for k := range s.m {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+// overrideBrowser stubs openBrowser for the duration of the test.
+func overrideBrowser(t *testing.T, fn func(string) error) {
+	t.Helper()
+	prev := openBrowser
+	openBrowser = fn
+	t.Cleanup(func() { openBrowser = prev })
+}
+
+// startFakeIdP runs a test server that acts as both the token endpoint and
+// the Graph /me endpoint, wiring authorityBase and graphMeURL to it.
+func startFakeIdP(t *testing.T, tokenJSON string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/token") {
+			fmt.Fprint(w, tokenJSON)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/me") {
+			fmt.Fprint(w, `{"mail":"user@example.com","displayName":"Test User"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	overrideAuthority(t, srv.URL)
+
+	prevMe := graphMeURL
+	graphMeURL = srv.URL + "/me"
+	t.Cleanup(func() { graphMeURL = prevMe })
+}
+
+// simulateRedirect returns a browser stub that immediately performs the IdP
+// redirect: it parses the authorize URL and GETs the loopback callback with
+// the given extra query parameters (plus the request's own state).
+func simulateRedirect(t *testing.T, extra url.Values) func(string) error {
+	t.Helper()
+	return func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		cb, err := url.Parse(q.Get("redirect_uri"))
+		if err != nil {
+			return err
+		}
+		cbq := url.Values{"state": {q.Get("state")}}
+		for k, vs := range extra {
+			cbq[k] = vs
+		}
+		cb.RawQuery = cbq.Encode()
+		go func() {
+			resp, err := http.Get(cb.String())
+			if err != nil {
+				t.Errorf("callback GET: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+		return nil
+	}
+}
+
+func TestLoginAuthCodeEndToEnd(t *testing.T) {
+	t.Setenv("OLK_CONFIG_DIR", t.TempDir())
+	startFakeIdP(t, `{"access_token":"at","refresh_token":"rt","expires_in":3600,"token_type":"Bearer"}`)
+	overrideBrowser(t, simulateRedirect(t, url.Values{"code": {"fake-code"}}))
+
+	store := newMemStore()
+	auth := NewAuthenticator(store, testClientID, testTenantID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	info, err := auth.LoginAuthCode(ctx, []string{"offline_access", "User.Read"}, false)
+	if err != nil {
+		t.Fatalf("LoginAuthCode: %v", err)
+	}
+	if info.Email != "user@example.com" || info.DisplayName != "Test User" {
+		t.Errorf("unexpected account info: %+v", info)
+	}
+
+	raw, err := store.Get("olk:token:user@example.com")
+	if err != nil {
+		t.Fatalf("token not stored: %v", err)
+	}
+	var data TokenData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		t.Fatalf("stored token is not JSON: %v", err)
+	}
+	if data.RefreshToken != "rt" {
+		t.Errorf("stored refresh token = %q, want rt", data.RefreshToken)
+	}
+	if data.AccessToken != "" {
+		t.Error("access token must not be persisted")
+	}
+}
+
+func TestLoginAuthCodeAccessDenied(t *testing.T) {
+	t.Setenv("OLK_CONFIG_DIR", t.TempDir())
+	startFakeIdP(t, `{}`)
+	overrideBrowser(t, simulateRedirect(t, url.Values{
+		"error":             {"access_denied"},
+		"error_description": {"user said no"},
+	}))
+
+	auth := NewAuthenticator(newMemStore(), testClientID, testTenantID)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := auth.LoginAuthCode(ctx, []string{"User.Read"}, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "access_denied") {
+		t.Errorf("error %q does not mention access_denied", err)
+	}
+}
+
+func TestLoginAuthCodeTimeout(t *testing.T) {
+	t.Setenv("OLK_CONFIG_DIR", t.TempDir())
+	startFakeIdP(t, `{}`)
+	overrideBrowser(t, func(string) error { return nil }) // browser never redirects
+
+	auth := NewAuthenticator(newMemStore(), testClientID, testTenantID)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := auth.LoginAuthCode(ctx, []string{"User.Read"}, false)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "AADSTS50011") {
+		t.Errorf("timeout error %q does not mention AADSTS50011 hint", err)
+	}
+}
+
+func TestLoginAuthCodeNoRefreshToken(t *testing.T) {
+	t.Setenv("OLK_CONFIG_DIR", t.TempDir())
+	startFakeIdP(t, `{"access_token":"at","expires_in":3600,"token_type":"Bearer"}`)
+	overrideBrowser(t, simulateRedirect(t, url.Values{"code": {"fake-code"}}))
+
+	auth := NewAuthenticator(newMemStore(), testClientID, testTenantID)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := auth.LoginAuthCode(ctx, []string{"User.Read"}, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "offline_access") {
+		t.Errorf("error %q does not mention offline_access", err)
+	}
+}

--- a/internal/msauth/devicecode.go
+++ b/internal/msauth/devicecode.go
@@ -51,6 +51,11 @@ func validateClientID(clientID string) error {
 // httpClient is a shared HTTP client with a sensible timeout for auth operations.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
+// authorityBase is the Microsoft identity platform base URL. It is a var
+// (not a const) so in-package tests can point token exchanges at a local
+// httptest server.
+var authorityBase = "https://login.microsoftonline.com"
+
 // DeviceCodeResponse holds the response from the device code authorization request.
 type DeviceCodeResponse struct {
 	DeviceCode      string `json:"device_code"`
@@ -81,12 +86,12 @@ type ErrorResponse struct {
 
 // deviceCodeURL returns the device code endpoint for the given tenant.
 func deviceCodeURL(tenantID string) string {
-	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/devicecode", tenantID)
+	return fmt.Sprintf("%s/%s/oauth2/v2.0/devicecode", authorityBase, tenantID)
 }
 
 // tokenURL returns the token endpoint for the given tenant.
 func tokenURL(tenantID string) string {
-	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+	return fmt.Sprintf("%s/%s/oauth2/v2.0/token", authorityBase, tenantID)
 }
 
 // RequestDeviceCode initiates the device code flow by requesting a device code
@@ -237,7 +242,14 @@ func PollForToken(ctx context.Context, clientID, tenantID, deviceCode string, in
 					}
 					continue
 				default:
-					return nil, fmt.Errorf("token request failed: %s: %s", sanitizeStr(errResp.Error), sanitizeStr(errResp.ErrorDescription))
+					// Conditional Access blocks on device code flow surface as
+					// access_denied or invalid_grant (e.g. AADSTS53003,
+					// AADSTS530003); the browser flow can satisfy them.
+					hint := ""
+					if errResp.Error == "access_denied" || errResp.Error == "invalid_grant" {
+						hint = " (if your organization blocks device code flow or requires a compliant device, retry with --browser)"
+					}
+					return nil, fmt.Errorf("token request failed: %s: %s%s", sanitizeStr(errResp.Error), sanitizeStr(errResp.ErrorDescription), hint)
 				}
 			}
 			return nil, fmt.Errorf("token request failed with status %d", resp.StatusCode)

--- a/internal/msauth/devicecode_test.go
+++ b/internal/msauth/devicecode_test.go
@@ -1,0 +1,57 @@
+package msauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPollForTokenTerminalErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantHint bool
+	}{
+		{
+			name:     "conditional access block hints at browser flow",
+			body:     `{"error":"access_denied","error_description":"AADSTS53003: blocked by Conditional Access"}`,
+			wantHint: true,
+		},
+		{
+			name:     "invalid_grant hints at browser flow",
+			body:     `{"error":"invalid_grant","error_description":"AADSTS50199: security check required"}`,
+			wantHint: true,
+		},
+		{
+			name:     "user declined gets no browser hint",
+			body:     `{"error":"authorization_declined","error_description":"user said no"}`,
+			wantHint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer srv.Close()
+			overrideAuthority(t, srv.URL)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_, err := PollForToken(ctx, testClientID, testTenantID, "device-code", 1, 60, "verifier", false)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := strings.Contains(err.Error(), "--browser"); got != tt.wantHint {
+				t.Errorf("error %q: --browser hint present = %v, want %v", err, got, tt.wantHint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `olk auth login --browser`: sign-in through the system browser using the OAuth2 authorization-code flow with PKCE and a loopback redirect listener. Device code remains the default flow.

## Why

Device code flow cannot present device state, so tenants whose Conditional Access policies require a compliant/managed device — or that block device code flow via the Authentication Flows condition, per Microsoft's own recommendation — cannot use olk. With `--browser`, the browser session can carry device identity (PRT via Platform SSO / Windows SSO on managed devices), so sign-in satisfies device-based CA policies.

## How

- `internal/msauth/authcode.go`: the flow — PKCE (reuses `generatePKCE`), random `state`, redirect URI `http://localhost:{port}/callback` (port-ignored matching is documented for localhost) with a listener on both loopback families (`127.0.0.1` required, `::1` best-effort), browser open with print-URL fallback, code exchange, shared `finishLogin` tail.
- Callback hardening: state validated before any result is accepted (a forged local request cannot consume a pending login), exactly-once delivery via `atomic.Bool` CAS, only `/callback` is routed, static HTML pages never echo server-provided strings, `ReadHeaderTimeout` set, `Serve` errors surfaced instead of stalling to timeout, context deadline ends the wait.
- `finishLogin` (extracted from `LoginDeviceCode`) now rejects token responses without a refresh token, since only the refresh token is persisted.
- Testability: `authorityBase` and `graphMeURL` become package vars; `openBrowser` is a stubable func var. New tests cover the URL builder, callback handler (success, wrong state, denial, wrong path, replay), code exchange against httptest, and the full `LoginAuthCode` orchestration end to end.
- Docs: README (browser sign-in section + custom app registration redirect-URI steps), SKILL.md, AGENTS.md, CLAUDE.md.

## Notes for review

- The embedded default client ID's app registration needs `http://localhost/callback` registered under the Mobile & desktop platform for `--browser` to work with it. Without it, users see AADSTS50011 in the browser and the CLI times out with a pointer to the docs. Device-code default is unaffected.
- Verified: `go test -race -count=1 ./...` green, golangci-lint v2.11.4 clean, plus two external review passes. A live login test against a tenant-controlled app registration (localhost + random-port matching) is still worth doing before merge.

Closes #67