### PR TITLE
feat(mail): page bounded message lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,34 @@ olk mail list --json --results-only | jq '.[0].subject'
 ### Field Selection
 
 ```bash
-olk mail list --select from,subject
+olk mail list --json --select id,from,subject,receivedDateTime
 ```
+
+For `mail list --json`, `--select` is both a Microsoft Graph projection and a
+JSON output projection: each result contains only the requested fields.
+Supported fields are `id`, `subject`, `from`, `toRecipients` (rendered as
+`to`), `receivedDateTime`, `isRead`, `hasAttachments`, `bodyPreview`,
+`categories`, and `conversationId`. Empty, duplicate, unknown, or
+unrenderable fields are rejected before any Graph request.
+
+### Bounded Mail Lists
+
+```bash
+# Return at most 1,000 inbox messages, oldest first
+olk mail list --folder inbox --top 1000 --order oldest --json --results-only
+```
+
+`--order` accepts `newest` (the default) or `oldest`. `--top` is the total
+result bound for the command, not a per-page size: `olk` follows provider pages
+internally until it reaches that bound or Microsoft Graph returns a terminal
+page. A terminal page before the bound is a successful short result containing
+every available matching message.
+
+Provider continuation URLs remain opaque and internal. A completed `mail list`
+JSON envelope therefore has an empty `nextLink`; raw continuations are never
+exposed for callers to replay. Traversal fails closed: an invalid, unexpected,
+non-progressing, or repeated continuation, a duplicate or missing message ID,
+cancellation, or a request failure returns an error and no partial list.
 
 ## Authentication
 
@@ -344,7 +370,7 @@ For common workflows, `olk` provides top-level shortcuts:
 | `--dry-run` | `OLK_DRY_RUN` | Dry run mode |
 | `--force` | `OLK_FORCE` | Skip confirmations |
 | `--color auto\|never\|always` | `OLK_COLOR` | Color mode |
-| `--select FIELDS` | `OLK_SELECT` | Field projection (table/plain output) |
+| `--select FIELDS` | `OLK_SELECT` | Command-specific field projection; `mail list --json` projects both the Graph request and JSON result |
 | `--concise` | `OLK_CONCISE` | Drop large free-text (bodies, previews, attendee lists) from JSON output |
 | `--results-only` | `OLK_RESULTS_ONLY` | Unwrap JSON envelope |
 | `--tz TIMEZONE` | `OLK_TIMEZONE` | IANA time zone for display (e.g. `America/New_York`) |
@@ -432,7 +458,7 @@ olk auth status                                      Check token validity
 ### Mail
 
 ```
-olk mail list [-n 25] [-f FOLDER] [-u] [--from X] [--after DATE] [--before DATE] [--focused] [--other]
+olk mail list [-n 25] [-f FOLDER] [-u] [--from X] [--after DATE] [--before DATE] [--focused] [--other] [--order newest|oldest] [--select FIELDS]
 olk mail get <ID> [--format full|text|html]
 olk mail batch --id <ID> [--id <ID>]...                  Fetch up to 20 messages in one $batch request
 olk mail thread <CONVERSATION_ID> [-n 50]                List all messages in a conversation

--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ internally until it reaches that bound or Microsoft Graph returns a terminal
 page. A terminal page before the bound is a successful short result containing
 every available matching message.
 
+`--order` cannot be combined with `--focused` or `--other`. Those
+classification filters use Microsoft Graph's provider order; `olk` does not
+fall back to client-side sorting, expose a raw Graph response, or return a
+partial or guessed ordering.
+
 Provider continuation URLs remain opaque and internal. A completed `mail list`
 JSON envelope therefore has an empty `nextLink`; raw continuations are never
 exposed for callers to replay. Traversal fails closed: an invalid, unexpected,
@@ -459,6 +464,7 @@ olk auth status                                      Check token validity
 
 ```
 olk mail list [-n 25] [-f FOLDER] [-u] [--from X] [--after DATE] [--before DATE] [--focused] [--other] [--order newest|oldest] [--select FIELDS]
+# --order cannot be combined with --focused or --other
 olk mail get <ID> [--format full|text|html]
 olk mail batch --id <ID> [--id <ID>]...                  Fetch up to 20 messages in one $batch request
 olk mail thread <CONVERSATION_ID> [-n 50]                List all messages in a conversation

--- a/SKILL.md
+++ b/SKILL.md
@@ -65,6 +65,7 @@ olk auth clean --force                          # remove ALL stored accounts and
 
 ```bash
 olk mail list [-n 25] [-f FOLDER] [-u] [--from SENDER] [--after DATE] [--before DATE] [--focused] [--other] [--order newest|oldest] [--select FIELDS]
+# --order cannot be combined with --focused or --other
 olk mail get <ID> [--format full|text|html]
 olk mail send --to a@b.com --subject "Hi" --body "Hello"                  # plain
 olk mail send --to a@b.com --subject "Hi" --body "<p>Hello</p>" --html    # HTML
@@ -102,6 +103,11 @@ continuations stay opaque and are never returned for callers to replay.
 Traversal fails closed: an unsafe, unexpected, non-progressing, or repeated
 continuation, duplicate or missing message ID, cancellation, or request error
 returns no partial list.
+
+`--order` cannot be combined with `--focused` or `--other`. Those
+classification filters use Graph's provider order; `olk` does not fall back to
+client-side sorting, expose a raw Graph response, or return a partial or
+guessed ordering.
 
 With `mail list --json`, `--select` projects both the Graph request and the JSON
 result. Supported fields are `id`, `subject`, `from`, `toRecipients` (rendered
@@ -163,6 +169,9 @@ olk mail list --focused                                                  # focus
 olk mail list --other                                                    # other messages
 olk mail list --focused --unread                                         # combine with filters
 ```
+
+Focused/other filters use provider order and cannot be combined with
+`--order`.
 
 ## Calendar
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ olk auth clean --force                          # remove ALL stored accounts and
 ## Mail
 
 ```bash
-olk mail list [-n 25] [-f FOLDER] [-u] [--from SENDER] [--after DATE] [--before DATE] [--focused] [--other]
+olk mail list [-n 25] [-f FOLDER] [-u] [--from SENDER] [--after DATE] [--before DATE] [--focused] [--other] [--order newest|oldest] [--select FIELDS]
 olk mail get <ID> [--format full|text|html]
 olk mail send --to a@b.com --subject "Hi" --body "Hello"                  # plain
 olk mail send --to a@b.com --subject "Hi" --body "<p>Hello</p>" --html    # HTML
@@ -87,6 +87,28 @@ olk mail attachments <ID>                                                 # list
 olk mail attachments <ID> --save [--out DIR]                             # download all
 olk mail attachments <ID> --attachment-id <ATT_ID> [--out DIR]           # download one
 ```
+
+For a bounded mail inventory, use:
+
+```bash
+olk mail list --folder inbox --top 1000 --order oldest --json --results-only
+```
+
+`--order` accepts `newest` (the default) or `oldest`. `--top` bounds the total
+result, not each provider page. `olk` follows pages internally until it reaches
+the bound or Graph returns a terminal page; reaching the terminal page early is
+a successful short result containing all available matches. Provider
+continuations stay opaque and are never returned for callers to replay.
+Traversal fails closed: an unsafe, unexpected, non-progressing, or repeated
+continuation, duplicate or missing message ID, cancellation, or request error
+returns no partial list.
+
+With `mail list --json`, `--select` projects both the Graph request and the JSON
+result. Supported fields are `id`, `subject`, `from`, `toRecipients` (rendered
+as `to`), `receivedDateTime`, `isRead`, `hasAttachments`, `bodyPreview`,
+`categories`, and `conversationId`. Empty, duplicate, unknown, or unrenderable
+fields fail locally before Graph is called. A completed JSON envelope has an
+empty `nextLink`; raw provider continuations are not exposed.
 
 Well-known folder names: `inbox`, `sentitems`, `drafts`, `deleteditems`, `junkemail`, `archive`.
 
@@ -318,7 +340,7 @@ export OLK_MAILBOX=boss@example.com
 | `--json` | JSON envelope `{ results, count, nextLink }` | Scripting |
 | `--json --results-only` | Bare JSON array | Best for scripting |
 | `--plain` | Tab-separated values | Piping to `awk`, `cut` |
-| `--select from,subject` | Field projection | Trim output |
+| `--select from,subject` | Command-specific field projection | Trim supported output fields |
 
 ## Global Flags
 
@@ -329,7 +351,7 @@ export OLK_MAILBOX=boss@example.com
 | `--account EMAIL` | `OLK_ACCOUNT` | Use a specific account |
 | `--mailbox EMAIL` | `OLK_MAILBOX` | Target another user's mailbox (delegated read; mail/calendar/contacts). Needs the matching `.Shared` scope + Exchange Full Access |
 | `--results-only` | `OLK_RESULTS_ONLY` | Unwrap JSON envelope |
-| `--select FIELDS` | `OLK_SELECT` | Field projection |
+| `--select FIELDS` | `OLK_SELECT` | Command-specific field projection; `mail list --json` projects both the Graph request and JSON result |
 | `--force` | `OLK_FORCE` | Skip confirmations |
 | `--dry-run` | `OLK_DRY_RUN` | Preview without executing |
 | `-v, --verbose` | `OLK_VERBOSE` | Verbose output |

--- a/internal/cmd/mail_batch.go
+++ b/internal/cmd/mail_batch.go
@@ -1,10 +1,15 @@
 package cmd
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+)
 
 // MailBatchCmd fetches up to 20 messages by ID in one Graph $batch round-trip.
 type MailBatchCmd struct {
-	ID []string `help:"Message ID to fetch (repeatable, max 20)" name:"id"`
+	ID         []string `help:"Message ID to fetch (repeatable, max 20)" name:"id"`
+	BodyFormat *string  `help:"Request provider-returned message body representation" enum:"text,html"`
 }
 
 func (c *MailBatchCmd) Run(ctx *RunContext) error {
@@ -20,7 +25,15 @@ func (c *MailBatchCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	messages, err := client.GetMessagesBatch(ctx.Ctx, target, c.ID)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseMessageBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	messages, err := client.GetMessagesBatch(ctx.Ctx, target, c.ID, preference)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_get.go
+++ b/internal/cmd/mail_get.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rlrghb/olkcli/internal/graphapi"
 	"github.com/rlrghb/olkcli/internal/outfmt"
 )
 
@@ -23,7 +24,14 @@ func (c *MailGetCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	msg, err := client.GetMessage(ctx.Ctx, target, c.ID)
+	preference := graphapi.MessageBodyDefault
+	if c.Format != "full" {
+		preference, err = graphapi.ParseMessageBodyPreference(c.Format)
+		if err != nil {
+			return err
+		}
+	}
+	msg, err := client.GetMessage(ctx.Ctx, target, c.ID, preference)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -9,15 +9,15 @@ import (
 )
 
 type MailListCmd struct {
-	Folder  string `help:"Mail folder ID or well-known name" short:"f" env:"OLK_MAIL_FOLDER"`
-	Top     int32  `help:"Number of messages to return" default:"25" short:"n"`
-	Unread  bool   `help:"Show only unread messages" short:"u"`
-	From    string `help:"Filter by sender email"`
-	After   string `help:"Filter messages after date (ISO 8601)"`
-	Before  string `help:"Filter messages before date (ISO 8601)"`
-	Focused bool   `help:"Show only Focused Inbox messages"`
-	Other   bool   `help:"Show only Other Inbox messages"`
-	Order   string `help:"Message order: newest|oldest" default:"newest" enum:"newest,oldest"`
+	Folder  string  `help:"Mail folder ID or well-known name" short:"f" env:"OLK_MAIL_FOLDER"`
+	Top     int32   `help:"Number of messages to return" default:"25" short:"n"`
+	Unread  bool    `help:"Show only unread messages" short:"u"`
+	From    string  `help:"Filter by sender email"`
+	After   string  `help:"Filter messages after date (ISO 8601)"`
+	Before  string  `help:"Filter messages before date (ISO 8601)"`
+	Focused bool    `help:"Show only Focused Inbox messages"`
+	Other   bool    `help:"Show only Other Inbox messages"`
+	Order   *string `help:"Message order: newest|oldest (default newest)" enum:"newest,oldest"`
 }
 
 // mailListSelectableFields is the Graph selector set that ListMessages converts
@@ -76,13 +76,16 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	if c.Focused && c.Other {
+		return fmt.Errorf("cannot use both --focused and --other")
+	}
+	if (c.Focused || c.Other) && c.Order != nil {
+		return fmt.Errorf("--order cannot be combined with --focused or --other")
+	}
+
 	client, err := ctx.GraphClient()
 	if err != nil {
 		return err
-	}
-
-	if c.Focused && c.Other {
-		return fmt.Errorf("cannot use both --focused and --other")
 	}
 
 	filter, err := buildMailFilter(c.Unread, c.From, c.After, c.Before)
@@ -107,11 +110,19 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	order := ""
+	if c.Order != nil {
+		order = *c.Order
+	}
+	orderBy := mailListOrderBy(order)
+	if c.Focused || c.Other {
+		orderBy = ""
+	}
 	opts := graphapi.ListMessagesOptions{
 		FolderID: c.Folder,
 		Top:      c.Top,
 		Filter:   filter,
-		OrderBy:  mailListOrderBy(c.Order),
+		OrderBy:  orderBy,
 		Select:   selected,
 	}
 

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -135,13 +135,17 @@ func mailListOrderBy(order string) string {
 	return "receivedDateTime desc"
 }
 
-func parseMailSelect(selectFields string) ([]string, error) {
-	if selectFields == "" {
+func parseMailSelect(selectFields SelectFields) ([]string, error) {
+	if !selectFields.Set {
 		return nil, nil
 	}
-	fields := make([]string, 0, strings.Count(selectFields, ",")+1)
+	if selectFields.Value == "" {
+		return nil, fmt.Errorf("--select cannot be empty")
+	}
+	selectValue := selectFields.Value
+	fields := make([]string, 0, strings.Count(selectValue, ",")+1)
 	seen := make(map[string]bool, cap(fields))
-	for _, rawField := range strings.Split(selectFields, ",") {
+	for _, rawField := range strings.Split(selectValue, ",") {
 		field := strings.TrimSpace(rawField)
 		if field == "" {
 			return nil, fmt.Errorf("--select cannot contain empty fields")

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/rlrghb/olkcli/internal/graphapi"
 	"github.com/rlrghb/olkcli/internal/outfmt"
@@ -16,6 +18,7 @@ type MailListCmd struct {
 	Before  string `help:"Filter messages before date (ISO 8601)"`
 	Focused bool   `help:"Show only Focused Inbox messages"`
 	Other   bool   `help:"Show only Other Inbox messages"`
+	Order   string `help:"Message order: newest|oldest" default:"newest" enum:"newest,oldest"`
 }
 
 func (c *MailListCmd) Run(ctx *RunContext) error {
@@ -54,14 +57,39 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		FolderID: c.Folder,
 		Top:      c.Top,
 		Filter:   filter,
+		OrderBy:  mailListOrderBy(c.Order),
+		Select:   parseMailSelect(ctx.Flags.Select),
 	}
 
 	messages, err := client.ListMessages(ctx.Ctx, target, &opts)
 	if err != nil {
 		return err
 	}
+	if ctx.Flags.JSON {
+		if selected := parseMailSelect(ctx.Flags.Select); len(selected) > 0 {
+			return ctx.Printer().PrintJSON(projectMailMessages(messages, selected), len(messages), "")
+		}
+	}
 
 	return printMessageList(ctx, messages)
+}
+
+func mailListOrderBy(order string) string {
+	if order == "oldest" {
+		return "receivedDateTime asc"
+	}
+	return "receivedDateTime desc"
+}
+
+func parseMailSelect(selectFields string) []string {
+	if selectFields == "" {
+		return nil
+	}
+	fields := strings.Split(selectFields, ",")
+	for i := range fields {
+		fields[i] = strings.TrimSpace(fields[i])
+	}
+	return fields
 }
 
 // printMessageList renders a slice of messages as JSON (full structs) or an
@@ -92,4 +120,31 @@ func printMessageList(ctx *RunContext, messages []graphapi.MailMessage) error {
 	}
 
 	return printer.Print(headers, rows, messages, len(messages), "")
+}
+
+func projectMailMessages(messages []graphapi.MailMessage, selected []string) []map[string]any {
+	projected := make([]map[string]any, len(messages))
+	messageType := reflect.TypeOf(graphapi.MailMessage{})
+	for i := range messages {
+		projected[i] = map[string]any{}
+		messageValue := reflect.ValueOf(messages[i])
+		for fieldIndex := range messageType.NumField() {
+			field := messageType.Field(fieldIndex)
+			jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+			if jsonName == "" || !mailJSONFieldSelected(jsonName, selected) {
+				continue
+			}
+			projected[i][jsonName] = messageValue.Field(fieldIndex).Interface()
+		}
+	}
+	return projected
+}
+
+func mailJSONFieldSelected(jsonName string, selected []string) bool {
+	for _, field := range selected {
+		if field == jsonName || (field == "toRecipients" && jsonName == "to") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/rlrghb/olkcli/internal/graphapi"
@@ -21,7 +20,62 @@ type MailListCmd struct {
 	Order   string `help:"Message order: newest|oldest" default:"newest" enum:"newest,oldest"`
 }
 
+// mailListSelectableFields is the Graph selector set that ListMessages converts
+// into mail-list JSON fields. Keep this limited to fields ListMessages converts into
+// graphapi.MailMessage; accepting a Graph field that list output cannot render
+// would otherwise produce a silently incomplete JSON object.
+var mailListSelectableFields = map[string]bool{
+	"id":               true,
+	"subject":          true,
+	"from":             true,
+	"toRecipients":     true,
+	"receivedDateTime": true,
+	"isRead":           true,
+	"hasAttachments":   true,
+	"bodyPreview":      true,
+	"categories":       true,
+	"conversationId":   true,
+}
+
+// unsupportedMailListSelectors are valid Graph message selectors that list
+// output does not represent. Rejecting them makes the command's select
+// contract honest instead of fetching fields that would disappear in output.
+var unsupportedMailListSelectors = map[string]bool{
+	"body":                 true,
+	"ccRecipients":         true,
+	"bccRecipients":        true,
+	"importance":           true,
+	"parentFolderId":       true,
+	"sender":               true,
+	"replyTo":              true,
+	"flag":                 true,
+	"internetMessageId":    true,
+	"createdDateTime":      true,
+	"lastModifiedDateTime": true,
+}
+
+// mailListJSONMessage preserves MailMessage's output tags while allowing a
+// selector to omit every unrequested field. Pointer fields retain selected
+// zero values, whereas --concise can still zero tagged fields for omission.
+type mailListJSONMessage struct {
+	ID             *string   `json:"id,omitempty"`
+	Subject        *string   `json:"subject,omitempty" untrusted:"true"`
+	From           *string   `json:"from,omitempty" untrusted:"true"`
+	To             *[]string `json:"to,omitempty" untrusted:"true"`
+	ReceivedAt     *string   `json:"receivedDateTime,omitempty"`
+	IsRead         *bool     `json:"isRead,omitempty"`
+	HasAttachments *bool     `json:"hasAttachments,omitempty"`
+	BodyPreview    *string   `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
+	Categories     *[]string `json:"categories,omitempty"`
+	ConversationID *string   `json:"conversationId,omitempty"`
+}
+
 func (c *MailListCmd) Run(ctx *RunContext) error {
+	selected, err := parseMailSelect(ctx.Flags.Select)
+	if err != nil {
+		return err
+	}
+
 	client, err := ctx.GraphClient()
 	if err != nil {
 		return err
@@ -58,7 +112,7 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		Top:      c.Top,
 		Filter:   filter,
 		OrderBy:  mailListOrderBy(c.Order),
-		Select:   parseMailSelect(ctx.Flags.Select),
+		Select:   selected,
 	}
 
 	messages, err := client.ListMessages(ctx.Ctx, target, &opts)
@@ -66,7 +120,7 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 	if ctx.Flags.JSON {
-		if selected := parseMailSelect(ctx.Flags.Select); len(selected) > 0 {
+		if len(selected) > 0 {
 			return ctx.Printer().PrintJSON(projectMailMessages(messages, selected), len(messages), "")
 		}
 	}
@@ -81,15 +135,30 @@ func mailListOrderBy(order string) string {
 	return "receivedDateTime desc"
 }
 
-func parseMailSelect(selectFields string) []string {
+func parseMailSelect(selectFields string) ([]string, error) {
 	if selectFields == "" {
-		return nil
+		return nil, nil
 	}
-	fields := strings.Split(selectFields, ",")
-	for i := range fields {
-		fields[i] = strings.TrimSpace(fields[i])
+	fields := make([]string, 0, strings.Count(selectFields, ",")+1)
+	seen := make(map[string]bool, cap(fields))
+	for _, rawField := range strings.Split(selectFields, ",") {
+		field := strings.TrimSpace(rawField)
+		if field == "" {
+			return nil, fmt.Errorf("--select cannot contain empty fields")
+		}
+		if seen[field] {
+			return nil, fmt.Errorf("--select field %q is duplicated", field)
+		}
+		if _, ok := mailListSelectableFields[field]; !ok {
+			if unsupportedMailListSelectors[field] {
+				return nil, fmt.Errorf("--select field %q is not available in mail list output", field)
+			}
+			return nil, fmt.Errorf("invalid --select field %q", field)
+		}
+		seen[field] = true
+		fields = append(fields, field)
 	}
-	return fields
+	return fields, nil
 }
 
 // printMessageList renders a slice of messages as JSON (full structs) or an
@@ -122,29 +191,40 @@ func printMessageList(ctx *RunContext, messages []graphapi.MailMessage) error {
 	return printer.Print(headers, rows, messages, len(messages), "")
 }
 
-func projectMailMessages(messages []graphapi.MailMessage, selected []string) []map[string]any {
-	projected := make([]map[string]any, len(messages))
-	messageType := reflect.TypeOf(graphapi.MailMessage{})
+func projectMailMessages(messages []graphapi.MailMessage, selected []string) []mailListJSONMessage {
+	projected := make([]mailListJSONMessage, len(messages))
 	for i := range messages {
-		projected[i] = map[string]any{}
-		messageValue := reflect.ValueOf(messages[i])
-		for fieldIndex := range messageType.NumField() {
-			field := messageType.Field(fieldIndex)
-			jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
-			if jsonName == "" || !mailJSONFieldSelected(jsonName, selected) {
-				continue
-			}
-			projected[i][jsonName] = messageValue.Field(fieldIndex).Interface()
-		}
+		message := &messages[i]
+		projected[i] = projectMailMessage(message, selected)
 	}
 	return projected
 }
 
-func mailJSONFieldSelected(jsonName string, selected []string) bool {
+func projectMailMessage(message *graphapi.MailMessage, selected []string) mailListJSONMessage {
+	projected := mailListJSONMessage{}
 	for _, field := range selected {
-		if field == jsonName || (field == "toRecipients" && jsonName == "to") {
-			return true
+		switch field {
+		case "id":
+			projected.ID = &message.ID
+		case "subject":
+			projected.Subject = &message.Subject
+		case "from":
+			projected.From = &message.From
+		case "toRecipients":
+			projected.To = &message.To
+		case "receivedDateTime":
+			projected.ReceivedAt = &message.ReceivedAt
+		case "isRead":
+			projected.IsRead = &message.IsRead
+		case "hasAttachments":
+			projected.HasAttachments = &message.HasAttachments
+		case "bodyPreview":
+			projected.BodyPreview = &message.BodyPreview
+		case "categories":
+			projected.Categories = &message.Categories
+		case "conversationId":
+			projected.ConversationID = &message.ConversationID
 		}
 	}
-	return false
+	return projected
 }

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -272,6 +272,99 @@ func TestMailThreadJSONIgnoresGlobalSelect(t *testing.T) {
 	}
 }
 
+func TestMailGetTextRequestsVerifiedProviderRepresentation(t *testing.T) {
+	output, calls, err := runMailCommand(t, []string{"mail", "get"}, []string{"--json", "--format", "text", "message-id"}, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("Prefer = %q, want provider text preference", got)
+		}
+		resp := graphJSONResponse(req, `{"id":"message-id","body":{"contentType":"text","content":"Provider text"}}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+	if err != nil {
+		t.Fatalf("run mail get: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Graph handler calls = %d, want 1", calls)
+	}
+	var envelope struct {
+		Results map[string]any `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, output)
+	}
+	if got := envelope.Results["body"]; got != "Provider text" {
+		t.Fatalf("JSON body = %v, want provider text", got)
+	}
+}
+
+func TestMailBatchBodyFormatTextRequestsVerifiedProviderRepresentation(t *testing.T) {
+	output, calls, err := runMailCommand(t, []string{"mail", "batch"}, []string{"--json", "--id", "message-id", "--body-format", "text"}, func(req *http.Request) *http.Response {
+		var batch struct {
+			Requests []struct {
+				ID      string            `json:"id"`
+				Headers map[string]string `json:"headers"`
+			} `json:"requests"`
+		}
+		if err := decodeGraphJSON(req.Body, &batch); err != nil {
+			t.Fatalf("decode batch request: %v", err)
+		}
+		if len(batch.Requests) != 1 {
+			t.Fatalf("batch request count = %d, want 1", len(batch.Requests))
+		}
+		if got := caseInsensitiveHeader(batch.Requests[0].Headers, "Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("batch Prefer = %q, want provider text preference", got)
+		}
+		return graphJSONResponse(req, `{"responses":[{
+			"id":"`+batch.Requests[0].ID+`",
+			"status":200,
+			"headers":{"Content-Type":"application/json","Preference-Applied":"outlook.body-content-type=\"text\""},
+			"body":{"id":"message-id","body":{"contentType":"text","content":"Provider text"}}
+		}]}`)
+	})
+	if err != nil {
+		t.Fatalf("run mail batch: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Graph handler calls = %d, want 1", calls)
+	}
+	if got := firstJSONMessage(t, output)["body"]; got != "Provider text" {
+		t.Fatalf("JSON body = %v, want provider text", got)
+	}
+}
+
+func TestMailThreadBodyFormatTextRequestsVerifiedProviderRepresentation(t *testing.T) {
+	output, calls, err := runMailCommand(t, []string{"mail", "thread"}, []string{"--json", "--body-format", "text", "conversation-id"}, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("Prefer = %q, want provider text preference", got)
+		}
+		if got := req.URL.Query().Get("$select"); !strings.Contains(got, "body") {
+			t.Errorf("$select = %q, want explicit body", got)
+		}
+		resp := graphJSONResponse(req, `{"value":[{"id":"message-id","body":{"contentType":"text","content":"Provider text"}}]}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+	if err != nil {
+		t.Fatalf("run mail thread: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Graph handler calls = %d, want 1", calls)
+	}
+	if got := firstJSONMessage(t, output)["body"]; got != "Provider text" {
+		t.Fatalf("JSON body = %v, want provider text", got)
+	}
+}
+
+func caseInsensitiveHeader(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}
+
 func runMailList(t *testing.T, args ...string) (url.Values, string) {
 	t.Helper()
 	query, output, err := runMailListResult(t, args...)

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -52,6 +54,40 @@ func TestMailListSelectDrivesGraphProjectionAndJSONKeys(t *testing.T) {
 	message := firstJSONMessage(t, output)
 	if got, want := sortedJSONKeys(message), []string{"id", "receivedDateTime", "subject"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("selected JSON keys = %v, want %v", got, want)
+	}
+}
+
+func TestMailListAdmittedSelectorsSerialize(t *testing.T) {
+	cases := []struct {
+		selector string
+		jsonKey  string
+		want     any
+	}{
+		{"id", "id", "message-id"},
+		{"subject", "subject", "Hello"},
+		{"from", "from", "sender@example.com"},
+		{"receivedDateTime", "receivedDateTime", "2026-07-28T10:30:00Z"},
+		{"isRead", "isRead", false},
+		{"hasAttachments", "hasAttachments", true},
+		{"bodyPreview", "bodyPreview", "Preview"},
+		{"categories", "categories", []any{"green"}},
+		{"conversationId", "conversationId", "conversation-id"},
+		{"toRecipients", "to", []any{"recipient@example.com"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.selector, func(t *testing.T) {
+			query, output := runMailList(t, "--json", "--select", tc.selector)
+			if got := query.Get("$select"); got != tc.selector {
+				t.Errorf("$select = %q, want %q", got, tc.selector)
+			}
+			message := firstJSONMessage(t, output)
+			if got, want := sortedJSONKeys(message), []string{tc.jsonKey}; !reflect.DeepEqual(got, want) {
+				t.Errorf("JSON keys = %v, want %v", got, want)
+			}
+			if got := message[tc.jsonKey]; !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("JSON %q = %v, want %v", tc.jsonKey, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -113,42 +149,90 @@ func TestMailListTrimsSelectorWhitespace(t *testing.T) {
 	}
 }
 
+func TestMailListRejectsExplicitEmptySelect(t *testing.T) {
+	_, _, calls, err := runMailListResultWithCalls(t, "--json", "--select=")
+	if err == nil {
+		t.Fatal("mail list accepted explicit empty --select")
+	}
+	if calls != 0 {
+		t.Errorf("Graph handler calls = %d, want 0", calls)
+	}
+}
+
 func TestMailListRejectsUnserializableGraphSelector(t *testing.T) {
-	_, _, err := runMailListResult(t, "--json", "--select", "importance")
+	_, _, calls, err := runMailListResultWithCalls(t, "--json", "--select", "importance")
 	if err == nil || !strings.Contains(err.Error(), "not available in mail list output") {
 		t.Fatalf("importance selector error = %v, want serializable-output rejection", err)
+	}
+	if calls != 0 {
+		t.Errorf("Graph handler calls = %d, want 0", calls)
 	}
 }
 
 func TestMailListRejectsUnknownSelector(t *testing.T) {
-	_, _, err := runMailListResult(t, "--json", "--select", "notAField")
+	_, _, calls, err := runMailListResultWithCalls(t, "--json", "--select", "notAField")
 	if err == nil || !strings.Contains(err.Error(), "invalid --select field") {
 		t.Fatalf("unknown selector error = %v, want --select validation error", err)
+	}
+	if calls != 0 {
+		t.Errorf("Graph handler calls = %d, want 0", calls)
 	}
 }
 
 func TestMailListRejectsEmptyAndDuplicateSelectors(t *testing.T) {
 	for _, selectFields := range []string{" ", "id, ,subject", "id,id"} {
 		t.Run(selectFields, func(t *testing.T) {
-			_, _, err := runMailListResult(t, "--json", "--select", selectFields)
+			_, _, calls, err := runMailListResultWithCalls(t, "--json", "--select", selectFields)
 			if err == nil || !strings.Contains(err.Error(), "--select") {
 				t.Fatalf("selector %q error = %v, want local --select validation error", selectFields, err)
+			}
+			if calls != 0 {
+				t.Errorf("Graph handler calls = %d, want 0", calls)
 			}
 		})
 	}
 }
 
-func TestPrintMessageListKeepsJSONUnprojectedForOtherMailCommands(t *testing.T) {
-	ctx := &RunContext{Flags: &RootFlags{JSON: true, Select: "subject"}}
-	output, _, err := captureStd(func() error {
-		return printMessageList(ctx, []graphapi.MailMessage{{ID: "message-id", Subject: "Hello"}})
+func TestMailBatchJSONIgnoresGlobalSelect(t *testing.T) {
+	output, calls, err := runMailCommand(t, []string{"mail", "batch"}, []string{"--json", "--select", "subject", "--id", "message-id"}, func(req *http.Request) *http.Response {
+		var batch struct {
+			Requests []struct {
+				ID string `json:"id"`
+			} `json:"requests"`
+		}
+		if err := decodeGraphJSON(req.Body, &batch); err != nil {
+			t.Fatalf("decode batch request: %v", err)
+		}
+		if len(batch.Requests) != 1 {
+			t.Fatalf("batch request count = %d, want 1", len(batch.Requests))
+		}
+		return graphBatchResponse(req, batch.Requests[0].ID)
 	})
 	if err != nil {
-		t.Fatalf("printMessageList: %v", err)
+		t.Fatalf("run mail batch: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Graph handler calls = %d, want 1", calls)
 	}
 	message := firstJSONMessage(t, output)
 	if _, found := message["id"]; !found {
-		t.Errorf("shared formatter applied mail-list projection: %v", message)
+		t.Errorf("mail batch applied mail-list projection: %v", message)
+	}
+}
+
+func TestMailThreadJSONIgnoresGlobalSelect(t *testing.T) {
+	output, calls, err := runMailCommand(t, []string{"mail", "thread"}, []string{"--json", "--select", "subject", "conversation-id"}, func(req *http.Request) *http.Response {
+		return graphMessageListResponse(req)
+	})
+	if err != nil {
+		t.Fatalf("run mail thread: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Graph handler calls = %d, want 1", calls)
+	}
+	message := firstJSONMessage(t, output)
+	if _, found := message["id"]; !found {
+		t.Errorf("mail thread applied mail-list projection: %v", message)
 	}
 }
 
@@ -162,41 +246,28 @@ func runMailList(t *testing.T, args ...string) (url.Values, string) {
 }
 
 func runMailListResult(t *testing.T, args ...string) (url.Values, string, error) {
+	query, output, _, err := runMailListResultWithCalls(t, args...)
+	return query, output, err
+}
+
+func runMailListResultWithCalls(t *testing.T, args ...string) (url.Values, string, int, error) {
 	t.Helper()
 	var query url.Values
+	calls := 0
 	client := testMailListClient(t, func(req *http.Request) *http.Response {
+		calls++
 		query = req.URL.Query()
-		body := `{
-			"value": [{
-				"id": "message-id",
-				"subject": "Hello",
-				"from": {"emailAddress": {"address": "sender@example.com"}},
-				"toRecipients": [{"emailAddress": {"address": "recipient@example.com"}}],
-				"receivedDateTime": "2026-07-28T10:30:00Z",
-				"isRead": false,
-				"hasAttachments": true,
-				"bodyPreview": "Preview",
-				"categories": ["green"],
-				"conversationId": "conversation-id"
-			}]
-		}`
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Header:        http.Header{"Content-Type": []string{"application/json"}},
-			Body:          io.NopCloser(strings.NewReader(body)),
-			Request:       req,
-			ContentLength: int64(len(body)),
-		}
+		return graphMessageListResponse(req)
 	})
 
 	cli := &CLI{}
 	parser, err := newKongParser(cli)
 	if err != nil {
-		return nil, "", err
+		return nil, "", calls, err
 	}
 	kctx, err := parser.Parse(append([]string{"mail", "list"}, args...))
 	if err != nil {
-		return nil, "", err
+		return nil, "", calls, err
 	}
 
 	output, _, err := captureStd(func() error {
@@ -206,7 +277,94 @@ func runMailListResult(t *testing.T, args ...string) (url.Values, string, error)
 			client: client,
 		})
 	})
-	return query, output, err
+	return query, output, calls, err
+}
+
+func runMailCommand(t *testing.T, path, args []string, responder func(*http.Request) *http.Response) (string, int, error) {
+	t.Helper()
+	calls := 0
+	client := testMailListClient(t, func(req *http.Request) *http.Response {
+		calls++
+		return responder(req)
+	})
+	cli := &CLI{}
+	parser, err := newKongParser(cli)
+	if err != nil {
+		return "", calls, err
+	}
+	kctx, err := parser.Parse(append(path, args...))
+	if err != nil {
+		return "", calls, err
+	}
+	output, _, err := captureStd(func() error {
+		return kctx.Run(&RunContext{Ctx: context.Background(), Flags: &cli.RootFlags, client: client})
+	})
+	return output, calls, err
+}
+
+func graphMessageListResponse(req *http.Request) *http.Response {
+	body := `{
+		"value": [{
+			"id": "message-id",
+			"subject": "Hello",
+			"from": {"emailAddress": {"address": "sender@example.com"}},
+			"toRecipients": [{"emailAddress": {"address": "recipient@example.com"}}],
+			"receivedDateTime": "2026-07-28T10:30:00Z",
+			"isRead": false,
+			"hasAttachments": true,
+			"bodyPreview": "Preview",
+			"categories": ["green"],
+			"conversationId": "conversation-id"
+		}]
+	}`
+	return graphJSONResponse(req, body)
+}
+
+func graphBatchResponse(req *http.Request, stepID string) *http.Response {
+	body := `{
+		"responses": [{
+			"id": "` + stepID + `",
+			"status": 200,
+			"headers": {"Content-Type": "application/json"},
+			"body": {
+				"id": "message-id",
+				"subject": "Hello",
+				"from": {"emailAddress": {"address": "sender@example.com"}},
+				"receivedDateTime": "2026-07-28T10:30:00Z",
+				"isRead": false,
+				"hasAttachments": true,
+				"bodyPreview": "Preview",
+				"conversationId": "conversation-id"
+			}
+		}]
+	}`
+	return graphJSONResponse(req, body)
+}
+
+func graphJSONResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		Request:       req,
+		ContentLength: int64(len(body)),
+	}
+}
+
+func decodeGraphJSON(reader io.Reader, target any) error {
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	if len(body) >= 2 && body[0] == 0x1f && body[1] == 0x8b {
+		gzipReader, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer gzipReader.Close()
+		return json.NewDecoder(gzipReader).Decode(target)
+	}
+	return json.Unmarshal(body, target)
 }
 
 func testMailListClient(t *testing.T, handler func(*http.Request) *http.Response) *graphapi.Client {

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+)
+
+func TestMailListDefaultsToNewestOrder(t *testing.T) {
+	query, _ := runMailList(t, "--json")
+	if got := query.Get("$orderby"); got != "receivedDateTime desc" {
+		t.Errorf("default $orderby = %q, want newest-first", got)
+	}
+}
+
+func TestMailListAcceptsOldestOrder(t *testing.T) {
+	query, _ := runMailList(t, "--json", "--order", "oldest")
+	if got := query.Get("$orderby"); got != "receivedDateTime asc" {
+		t.Errorf("oldest $orderby = %q, want oldest-first", got)
+	}
+}
+
+func TestMailListRejectsInvalidOrder(t *testing.T) {
+	cli := &CLI{}
+	parser, err := newKongParser(cli)
+	if err != nil {
+		t.Fatalf("newKongParser: %v", err)
+	}
+	if _, err := parser.Parse([]string{"mail", "list", "--order", "middle"}); err == nil {
+		t.Fatal("mail list accepted invalid --order")
+	}
+}
+
+func TestMailListSelectDrivesGraphProjectionAndJSONKeys(t *testing.T) {
+	query, output := runMailList(t, "--json", "--select", "id,subject,receivedDateTime")
+	if got, want := query.Get("$select"), "id,subject,receivedDateTime"; got != want {
+		t.Errorf("$select = %q, want %q", got, want)
+	}
+
+	message := firstJSONMessage(t, output)
+	if got, want := sortedJSONKeys(message), []string{"id", "receivedDateTime", "subject"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("selected JSON keys = %v, want %v", got, want)
+	}
+}
+
+func TestMailListWithoutSelectKeepsDefaultJSON(t *testing.T) {
+	_, output := runMailList(t, "--json")
+	message := firstJSONMessage(t, output)
+	want := []string{"bodyPreview", "categories", "conversationId", "from", "hasAttachments", "id", "isRead", "receivedDateTime", "subject", "to"}
+	if got := sortedJSONKeys(message); !reflect.DeepEqual(got, want) {
+		t.Errorf("default JSON keys = %v, want %v", got, want)
+	}
+}
+
+func runMailList(t *testing.T, args ...string) (url.Values, string) {
+	t.Helper()
+	var query url.Values
+	client := testMailListClient(t, func(req *http.Request) *http.Response {
+		query = req.URL.Query()
+		body := `{
+			"value": [{
+				"id": "message-id",
+				"subject": "Hello",
+				"from": {"emailAddress": {"address": "sender@example.com"}},
+				"receivedDateTime": "2026-07-28T10:30:00Z",
+				"isRead": false,
+				"hasAttachments": true,
+				"bodyPreview": "Preview",
+				"categories": ["green"],
+				"conversationId": "conversation-id"
+			}]
+		}`
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": []string{"application/json"}},
+			Body:          io.NopCloser(strings.NewReader(body)),
+			Request:       req,
+			ContentLength: int64(len(body)),
+		}
+	})
+
+	cli := &CLI{}
+	parser, err := newKongParser(cli)
+	if err != nil {
+		t.Fatalf("newKongParser: %v", err)
+	}
+	kctx, err := parser.Parse(append([]string{"mail", "list"}, args...))
+	if err != nil {
+		t.Fatalf("parse mail list: %v", err)
+	}
+
+	output, _, err := captureStd(func() error {
+		return kctx.Run(&RunContext{
+			Ctx:    context.Background(),
+			Flags:  &cli.RootFlags,
+			client: client,
+		})
+	})
+	if err != nil {
+		t.Fatalf("run mail list: %v", err)
+	}
+	return query, output
+}
+
+func testMailListClient(t *testing.T, handler func(*http.Request) *http.Response) *graphapi.Client {
+	t.Helper()
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = mailListRoundTrip(handler)
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	client, err := graphapi.NewClient(mailListCredential{})
+	if err != nil {
+		t.Fatalf("new Graph client: %v", err)
+	}
+	return client
+}
+
+type mailListRoundTrip func(*http.Request) *http.Response
+
+func (f mailListRoundTrip) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+type mailListCredential struct{}
+
+func (mailListCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "test-token", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func firstJSONMessage(t *testing.T, output string) map[string]any {
+	t.Helper()
+	var envelope struct {
+		Results []map[string]any `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, output)
+	}
+	if len(envelope.Results) != 1 {
+		t.Fatalf("result count = %d, want 1", len(envelope.Results))
+	}
+	return envelope.Results[0]
+}
+
+func sortedJSONKeys(value map[string]any) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -335,21 +335,39 @@ func TestMailBatchBodyFormatTextRequestsVerifiedProviderRepresentation(t *testin
 
 func TestMailThreadBodyFormatTextRequestsVerifiedProviderRepresentation(t *testing.T) {
 	output, calls, err := runMailCommand(t, []string{"mail", "thread"}, []string{"--json", "--body-format", "text", "conversation-id"}, func(req *http.Request) *http.Response {
-		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
-			t.Errorf("Prefer = %q, want provider text preference", got)
+		if req.URL.Path != "/v1.0/$batch" {
+			if got := req.Header.Get("Prefer"); got != "" {
+				t.Errorf("metadata Prefer = %q, want none", got)
+			}
+			return graphJSONResponse(req, `{"value":[{"id":"message-id"}]}`)
 		}
-		if got := req.URL.Query().Get("$select"); !strings.Contains(got, "body") {
-			t.Errorf("$select = %q, want explicit body", got)
+		var batch struct {
+			Requests []struct {
+				ID      string            `json:"id"`
+				Headers map[string]string `json:"headers"`
+			} `json:"requests"`
 		}
-		resp := graphJSONResponse(req, `{"value":[{"id":"message-id","body":{"contentType":"text","content":"Provider text"}}]}`)
-		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
-		return resp
+		if err := decodeGraphJSON(req.Body, &batch); err != nil {
+			t.Fatalf("decode batch request: %v", err)
+		}
+		if len(batch.Requests) != 1 {
+			t.Fatalf("batch request count = %d, want 1", len(batch.Requests))
+		}
+		if got := caseInsensitiveHeader(batch.Requests[0].Headers, "Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("batch Prefer = %q, want provider text preference", got)
+		}
+		return graphJSONResponse(req, `{"responses":[{
+			"id":"`+batch.Requests[0].ID+`",
+			"status":200,
+			"headers":{"Content-Type":"application/json","Preference-Applied":"outlook.body-content-type=\"text\""},
+			"body":{"id":"message-id","conversationId":"conversation-id","body":{"contentType":"text","content":"Provider text"}}
+		}]}`)
 	})
 	if err != nil {
 		t.Fatalf("run mail thread: %v", err)
 	}
-	if calls != 1 {
-		t.Fatalf("Graph handler calls = %d, want 1", calls)
+	if calls != 2 {
+		t.Fatalf("Graph handler calls = %d, want 2", calls)
 	}
 	if got := firstJSONMessage(t, output)["body"]; got != "Provider text" {
 		t.Fatalf("JSON body = %v, want provider text", got)

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -64,7 +64,104 @@ func TestMailListWithoutSelectKeepsDefaultJSON(t *testing.T) {
 	}
 }
 
+func TestMailListSelectPreservesUntrustedWrapping(t *testing.T) {
+	_, output := runMailList(t, "--json", "--select", "subject", "--wrap-untrusted")
+	var envelope struct {
+		UntrustedNotice string           `json:"untrustedNotice"`
+		Results         []map[string]any `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, output)
+	}
+	if envelope.UntrustedNotice == "" {
+		t.Fatal("selected JSON omitted the untrusted-content notice")
+	}
+	if got, _ := envelope.Results[0]["subject"].(string); !strings.HasPrefix(got, "[UNTRUSTED:") {
+		t.Errorf("selected subject = %q, want untrusted-content marker", got)
+	}
+}
+
+func TestMailListSelectPreservesConciseOutput(t *testing.T) {
+	_, output := runMailList(t, "--json", "--select", "bodyPreview", "--concise")
+	message := firstJSONMessage(t, output)
+	if _, found := message["bodyPreview"]; found {
+		t.Errorf("--concise retained selected bodyPreview: %v", message)
+	}
+}
+
+func TestMailListSelectMapsToRecipientsToCanonicalJSONKey(t *testing.T) {
+	query, output := runMailList(t, "--json", "--select", "toRecipients")
+	if got := query.Get("$select"); got != "toRecipients" {
+		t.Errorf("$select = %q, want toRecipients", got)
+	}
+	message := firstJSONMessage(t, output)
+	if got, want := sortedJSONKeys(message), []string{"to"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("toRecipients JSON keys = %v, want %v", got, want)
+	}
+	if got, want := message["to"], []any{"recipient@example.com"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("toRecipients JSON value = %v, want %v", got, want)
+	}
+}
+
+func TestMailListTrimsSelectorWhitespace(t *testing.T) {
+	query, output := runMailList(t, "--json", "--select", " id , subject ")
+	if got := query.Get("$select"); got != "id,subject" {
+		t.Errorf("trimmed $select = %q, want id,subject", got)
+	}
+	if got, want := sortedJSONKeys(firstJSONMessage(t, output)), []string{"id", "subject"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("trimmed selector JSON keys = %v, want %v", got, want)
+	}
+}
+
+func TestMailListRejectsUnserializableGraphSelector(t *testing.T) {
+	_, _, err := runMailListResult(t, "--json", "--select", "importance")
+	if err == nil || !strings.Contains(err.Error(), "not available in mail list output") {
+		t.Fatalf("importance selector error = %v, want serializable-output rejection", err)
+	}
+}
+
+func TestMailListRejectsUnknownSelector(t *testing.T) {
+	_, _, err := runMailListResult(t, "--json", "--select", "notAField")
+	if err == nil || !strings.Contains(err.Error(), "invalid --select field") {
+		t.Fatalf("unknown selector error = %v, want --select validation error", err)
+	}
+}
+
+func TestMailListRejectsEmptyAndDuplicateSelectors(t *testing.T) {
+	for _, selectFields := range []string{" ", "id, ,subject", "id,id"} {
+		t.Run(selectFields, func(t *testing.T) {
+			_, _, err := runMailListResult(t, "--json", "--select", selectFields)
+			if err == nil || !strings.Contains(err.Error(), "--select") {
+				t.Fatalf("selector %q error = %v, want local --select validation error", selectFields, err)
+			}
+		})
+	}
+}
+
+func TestPrintMessageListKeepsJSONUnprojectedForOtherMailCommands(t *testing.T) {
+	ctx := &RunContext{Flags: &RootFlags{JSON: true, Select: "subject"}}
+	output, _, err := captureStd(func() error {
+		return printMessageList(ctx, []graphapi.MailMessage{{ID: "message-id", Subject: "Hello"}})
+	})
+	if err != nil {
+		t.Fatalf("printMessageList: %v", err)
+	}
+	message := firstJSONMessage(t, output)
+	if _, found := message["id"]; !found {
+		t.Errorf("shared formatter applied mail-list projection: %v", message)
+	}
+}
+
 func runMailList(t *testing.T, args ...string) (url.Values, string) {
+	t.Helper()
+	query, output, err := runMailListResult(t, args...)
+	if err != nil {
+		t.Fatalf("run mail list: %v", err)
+	}
+	return query, output
+}
+
+func runMailListResult(t *testing.T, args ...string) (url.Values, string, error) {
 	t.Helper()
 	var query url.Values
 	client := testMailListClient(t, func(req *http.Request) *http.Response {
@@ -74,6 +171,7 @@ func runMailList(t *testing.T, args ...string) (url.Values, string) {
 				"id": "message-id",
 				"subject": "Hello",
 				"from": {"emailAddress": {"address": "sender@example.com"}},
+				"toRecipients": [{"emailAddress": {"address": "recipient@example.com"}}],
 				"receivedDateTime": "2026-07-28T10:30:00Z",
 				"isRead": false,
 				"hasAttachments": true,
@@ -94,11 +192,11 @@ func runMailList(t *testing.T, args ...string) (url.Values, string) {
 	cli := &CLI{}
 	parser, err := newKongParser(cli)
 	if err != nil {
-		t.Fatalf("newKongParser: %v", err)
+		return nil, "", err
 	}
 	kctx, err := parser.Parse(append([]string{"mail", "list"}, args...))
 	if err != nil {
-		t.Fatalf("parse mail list: %v", err)
+		return nil, "", err
 	}
 
 	output, _, err := captureStd(func() error {
@@ -108,10 +206,7 @@ func runMailList(t *testing.T, args ...string) (url.Values, string) {
 			client: client,
 		})
 	})
-	if err != nil {
-		t.Fatalf("run mail list: %v", err)
-	}
-	return query, output
+	return query, output, err
 }
 
 func testMailListClient(t *testing.T, handler func(*http.Request) *http.Response) *graphapi.Client {

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -34,6 +34,42 @@ func TestMailListAcceptsOldestOrder(t *testing.T) {
 	}
 }
 
+func TestMailListClassificationFiltersUseProviderOrderWhenOrderOmitted(t *testing.T) {
+	for _, classification := range []struct {
+		flag       string
+		wantFilter string
+	}{
+		{"--focused", "inferenceClassification eq 'focused'"},
+		{"--other", "inferenceClassification eq 'other'"},
+	} {
+		t.Run(classification.flag, func(t *testing.T) {
+			query, _ := runMailList(t, "--json", classification.flag)
+			if got := query.Get("$orderby"); got != "" {
+				t.Errorf("$orderby = %q, want provider default", got)
+			}
+			if got := query.Get("$filter"); got != classification.wantFilter {
+				t.Errorf("$filter = %q, want %q", got, classification.wantFilter)
+			}
+		})
+	}
+}
+
+func TestMailListRejectsExplicitOrderWithClassificationWithoutRequest(t *testing.T) {
+	for _, classification := range []string{"--focused", "--other"} {
+		for _, order := range []string{"newest", "oldest"} {
+			t.Run(classification+"/"+order, func(t *testing.T) {
+				_, _, calls, err := runMailListResultWithCalls(t, "--json", classification, "--order", order)
+				if err == nil || !strings.Contains(err.Error(), "--order cannot be combined with --focused or --other") {
+					t.Fatalf("mail list error = %v, want incompatible-order rejection", err)
+				}
+				if calls != 0 {
+					t.Errorf("Graph handler calls = %d, want 0", calls)
+				}
+			})
+		}
+	}
+}
+
 func TestMailListRejectsInvalidOrder(t *testing.T) {
 	cli := &CLI{}
 	parser, err := newKongParser(cli)

--- a/internal/cmd/mail_thread.go
+++ b/internal/cmd/mail_thread.go
@@ -1,11 +1,14 @@
 package cmd
 
+import "github.com/rlrghb/olkcli/internal/graphapi"
+
 // MailThreadCmd returns every message in a conversation, oldest first. The
 // conversation id comes from a message's conversationId field (shown by mail
 // list and mail get).
 type MailThreadCmd struct {
-	ConversationID string `arg:"" help:"Conversation ID (a message's conversationId)" name:"conversation-id"`
-	Top            int32  `help:"Max messages to return" default:"50" short:"n"`
+	ConversationID string  `arg:"" help:"Conversation ID (a message's conversationId)" name:"conversation-id"`
+	Top            int32   `help:"Max messages to return" default:"50" short:"n"`
+	BodyFormat     *string `help:"Request provider-returned message body representation" enum:"text,html"`
 }
 
 func (c *MailThreadCmd) Run(ctx *RunContext) error {
@@ -18,7 +21,15 @@ func (c *MailThreadCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	messages, err := client.ListThread(ctx.Ctx, target, c.ConversationID, c.Top)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseMessageBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	messages, err := client.ListThread(ctx.Ctx, target, c.ConversationID, c.Top, preference)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,19 +24,19 @@ var (
 )
 
 type RootFlags struct {
-	JSON        bool   `help:"Output as JSON" env:"OLK_JSON"`
-	Plain       bool   `help:"Output as plain TSV" env:"OLK_PLAIN"`
-	Account     string `help:"Account email to use" env:"OLK_ACCOUNT"`
-	Mailbox     string `help:"Target a different user's mailbox via delegated access (requires Mail.Read.Shared at login)" env:"OLK_MAILBOX"`
-	Verbose     bool   `help:"Verbose output" short:"v" env:"OLK_VERBOSE"`
-	DryRun      bool   `help:"Dry run mode" env:"OLK_DRY_RUN"`
-	Force       bool   `help:"Force operation" env:"OLK_FORCE"`
-	Color       string `help:"Color mode: auto|never|always" default:"auto" env:"OLK_COLOR" enum:"auto,never,always"`
-	Select      string `help:"Comma-separated fields to output" env:"OLK_SELECT"`
-	ResultsOnly bool   `help:"Output only the results array (no envelope)" env:"OLK_RESULTS_ONLY"`
-	Concise     bool   `help:"Drop large free-text fields (message/event/task bodies, previews, attendee lists) from JSON output to reduce size" env:"OLK_CONCISE"`
-	Timeout     int    `help:"Request timeout in seconds" default:"60" env:"OLK_TIMEOUT"`
-	TimeZone    string `help:"IANA time zone for display (e.g. America/New_York, Local, UTC)" name:"tz" env:"OLK_TIMEZONE"`
+	JSON        bool         `help:"Output as JSON" env:"OLK_JSON"`
+	Plain       bool         `help:"Output as plain TSV" env:"OLK_PLAIN"`
+	Account     string       `help:"Account email to use" env:"OLK_ACCOUNT"`
+	Mailbox     string       `help:"Target a different user's mailbox via delegated access (requires Mail.Read.Shared at login)" env:"OLK_MAILBOX"`
+	Verbose     bool         `help:"Verbose output" short:"v" env:"OLK_VERBOSE"`
+	DryRun      bool         `help:"Dry run mode" env:"OLK_DRY_RUN"`
+	Force       bool         `help:"Force operation" env:"OLK_FORCE"`
+	Color       string       `help:"Color mode: auto|never|always" default:"auto" env:"OLK_COLOR" enum:"auto,never,always"`
+	Select      SelectFields `help:"Comma-separated fields to output" env:"OLK_SELECT"`
+	ResultsOnly bool         `help:"Output only the results array (no envelope)" env:"OLK_RESULTS_ONLY"`
+	Concise     bool         `help:"Drop large free-text fields (message/event/task bodies, previews, attendee lists) from JSON output to reduce size" env:"OLK_CONCISE"`
+	Timeout     int          `help:"Request timeout in seconds" default:"60" env:"OLK_TIMEOUT"`
+	TimeZone    string       `help:"IANA time zone for display (e.g. America/New_York, Local, UTC)" name:"tz" env:"OLK_TIMEZONE"`
 
 	// Capability guards (enforced for CLI, MCP, scripts, and --mailbox alike).
 	// Named --no-write rather than --read-only because `auth login --read-only`
@@ -50,6 +50,19 @@ type RootFlags struct {
 	EnableCommands      string `help:"Allow only these command prefixes (csv; e.g. mail,calendar)" env:"OLK_ENABLE_COMMANDS"`
 	EnableCommandsExact string `help:"Allow only these exact command paths (csv; e.g. mail.list,mail.get)" env:"OLK_ENABLE_COMMANDS_EXACT"`
 	DisableCommands     string `help:"Block these command paths (csv; overrides allows)" env:"OLK_DISABLE_COMMANDS"`
+}
+
+// SelectFields records whether --select was supplied so an explicit empty
+// value can be rejected instead of being confused with an absent selection.
+type SelectFields struct {
+	Value string
+	Set   bool
+}
+
+func (s *SelectFields) UnmarshalText(value []byte) error {
+	s.Value = string(value)
+	s.Set = true
+	return nil
 }
 
 type RunContext struct {
@@ -174,7 +187,7 @@ func (r *RunContext) Printer() *outfmt.Printer {
 	if loc, err := r.Timezone(); err == nil {
 		tzName = loc.String()
 	}
-	return outfmt.NewPrinter(r.Flags.JSON, r.Flags.Plain, r.Flags.ResultsOnly, r.Flags.Select, tzName, r.Flags.WrapUntrusted, r.Flags.Concise)
+	return outfmt.NewPrinter(r.Flags.JSON, r.Flags.Plain, r.Flags.ResultsOnly, r.Flags.Select.Value, tzName, r.Flags.WrapUntrusted, r.Flags.Concise)
 }
 
 type CLI struct {

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -8,14 +8,17 @@ import (
 type VersionCmd struct{}
 
 type versionInfo struct {
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
-	Date    string `json:"date"`
+	Version      string   `json:"version"`
+	Commit       string   `json:"commit"`
+	Date         string   `json:"date"`
+	Capabilities []string `json:"capabilities"`
 }
+
+var advertisedCapabilities = []string{"mail.provider-body-format-v1"}
 
 func (c *VersionCmd) Run(ctx *RunContext) error {
 	if ctx.Flags.JSON {
-		info := versionInfo{Version: Version, Commit: Commit, Date: Date}
+		info := versionInfo{Version: Version, Commit: Commit, Date: Date, Capabilities: advertisedCapabilities}
 		data, err := json.Marshal(info)
 		if err != nil {
 			return err

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestVersionJSONAdvertisesProviderBodyFormatCapability(t *testing.T) {
+	flags := &RootFlags{JSON: true}
+	stdout, _, err := captureStd(func() error {
+		return (&VersionCmd{}).Run(&RunContext{Ctx: context.Background(), Flags: flags})
+	})
+	if err != nil {
+		t.Fatalf("VersionCmd.Run() error = %v", err)
+	}
+
+	var got struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &got); err != nil {
+		t.Fatalf("decoding version JSON: %v\n%s", err, stdout)
+	}
+	if want := []string{"mail.provider-body-format-v1"}; !reflect.DeepEqual(got.Capabilities, want) {
+		t.Fatalf("capabilities = %v, want %v", got.Capabilities, want)
+	}
+}

--- a/internal/graphapi/delta.go
+++ b/internal/graphapi/delta.go
@@ -3,8 +3,6 @@ package graphapi
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strings"
 	"time"
 
 	abs "github.com/microsoft/kiota-abstractions-go"
@@ -74,31 +72,14 @@ func deltaPageFrom(r deltaLinker) DeltaPage {
 	return DeltaPage{Complete: true}
 }
 
-// graphAPIHosts are the Microsoft Graph endpoints a delta continuation token may
-// target. A token is a full Graph URL replayed with the authenticated adapter,
-// so it must be validated before use to avoid sending the bearer token to an
-// attacker-supplied host (SSRF / token exfiltration).
+// graphAPIHosts are the Microsoft Graph endpoints continuations may target. A
+// continuation is a full Graph URL replayed with the authenticated adapter, so
+// it must be validated before use to avoid bearer-token exfiltration.
 var graphAPIHosts = map[string]bool{
 	"graph.microsoft.com":             true,
 	"graph.microsoft.us":              true, // US Government L4
 	"dod-graph.microsoft.us":          true, // US Government L5 (DOD)
 	"microsoftgraph.chinacloudapi.cn": true, // 21Vianet (China)
-}
-
-// validateDeltaToken rejects a continuation token that isn't an HTTPS Microsoft
-// Graph URL, so a model can't redirect an authenticated request elsewhere.
-func validateDeltaToken(raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("invalid delta token")
-	}
-	if !strings.EqualFold(u.Scheme, "https") {
-		return fmt.Errorf("refusing non-HTTPS delta token")
-	}
-	if !graphAPIHosts[strings.ToLower(u.Hostname())] {
-		return fmt.Errorf("refusing delta token for untrusted host %q", u.Hostname())
-	}
-	return nil
 }
 
 func isRemoved(additionalData map[string]any) bool {
@@ -121,7 +102,7 @@ func (c *Client) DeltaMessages(ctx context.Context, target, folderID, token stri
 		cfg := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{Headers: maxPageSizeHeaders(top)}
 		resp, err = c.targetUser(target).MailFolders().ByMailFolderId(folderID).Messages().Delta().GetAsDeltaGetResponse(ctx, cfg)
 	} else {
-		if err := validateDeltaToken(token); err != nil {
+		if err := validateGraphContinuation(token, mailMessagesDeltaScope(target, folderID)); err != nil {
 			return nil, DeltaPage{}, err
 		}
 		rb := users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(token, c.inner.GetAdapter())
@@ -150,7 +131,7 @@ func (c *Client) DeltaCalendarView(ctx context.Context, target, token string, st
 		cfg := &users.ItemCalendarViewDeltaRequestBuilderGetRequestConfiguration{QueryParameters: qp, Headers: maxPageSizeHeaders(top)}
 		resp, err = c.targetUser(target).CalendarView().Delta().GetAsDeltaGetResponse(ctx, cfg)
 	} else {
-		if err := validateDeltaToken(token); err != nil {
+		if err := validateGraphContinuation(token, calendarViewDeltaScope(target)); err != nil {
 			return nil, DeltaPage{}, err
 		}
 		rb := users.NewItemCalendarViewDeltaRequestBuilder(token, c.inner.GetAdapter())
@@ -175,7 +156,7 @@ func (c *Client) DeltaContacts(ctx context.Context, target, token string, top in
 		cfg := &users.ItemContactsDeltaRequestBuilderGetRequestConfiguration{Headers: maxPageSizeHeaders(top)}
 		resp, err = c.targetUser(target).Contacts().Delta().GetAsDeltaGetResponse(ctx, cfg)
 	} else {
-		if err := validateDeltaToken(token); err != nil {
+		if err := validateGraphContinuation(token, contactsDeltaScope(target)); err != nil {
 			return nil, DeltaPage{}, err
 		}
 		rb := users.NewItemContactsDeltaRequestBuilder(token, c.inner.GetAdapter())

--- a/internal/graphapi/delta_test.go
+++ b/internal/graphapi/delta_test.go
@@ -13,11 +13,11 @@ func TestValidateDeltaContinuation(t *testing.T) {
 		},
 		{
 			url:   "https://graph.microsoft.us/v1.0/me/contacts/delta?$skiptoken=xyz",
-			scope: contactsDeltaScope(""),
+			scope: continuationScope("graph.microsoft.us", "/v1.0/me/contacts/delta"),
 		},
 		{
 			url:   "https://microsoftgraph.chinacloudapi.cn/v1.0/me/calendarView/delta?$deltatoken=q",
-			scope: calendarViewDeltaScope(""),
+			scope: continuationScope("microsoftgraph.chinacloudapi.cn", "/v1.0/me/calendarView/delta"),
 		},
 	}
 	for _, tc := range tests {

--- a/internal/graphapi/delta_test.go
+++ b/internal/graphapi/delta_test.go
@@ -2,26 +2,27 @@ package graphapi
 
 import "testing"
 
-func TestValidateDeltaToken(t *testing.T) {
-	ok := []string{
-		"https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=abc",
-		"https://graph.microsoft.us/v1.0/me/contacts/delta?$skiptoken=xyz",
-		"https://microsoftgraph.chinacloudapi.cn/v1.0/me/calendarView/delta?$deltatoken=q",
+func TestValidateDeltaContinuation(t *testing.T) {
+	tests := []struct {
+		url   string
+		scope graphContinuationScope
+	}{
+		{
+			url:   "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=abc",
+			scope: mailMessagesDeltaScope("", "inbox"),
+		},
+		{
+			url:   "https://graph.microsoft.us/v1.0/me/contacts/delta?$skiptoken=xyz",
+			scope: contactsDeltaScope(""),
+		},
+		{
+			url:   "https://microsoftgraph.chinacloudapi.cn/v1.0/me/calendarView/delta?$deltatoken=q",
+			scope: calendarViewDeltaScope(""),
+		},
 	}
-	for _, u := range ok {
-		if err := validateDeltaToken(u); err != nil {
-			t.Errorf("expected %q to be accepted, got %v", u, err)
-		}
-	}
-	bad := []string{
-		"http://graph.microsoft.com/v1.0/me/messages/delta",        // non-https
-		"https://evil.example.com/v1.0/me/messages/delta?$token=x", // untrusted host
-		"https://graph.microsoft.com.evil.com/delta",               // suffix trick
-		"::not a url", // unparseable
-	}
-	for _, u := range bad {
-		if err := validateDeltaToken(u); err == nil {
-			t.Errorf("expected %q to be rejected", u)
+	for _, tc := range tests {
+		if err := validateGraphContinuation(tc.url, tc.scope); err != nil {
+			t.Errorf("expected %q to be accepted, got %v", tc.url, err)
 		}
 	}
 }

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -78,12 +78,13 @@ type MailFolder struct {
 
 // ListMessagesOptions for filtering messages
 type ListMessagesOptions struct {
-	FolderID string
-	Top      int32
-	Filter   string
-	OrderBy  string
-	Search   string
-	Select   []string
+	FolderID       string
+	Top            int32
+	Filter         string
+	OrderBy        string
+	Search         string
+	Select         []string
+	BodyPreference MessageBodyPreference
 }
 
 // ListMessages returns messages from the target mailbox, or the signed-in user's
@@ -95,6 +96,9 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		opts = &ListMessagesOptions{}
 	}
 	top := clampTop(opts.Top)
+	if _, err := opts.BodyPreference.headerValue(); err != nil {
+		return nil, err
+	}
 
 	hasInferenceClassification := strings.Contains(opts.Filter, "inferenceClassification")
 	if opts.OrderBy != "" && hasInferenceClassification {
@@ -131,7 +135,7 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 				return nil, fmt.Errorf("invalid select field: %q", f)
 			}
 		}
-		queryParams.Select = opts.Select
+		queryParams.Select = append([]string(nil), opts.Select...)
 	} else {
 		queryParams.Select = []string{"id", "subject", "from", "toRecipients", "receivedDateTime", "isRead", "hasAttachments", "bodyPreview", "categories", "conversationId"}
 	}
@@ -156,10 +160,19 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		messages, err := collectMessagePages(ctx, top,
 			func(ctx context.Context, pageTop int32) (messagePage, error) {
 				folderQueryParams.Top = &pageTop
+				headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
+				if err != nil {
+					return messagePage{}, err
+				}
 				resp, err := c.targetUser(target).MailFolders().ByMailFolderId(opts.FolderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+					Headers:         headers,
+					Options:         options,
 					QueryParameters: folderQueryParams,
 				})
 				if err != nil {
+					return messagePage{}, err
+				}
+				if err := contract.verify(); err != nil {
 					return messagePage{}, err
 				}
 				if resp == nil {
@@ -174,8 +187,18 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 				}); err != nil {
 					return messagePage{}, err
 				}
-				resp, err := users.NewItemMailFoldersItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
+				headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
 				if err != nil {
+					return messagePage{}, err
+				}
+				resp, err := users.NewItemMailFoldersItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+					Headers: headers,
+					Options: options,
+				})
+				if err != nil {
+					return messagePage{}, err
+				}
+				if err := contract.verify(); err != nil {
 					return messagePage{}, err
 				}
 				if resp == nil {
@@ -189,7 +212,12 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		}
 		result := make([]MailMessage, 0, len(messages))
 		for _, msg := range messages {
-			result = append(result, convertMessage(msg))
+			converted := convertMessage(msg)
+			fillBody(&converted, msg)
+			if err := verifyMessageBody(converted, opts.BodyPreference); err != nil {
+				return nil, err
+			}
+			result = append(result, converted)
 		}
 		return result, nil
 	}
@@ -197,10 +225,19 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	messages, err := collectMessagePages(ctx, top,
 		func(ctx context.Context, pageTop int32) (messagePage, error) {
 			queryParams.Top = &pageTop
+			headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
+			if err != nil {
+				return messagePage{}, err
+			}
 			resp, err := c.targetUser(target).Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
+				Headers:         headers,
+				Options:         options,
 				QueryParameters: queryParams,
 			})
 			if err != nil {
+				return messagePage{}, err
+			}
+			if err := contract.verify(); err != nil {
 				return messagePage{}, err
 			}
 			if resp == nil {
@@ -215,8 +252,18 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 			}); err != nil {
 				return messagePage{}, err
 			}
-			resp, err := users.NewItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
+			headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
 			if err != nil {
+				return messagePage{}, err
+			}
+			resp, err := users.NewItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
+				Headers: headers,
+				Options: options,
+			})
+			if err != nil {
+				return messagePage{}, err
+			}
+			if err := contract.verify(); err != nil {
 				return messagePage{}, err
 			}
 			if resp == nil {
@@ -230,18 +277,29 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	}
 	result := make([]MailMessage, 0, len(messages))
 	for _, msg := range messages {
-		result = append(result, convertMessage(msg))
+		converted := convertMessage(msg)
+		fillBody(&converted, msg)
+		if err := verifyMessageBody(converted, opts.BodyPreference); err != nil {
+			return nil, err
+		}
+		result = append(result, converted)
 	}
 	return result, nil
 }
 
 // GetMessage returns a single message from the target mailbox, or the signed-in
 // user's mailbox when target is empty. See ListMessages for scope requirements.
-func (c *Client) GetMessage(ctx context.Context, target, messageID string) (*MailMessage, error) {
+func (c *Client) GetMessage(ctx context.Context, target, messageID string, preference MessageBodyPreference) (*MailMessage, error) {
 	if err := validateID(messageID, "message ID"); err != nil {
 		return nil, err
 	}
+	headers, options, contract, err := newMessageBodyResponseContract(preference)
+	if err != nil {
+		return nil, err
+	}
 	msg, err := c.targetUser(target).Messages().ByMessageId(messageID).Get(ctx, &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
+		Headers: headers,
+		Options: options,
 		QueryParameters: &users.ItemMessagesMessageItemRequestBuilderGetQueryParameters{
 			Select: messageDetailSelect,
 		},
@@ -249,8 +307,14 @@ func (c *Client) GetMessage(ctx context.Context, target, messageID string) (*Mai
 	if err != nil {
 		return nil, fmt.Errorf("getting message: %w", err)
 	}
+	if err := contract.verify(); err != nil {
+		return nil, fmt.Errorf("getting message: %w", err)
+	}
 	m := convertMessage(msg)
 	fillBody(&m, msg)
+	if err := verifyMessageBody(m, preference); err != nil {
+		return nil, fmt.Errorf("getting message: %w", err)
+	}
 	return &m, nil
 }
 

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -3,6 +3,7 @@ package graphapi
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -99,8 +100,6 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		return nil, fmt.Errorf("invalid orderBy value: %q", opts.OrderBy)
 	}
 
-	var config *users.ItemMessagesRequestBuilderGetRequestConfiguration
-
 	top := opts.Top
 	orderBy := opts.OrderBy
 
@@ -132,10 +131,6 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		queryParams.Select = []string{"id", "subject", "from", "toRecipients", "receivedDateTime", "isRead", "hasAttachments", "bodyPreview", "categories", "conversationId"}
 	}
 
-	config = &users.ItemMessagesRequestBuilderGetRequestConfiguration{
-		QueryParameters: queryParams,
-	}
-
 	if opts.FolderID != "" {
 		if err := validateID(opts.FolderID, "folder ID"); err != nil {
 			return nil, err
@@ -153,25 +148,71 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		if opts.Search != "" {
 			folderQueryParams.Search = &opts.Search
 		}
-		resp, err := c.targetUser(target).MailFolders().ByMailFolderId(opts.FolderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
-			QueryParameters: folderQueryParams,
-		})
+		messages, err := collectMessagePages(ctx, top,
+			func(ctx context.Context, pageTop int32) (messagePage, error) {
+				folderQueryParams.Top = &pageTop
+				resp, err := c.targetUser(target).MailFolders().ByMailFolderId(opts.FolderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+					QueryParameters: folderQueryParams,
+				})
+				if err != nil {
+					return messagePage{}, err
+				}
+				return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
+			},
+			func(ctx context.Context, nextLink string, _ int32) (messagePage, error) {
+				if err := validateGraphContinuation(nextLink, graphContinuationScope{
+					host:           defaultGraphAPIHost,
+					collectionPath: graphUserCollectionPath(target, "mailFolders/"+url.PathEscape(opts.FolderID)+"/messages"),
+				}); err != nil {
+					return messagePage{}, err
+				}
+				resp, err := users.NewItemMailFoldersItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
+				if err != nil {
+					return messagePage{}, err
+				}
+				return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
+			},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("listing messages: %w", err)
 		}
-		result := make([]MailMessage, 0, len(resp.GetValue()))
-		for _, msg := range resp.GetValue() {
+		result := make([]MailMessage, 0, len(messages))
+		for _, msg := range messages {
 			result = append(result, convertMessage(msg))
 		}
 		return result, nil
 	}
 
-	resp, err := c.targetUser(target).Messages().Get(ctx, config)
+	messages, err := collectMessagePages(ctx, top,
+		func(ctx context.Context, pageTop int32) (messagePage, error) {
+			queryParams.Top = &pageTop
+			resp, err := c.targetUser(target).Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
+				QueryParameters: queryParams,
+			})
+			if err != nil {
+				return messagePage{}, err
+			}
+			return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
+		},
+		func(ctx context.Context, nextLink string, _ int32) (messagePage, error) {
+			if err := validateGraphContinuation(nextLink, graphContinuationScope{
+				host:           defaultGraphAPIHost,
+				collectionPath: graphUserCollectionPath(target, "messages"),
+			}); err != nil {
+				return messagePage{}, err
+			}
+			resp, err := users.NewItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
+			if err != nil {
+				return messagePage{}, err
+			}
+			return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("listing messages: %w", err)
 	}
-	result := make([]MailMessage, 0, len(resp.GetValue()))
-	for _, msg := range resp.GetValue() {
+	result := make([]MailMessage, 0, len(messages))
+	for _, msg := range messages {
 		result = append(result, convertMessage(msg))
 	}
 	return result, nil

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -78,13 +78,12 @@ type MailFolder struct {
 
 // ListMessagesOptions for filtering messages
 type ListMessagesOptions struct {
-	FolderID       string
-	Top            int32
-	Filter         string
-	OrderBy        string
-	Search         string
-	Select         []string
-	BodyPreference MessageBodyPreference
+	FolderID string
+	Top      int32
+	Filter   string
+	OrderBy  string
+	Search   string
+	Select   []string
 }
 
 // ListMessages returns messages from the target mailbox, or the signed-in user's
@@ -96,9 +95,6 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		opts = &ListMessagesOptions{}
 	}
 	top := clampTop(opts.Top)
-	if _, err := opts.BodyPreference.headerValue(); err != nil {
-		return nil, err
-	}
 
 	hasInferenceClassification := strings.Contains(opts.Filter, "inferenceClassification")
 	if opts.OrderBy != "" && hasInferenceClassification {
@@ -160,19 +156,10 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		messages, err := collectMessagePages(ctx, top,
 			func(ctx context.Context, pageTop int32) (messagePage, error) {
 				folderQueryParams.Top = &pageTop
-				headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
-				if err != nil {
-					return messagePage{}, err
-				}
 				resp, err := c.targetUser(target).MailFolders().ByMailFolderId(opts.FolderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
-					Headers:         headers,
-					Options:         options,
 					QueryParameters: folderQueryParams,
 				})
 				if err != nil {
-					return messagePage{}, err
-				}
-				if err := contract.verify(); err != nil {
 					return messagePage{}, err
 				}
 				if resp == nil {
@@ -187,18 +174,8 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 				}); err != nil {
 					return messagePage{}, err
 				}
-				headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
+				resp, err := users.NewItemMailFoldersItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
 				if err != nil {
-					return messagePage{}, err
-				}
-				resp, err := users.NewItemMailFoldersItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
-					Headers: headers,
-					Options: options,
-				})
-				if err != nil {
-					return messagePage{}, err
-				}
-				if err := contract.verify(); err != nil {
 					return messagePage{}, err
 				}
 				if resp == nil {
@@ -212,12 +189,7 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 		}
 		result := make([]MailMessage, 0, len(messages))
 		for _, msg := range messages {
-			converted := convertMessage(msg)
-			fillBody(&converted, msg)
-			if err := verifyMessageBody(converted, opts.BodyPreference); err != nil {
-				return nil, err
-			}
-			result = append(result, converted)
+			result = append(result, convertMessage(msg))
 		}
 		return result, nil
 	}
@@ -225,19 +197,10 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	messages, err := collectMessagePages(ctx, top,
 		func(ctx context.Context, pageTop int32) (messagePage, error) {
 			queryParams.Top = &pageTop
-			headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
-			if err != nil {
-				return messagePage{}, err
-			}
 			resp, err := c.targetUser(target).Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
-				Headers:         headers,
-				Options:         options,
 				QueryParameters: queryParams,
 			})
 			if err != nil {
-				return messagePage{}, err
-			}
-			if err := contract.verify(); err != nil {
 				return messagePage{}, err
 			}
 			if resp == nil {
@@ -252,18 +215,8 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 			}); err != nil {
 				return messagePage{}, err
 			}
-			headers, options, contract, err := newMessageBodyResponseContract(opts.BodyPreference)
+			resp, err := users.NewItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
 			if err != nil {
-				return messagePage{}, err
-			}
-			resp, err := users.NewItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
-				Headers: headers,
-				Options: options,
-			})
-			if err != nil {
-				return messagePage{}, err
-			}
-			if err := contract.verify(); err != nil {
 				return messagePage{}, err
 			}
 			if resp == nil {
@@ -277,12 +230,7 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	}
 	result := make([]MailMessage, 0, len(messages))
 	for _, msg := range messages {
-		converted := convertMessage(msg)
-		fillBody(&converted, msg)
-		if err := verifyMessageBody(converted, opts.BodyPreference); err != nil {
-			return nil, err
-		}
-		result = append(result, converted)
+		result = append(result, convertMessage(msg))
 	}
 	return result, nil
 }

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -2,6 +2,7 @@ package graphapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -10,6 +11,8 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 )
+
+var errNilMessageResponse = errors.New("graph returned no message response")
 
 // allowedOrderBy is the set of valid $orderby field values.
 var allowedOrderBy = map[string]bool{
@@ -157,6 +160,9 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 				if err != nil {
 					return messagePage{}, err
 				}
+				if resp == nil {
+					return messagePage{}, errNilMessageResponse
+				}
 				return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
 			},
 			func(ctx context.Context, nextLink string, _ int32) (messagePage, error) {
@@ -169,6 +175,9 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 				resp, err := users.NewItemMailFoldersItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
 				if err != nil {
 					return messagePage{}, err
+				}
+				if resp == nil {
+					return messagePage{}, errNilMessageResponse
 				}
 				return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
 			},
@@ -192,6 +201,9 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 			if err != nil {
 				return messagePage{}, err
 			}
+			if resp == nil {
+				return messagePage{}, errNilMessageResponse
+			}
 			return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
 		},
 		func(ctx context.Context, nextLink string, _ int32) (messagePage, error) {
@@ -204,6 +216,9 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 			resp, err := users.NewItemMessagesRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
 			if err != nil {
 				return messagePage{}, err
+			}
+			if resp == nil {
+				return messagePage{}, errNilMessageResponse
 			}
 			return messagePage{Values: resp.GetValue(), NextLink: derefStr(resp.GetOdataNextLink())}, nil
 		},

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -94,7 +94,7 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	if opts == nil {
 		opts = &ListMessagesOptions{}
 	}
-	opts.Top = clampTop(opts.Top)
+	top := clampTop(opts.Top)
 
 	hasInferenceClassification := strings.Contains(opts.Filter, "inferenceClassification")
 	if opts.OrderBy != "" && hasInferenceClassification {
@@ -107,8 +107,6 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	if !allowedOrderBy[orderBy] {
 		return nil, fmt.Errorf("invalid orderBy value: %q", orderBy)
 	}
-
-	top := opts.Top
 
 	queryParams := &users.ItemMessagesRequestBuilderGetQueryParameters{
 		Top: &top,

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -100,15 +100,15 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	if opts.OrderBy != "" && hasInferenceClassification {
 		return nil, fmt.Errorf("cannot combine orderBy with inferenceClassification filter")
 	}
-	if opts.OrderBy == "" {
-		opts.OrderBy = "receivedDateTime desc"
+	orderBy := opts.OrderBy
+	if orderBy == "" {
+		orderBy = "receivedDateTime desc"
 	}
-	if !allowedOrderBy[opts.OrderBy] {
-		return nil, fmt.Errorf("invalid orderBy value: %q", opts.OrderBy)
+	if !allowedOrderBy[orderBy] {
+		return nil, fmt.Errorf("invalid orderBy value: %q", orderBy)
 	}
 
 	top := opts.Top
-	orderBy := opts.OrderBy
 
 	queryParams := &users.ItemMessagesRequestBuilderGetQueryParameters{
 		Top: &top,

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -96,6 +96,10 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	}
 	opts.Top = clampTop(opts.Top)
 
+	hasInferenceClassification := strings.Contains(opts.Filter, "inferenceClassification")
+	if opts.OrderBy != "" && hasInferenceClassification {
+		return nil, fmt.Errorf("cannot combine orderBy with inferenceClassification filter")
+	}
 	if opts.OrderBy == "" {
 		opts.OrderBy = "receivedDateTime desc"
 	}
@@ -111,9 +115,9 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 	}
 	// Microsoft Graph does not support $orderBy combined with $search, an
 	// inferenceClassification filter, or a conversationId filter ("restriction or
-	// sort order is too complex"). Callers that need ordering in those cases sort
-	// client-side.
-	skipOrderBy := opts.Search != "" || strings.Contains(opts.Filter, "inferenceClassification") || strings.Contains(opts.Filter, "conversationId")
+	// sort order is too complex"). Explicit classification ordering is rejected
+	// above; search and conversation callers retain their existing semantics.
+	skipOrderBy := opts.Search != "" || hasInferenceClassification || strings.Contains(opts.Filter, "conversationId")
 	if !skipOrderBy {
 		queryParams.Orderby = []string{orderBy}
 	}

--- a/internal/graphapi/mail_batch.go
+++ b/internal/graphapi/mail_batch.go
@@ -17,7 +17,7 @@ const maxBatchMessages = 20
 // (up to maxBatchMessages), instead of one request each. It is best-effort: an
 // id that fails (not found / no access) is omitted from the result rather than
 // failing the whole call, so a missing id in the output means that fetch failed.
-func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []string) ([]MailMessage, error) {
+func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []string, preference MessageBodyPreference) ([]MailMessage, error) {
 	if len(ids) == 0 {
 		return nil, fmt.Errorf("no message IDs provided")
 	}
@@ -28,6 +28,10 @@ func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []stri
 		if err := validateID(id, "message ID"); err != nil {
 			return nil, err
 		}
+	}
+	preferenceValue, err := preference.headerValue()
+	if err != nil {
+		return nil, err
 	}
 
 	adapter := c.inner.GetAdapter()
@@ -45,6 +49,9 @@ func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []stri
 		if err != nil {
 			return nil, fmt.Errorf("building batch request: %w", err)
 		}
+		if preference != MessageBodyDefault {
+			reqInfo.Headers.Add(preferHeader, preferenceValue)
+		}
 		item, err := batch.AddBatchRequestStep(*reqInfo)
 		if err != nil {
 			return nil, fmt.Errorf("adding batch step: %w", err)
@@ -59,12 +66,27 @@ func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []stri
 
 	out := make([]MailMessage, 0, len(stepIDs))
 	for _, stepID := range stepIDs {
+		if preference != MessageBodyDefault {
+			item := resp.GetResponseById(stepID)
+			if item == nil || item.GetStatus() == nil || *item.GetStatus() >= 400 {
+				return nil, fmt.Errorf("batch message %q did not return a successful provider body response", stepID)
+			}
+			if err := verifyPreferenceApplied(batchResponseHeader(item.GetHeaders(), preferenceAppliedHeader), preference); err != nil {
+				return nil, fmt.Errorf("batch message %q: %w", stepID, err)
+			}
+		}
 		msg, err := graphcore.GetBatchResponseById[models.Messageable](resp, stepID, models.CreateMessageFromDiscriminatorValue)
 		if err != nil {
+			if preference != MessageBodyDefault {
+				return nil, fmt.Errorf("batch message %q: %w", stepID, err)
+			}
 			continue // best-effort: skip ids that failed (not found / no access)
 		}
 		m := convertMessage(msg)
 		fillBody(&m, msg)
+		if err := verifyMessageBody(m, preference); err != nil {
+			return nil, fmt.Errorf("batch message %q: %w", stepID, err)
+		}
 		out = append(out, m)
 	}
 	if len(out) == 0 {
@@ -76,7 +98,7 @@ func (c *Client) GetMessagesBatch(ctx context.Context, target string, ids []stri
 // ListThread returns every message in a conversation, oldest first. The
 // conversation id comes from a message's conversationId field (now included in
 // list/get output). Messages are matched across all folders (inbox, sent, …).
-func (c *Client) ListThread(ctx context.Context, target, conversationID string, top int32) ([]MailMessage, error) {
+func (c *Client) ListThread(ctx context.Context, target, conversationID string, top int32, preference MessageBodyPreference) ([]MailMessage, error) {
 	if err := validateID(conversationID, "conversation ID"); err != nil {
 		return nil, err
 	}
@@ -84,7 +106,12 @@ func (c *Client) ListThread(ctx context.Context, target, conversationID string, 
 	// the OData string literal — the filter is injection-safe. Graph rejects
 	// $orderby alongside a conversationId filter, so order client-side.
 	filter := fmt.Sprintf("conversationId eq '%s'", conversationID)
-	messages, err := c.ListMessages(ctx, target, &ListMessagesOptions{Filter: filter, Top: top})
+	opts := &ListMessagesOptions{Filter: filter, Top: top}
+	if preference != MessageBodyDefault {
+		opts.Select = messageDetailSelect
+		opts.BodyPreference = preference
+	}
+	messages, err := c.ListMessages(ctx, target, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graphapi/mail_batch.go
+++ b/internal/graphapi/mail_batch.go
@@ -102,21 +102,87 @@ func (c *Client) ListThread(ctx context.Context, target, conversationID string, 
 	if err := validateID(conversationID, "conversation ID"); err != nil {
 		return nil, err
 	}
+	if _, err := preference.headerValue(); err != nil {
+		return nil, err
+	}
 	// validateID's character set excludes quotes, so the id can't break out of
 	// the OData string literal — the filter is injection-safe. Graph rejects
 	// $orderby alongside a conversationId filter, so order client-side.
 	filter := fmt.Sprintf("conversationId eq '%s'", conversationID)
-	opts := &ListMessagesOptions{Filter: filter, Top: top}
-	if preference != MessageBodyDefault {
-		opts.Select = messageDetailSelect
-		opts.BodyPreference = preference
+	if preference == MessageBodyDefault {
+		// Preserve the historical single-list-request, metadata-only contract.
+		// Only an explicit typed body preference opts into exact batch hydration.
+		messages, err := c.ListMessages(ctx, target, &ListMessagesOptions{Filter: filter, Top: top})
+		if err != nil {
+			return nil, err
+		}
+		sortThreadMessages(messages)
+		return messages, nil
 	}
-	messages, err := c.ListMessages(ctx, target, opts)
+
+	metadata, err := c.ListMessages(ctx, target, &ListMessagesOptions{
+		Filter: filter,
+		Top:    top,
+		Select: []string{"id"},
+	})
 	if err != nil {
 		return nil, err
 	}
+	discoveredIDs := make([]string, 0, len(metadata))
+	for _, message := range metadata {
+		discoveredIDs = append(discoveredIDs, message.ID)
+	}
+
+	messages := make([]MailMessage, 0, len(discoveredIDs))
+	for start := 0; start < len(discoveredIDs); start += maxBatchMessages {
+		end := min(start+maxBatchMessages, len(discoveredIDs))
+		chunkIDs := discoveredIDs[start:end]
+		chunk, err := c.GetMessagesBatch(ctx, target, chunkIDs, preference)
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyExactMessageIdentity(chunkIDs, chunk); err != nil {
+			return nil, fmt.Errorf("thread batch identity: %w", err)
+		}
+		messages = append(messages, chunk...)
+	}
+	if err := verifyExactMessageIdentity(discoveredIDs, messages); err != nil {
+		return nil, fmt.Errorf("thread identity: %w", err)
+	}
+	for _, message := range messages {
+		if message.ConversationID != conversationID {
+			return nil, fmt.Errorf("thread message %q conversation = %q, want %q", message.ID, message.ConversationID, conversationID)
+		}
+	}
+	sortThreadMessages(messages)
+	return messages, nil
+}
+
+func verifyExactMessageIdentity(expected []string, messages []MailMessage) error {
+	if len(messages) != len(expected) {
+		return fmt.Errorf("returned %d messages, want %d", len(messages), len(expected))
+	}
+	remaining := make(map[string]struct{}, len(expected))
+	for _, id := range expected {
+		if _, duplicate := remaining[id]; duplicate {
+			return fmt.Errorf("expected message ID %q is duplicated", id)
+		}
+		remaining[id] = struct{}{}
+	}
+	for _, message := range messages {
+		if _, found := remaining[message.ID]; !found {
+			return fmt.Errorf("unexpected or duplicate message ID %q", message.ID)
+		}
+		delete(remaining, message.ID)
+	}
+	if len(remaining) != 0 {
+		return fmt.Errorf("missing %d expected message IDs", len(remaining))
+	}
+	return nil
+}
+
+func sortThreadMessages(messages []MailMessage) {
 	sort.SliceStable(messages, func(i, j int) bool {
 		return messages[i].ReceivedAt < messages[j].ReceivedAt // RFC3339 Z strings sort chronologically
 	})
-	return messages, nil
 }

--- a/internal/graphapi/mail_batch_test.go
+++ b/internal/graphapi/mail_batch_test.go
@@ -13,28 +13,28 @@ func TestGetMessagesBatch_Validation(t *testing.T) {
 	c := &Client{}
 	ctx := context.Background()
 
-	if _, err := c.GetMessagesBatch(ctx, "", nil); err == nil {
+	if _, err := c.GetMessagesBatch(ctx, "", nil, MessageBodyDefault); err == nil {
 		t.Error("expected error for empty id list")
 	}
 	many := make([]string, maxBatchMessages+1)
 	for i := range many {
 		many[i] = "AAA"
 	}
-	if _, err := c.GetMessagesBatch(ctx, "", many); err == nil || !strings.Contains(err.Error(), "max") {
+	if _, err := c.GetMessagesBatch(ctx, "", many, MessageBodyDefault); err == nil || !strings.Contains(err.Error(), "max") {
 		t.Errorf("expected max-batch error, got %v", err)
 	}
-	if _, err := c.GetMessagesBatch(ctx, "", []string{"bad id with spaces"}); err == nil {
+	if _, err := c.GetMessagesBatch(ctx, "", []string{"bad id with spaces"}, MessageBodyDefault); err == nil {
 		t.Error("expected invalid-id error")
 	}
 }
 
 func TestListThread_Validation(t *testing.T) {
 	c := &Client{}
-	if _, err := c.ListThread(context.Background(), "", "", 50); err == nil {
+	if _, err := c.ListThread(context.Background(), "", "", 50, MessageBodyDefault); err == nil {
 		t.Error("expected error for empty conversation id")
 	}
 	// A quote can't pass validateID, so OData injection is impossible.
-	if _, err := c.ListThread(context.Background(), "", "x' or '1'='1", 50); err == nil {
+	if _, err := c.ListThread(context.Background(), "", "x' or '1'='1", 50, MessageBodyDefault); err == nil {
 		t.Error("expected invalid-id error for quote-bearing conversation id")
 	}
 }

--- a/internal/graphapi/mail_body_preference.go
+++ b/internal/graphapi/mail_body_preference.go
@@ -1,0 +1,114 @@
+package graphapi
+
+import (
+	"fmt"
+	"strings"
+
+	abs "github.com/microsoft/kiota-abstractions-go"
+	khttp "github.com/microsoft/kiota-http-go"
+)
+
+const (
+	preferHeader            = "Prefer"
+	preferenceAppliedHeader = "Preference-Applied"
+)
+
+// MessageBodyPreference is a typed request for the representation Graph must
+// return for a message body. The zero value preserves Graph's default.
+type MessageBodyPreference string
+
+const (
+	MessageBodyDefault MessageBodyPreference = ""
+	MessageBodyText    MessageBodyPreference = "text"
+	MessageBodyHTML    MessageBodyPreference = "html"
+)
+
+// ParseMessageBodyPreference converts a CLI-facing value into the closed set
+// accepted by the Graph request layer.
+func ParseMessageBodyPreference(value string) (MessageBodyPreference, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return MessageBodyDefault, nil
+	case string(MessageBodyText):
+		return MessageBodyText, nil
+	case string(MessageBodyHTML):
+		return MessageBodyHTML, nil
+	default:
+		return MessageBodyDefault, fmt.Errorf("invalid body format %q: must be text or html", value)
+	}
+}
+
+func (p MessageBodyPreference) headerValue() (string, error) {
+	switch p {
+	case MessageBodyDefault:
+		return "", nil
+	case MessageBodyText, MessageBodyHTML:
+		return fmt.Sprintf(`outlook.body-content-type="%s"`, p), nil
+	default:
+		return "", fmt.Errorf("invalid message body preference %q", p)
+	}
+}
+
+type messageBodyResponseContract struct {
+	preference MessageBodyPreference
+	inspection *khttp.HeadersInspectionOptions
+}
+
+func newMessageBodyResponseContract(preference MessageBodyPreference) (*abs.RequestHeaders, []abs.RequestOption, *messageBodyResponseContract, error) {
+	value, err := preference.headerValue()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if preference == MessageBodyDefault {
+		return nil, nil, nil, nil
+	}
+
+	headers := abs.NewRequestHeaders()
+	headers.Add(preferHeader, value)
+	inspection := khttp.NewHeadersInspectionOptions()
+	inspection.InspectResponseHeaders = true
+	return headers, []abs.RequestOption{inspection}, &messageBodyResponseContract{
+		preference: preference,
+		inspection: inspection,
+	}, nil
+}
+
+func (c *messageBodyResponseContract) verify() error {
+	if c == nil {
+		return nil
+	}
+	return verifyPreferenceApplied(c.inspection.GetResponseHeaders().Get(preferenceAppliedHeader), c.preference)
+}
+
+func verifyPreferenceApplied(values []string, preference MessageBodyPreference) error {
+	expected, err := preference.headerValue()
+	if err != nil {
+		return err
+	}
+	if preference == MessageBodyDefault {
+		return nil
+	}
+	if len(values) != 1 || !strings.EqualFold(strings.TrimSpace(values[0]), expected) {
+		return fmt.Errorf("%s = %q, want exact %q", preferenceAppliedHeader, values, expected)
+	}
+	return nil
+}
+
+func batchResponseHeader(headers map[string]string, name string) []string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return []string{value}
+		}
+	}
+	return nil
+}
+
+func verifyMessageBody(message MailMessage, preference MessageBodyPreference) error {
+	if preference == MessageBodyDefault {
+		return nil
+	}
+	if !strings.EqualFold(message.BodyType, string(preference)) {
+		return fmt.Errorf("provider body type = %q, want %q", message.BodyType, preference)
+	}
+	return nil
+}

--- a/internal/graphapi/mail_body_preference_test.go
+++ b/internal/graphapi/mail_body_preference_test.go
@@ -3,9 +3,11 @@ package graphapi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -200,67 +202,204 @@ func TestGetMessagesBatchFailsWholeResultOnRepresentationContractFailure(t *test
 	}
 }
 
-func TestListThreadRequestsAndVerifiesProviderTextOnEveryPage(t *testing.T) {
+func TestListThreadDiscoversPagedMetadataThenFetchesAcknowledgedBatchChunks(t *testing.T) {
 	requests := 0
+	firstPage := make([]string, 0, 10)
+	secondPage := make([]string, 0, 11)
+	for index := 20; index >= 11; index-- {
+		firstPage = append(firstPage, fmt.Sprintf("message-%02d", index))
+	}
+	for index := 10; index >= 0; index-- {
+		secondPage = append(secondPage, fmt.Sprintf("message-%02d", index))
+	}
+	var batchSizes []int
+
 	client := testGraphClient(t, func(req *http.Request) *http.Response {
 		requests++
-		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
-			t.Errorf("request %d Prefer = %q, want provider text preference", requests, got)
-		}
-		if requests == 1 && !strings.Contains(req.URL.Query().Get("$select"), "body") {
-			got := req.URL.Query().Get("$select")
-			t.Errorf("request %d $select = %q, want explicit body", requests, got)
-		}
-
-		var body string
 		switch requests {
 		case 1:
-			body = `{"value":[{"id":"one","receivedDateTime":"2026-01-01T00:00:00Z","body":{"contentType":"text","content":""}}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/me/messages?$skiptoken=second"}`
+			if got := req.Header.Get("Prefer"); got != "" {
+				t.Errorf("metadata Prefer = %q, want none", got)
+			}
+			if got := req.URL.Query().Get("$select"); got != "id" {
+				t.Errorf("metadata $select = %q, want id", got)
+			}
+			return graphMessageIDsResponse(req, firstPage, "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=second")
 		case 2:
-			body = `{"value":[{"id":"two","receivedDateTime":"2026-01-02T00:00:00Z","body":{"contentType":"text","content":"Second"}}]}`
+			if got := req.Header.Get("Prefer"); got != "" {
+				t.Errorf("continuation metadata Prefer = %q, want none", got)
+			}
+			return graphMessageIDsResponse(req, secondPage, "")
+		case 3, 4:
+			batch := decodeBodyPreferenceBatch(t, req)
+			batchSizes = append(batchSizes, len(batch))
+			return graphThreadBatchResponse(t, req, batch, "conversation-one", true, nil)
 		default:
 			t.Fatalf("unexpected request %d", requests)
+			return nil
 		}
-		resp := graphJSONResponse(req, body)
-		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
-		return resp
 	})
 
-	messages, err := client.ListThread(context.Background(), "", "conversation-one", 2, MessageBodyText)
+	messages, err := client.ListThread(context.Background(), "", "conversation-one", 21, MessageBodyText)
 	if err != nil {
 		t.Fatalf("ListThread() error = %v", err)
 	}
-	if requests != 2 {
-		t.Fatalf("request count = %d, want 2", requests)
+	if requests != 4 {
+		t.Fatalf("request count = %d, want 4", requests)
 	}
-	got := []string{messages[0].Body, messages[1].Body}
-	if !reflect.DeepEqual(got, []string{"", "Second"}) {
-		t.Fatalf("ListThread() bodies = %v, want [empty Second]", got)
+	if !reflect.DeepEqual(batchSizes, []int{20, 1}) {
+		t.Fatalf("batch sizes = %v, want [20 1]", batchSizes)
+	}
+	if len(messages) != 21 || messages[0].ID != "message-00" || messages[20].ID != "message-20" {
+		t.Fatalf("sorted message IDs start/end = %q/%q count=%d, want message-00/message-20 count=21", messages[0].ID, messages[len(messages)-1].ID, len(messages))
 	}
 }
 
-func TestListThreadRejectsMissingContinuationAcknowledgement(t *testing.T) {
-	requests := 0
+func TestListThreadRejectsBatchIdentitySetMismatch(t *testing.T) {
 	client := testGraphClient(t, func(req *http.Request) *http.Response {
-		requests++
-		var body string
-		if requests == 1 {
-			body = `{"value":[{"id":"one","body":{"contentType":"text","content":"First"}}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/me/messages?$skiptoken=second"}`
-		} else {
-			body = `{"value":[{"id":"two","body":{"contentType":"text","content":"Second"}}]}`
+		if req.URL.Path != "/v1.0/$batch" {
+			return graphMessageIDsResponse(req, []string{"one", "two"}, "")
 		}
-		resp := graphJSONResponse(req, body)
-		if requests == 1 {
-			resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
-		}
-		return resp
+		batch := decodeBodyPreferenceBatch(t, req)
+		return graphThreadBatchResponse(t, req, batch, "conversation-one", true, func(id string) string {
+			if id == "two" {
+				return "one"
+			}
+			return id
+		})
 	})
 
 	messages, err := client.ListThread(context.Background(), "", "conversation-one", 2, MessageBodyText)
-	if err == nil || !strings.Contains(err.Error(), "Preference-Applied") {
-		t.Fatalf("ListThread() error = %v, want continuation acknowledgement failure", err)
+	if err == nil || !strings.Contains(err.Error(), "identity") {
+		t.Fatalf("ListThread() error = %v, want exact identity rejection", err)
 	}
 	if messages != nil {
-		t.Fatalf("ListThread() messages = %#v, want nil on representation contract failure", messages)
+		t.Fatalf("ListThread() messages = %#v, want nil on identity failure", messages)
 	}
+}
+
+func TestListThreadRejectsWrongConversationInHydratedMessage(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if req.URL.Path != "/v1.0/$batch" {
+			return graphMessageIDsResponse(req, []string{"one"}, "")
+		}
+		return graphThreadBatchResponse(t, req, decodeBodyPreferenceBatch(t, req), "other-conversation", true, nil)
+	})
+
+	messages, err := client.ListThread(context.Background(), "", "conversation-one", 1, MessageBodyText)
+	if err == nil || !strings.Contains(err.Error(), "conversation") {
+		t.Fatalf("ListThread() error = %v, want conversation mismatch rejection", err)
+	}
+	if messages != nil {
+		t.Fatalf("ListThread() messages = %#v, want nil on conversation failure", messages)
+	}
+}
+
+func TestListThreadRejectsUnacknowledgedBatchBody(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if req.URL.Path != "/v1.0/$batch" {
+			return graphMessageIDsResponse(req, []string{"one"}, "")
+		}
+		return graphThreadBatchResponse(t, req, decodeBodyPreferenceBatch(t, req), "conversation-one", false, nil)
+	})
+
+	messages, err := client.ListThread(context.Background(), "", "conversation-one", 1, MessageBodyText)
+	if err == nil || !strings.Contains(err.Error(), "Preference-Applied") {
+		t.Fatalf("ListThread() error = %v, want batch acknowledgement rejection", err)
+	}
+	if messages != nil {
+		t.Fatalf("ListThread() messages = %#v, want nil on acknowledgement failure", messages)
+	}
+}
+
+type bodyPreferenceBatchRequest struct {
+	ID      string            `json:"id"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers"`
+}
+
+func decodeBodyPreferenceBatch(t *testing.T, req *http.Request) []bodyPreferenceBatchRequest {
+	t.Helper()
+	var payload struct {
+		Requests []bodyPreferenceBatchRequest `json:"requests"`
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading batch request: %v", err)
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decoding batch request: %v\n%s", err, data)
+	}
+	for _, item := range payload.Requests {
+		if got := headerValue(item.Headers, "Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("batch item %q Prefer = %q, want provider text preference", item.ID, got)
+		}
+	}
+	return payload.Requests
+}
+
+func graphMessageIDsResponse(req *http.Request, ids []string, nextLink string) *http.Response {
+	values := make([]map[string]string, 0, len(ids))
+	for _, id := range ids {
+		values = append(values, map[string]string{"id": id})
+	}
+	payload := map[string]any{"value": values}
+	if nextLink != "" {
+		payload["@odata.nextLink"] = nextLink
+	}
+	body, _ := json.Marshal(payload)
+	return graphJSONResponse(req, string(body))
+}
+
+func graphThreadBatchResponse(
+	t *testing.T,
+	req *http.Request,
+	batch []bodyPreferenceBatchRequest,
+	conversationID string,
+	acknowledge bool,
+	transformID func(string) string,
+) *http.Response {
+	t.Helper()
+	responses := make([]map[string]any, 0, len(batch))
+	for _, item := range batch {
+		messageID := item.URL
+		if marker := strings.LastIndex(messageID, "/messages/"); marker >= 0 {
+			messageID = messageID[marker+len("/messages/"):]
+		}
+		if query := strings.IndexByte(messageID, '?'); query >= 0 {
+			messageID = messageID[:query]
+		}
+		if transformID != nil {
+			messageID = transformID(messageID)
+		}
+		headers := map[string]string{"Content-Type": "application/json"}
+		if acknowledge {
+			headers["Preference-Applied"] = `outlook.body-content-type="text"`
+		}
+		received := "2026-01-01T00:00:00Z"
+		if suffix := strings.TrimPrefix(messageID, "message-"); suffix != messageID {
+			if index, err := strconv.Atoi(suffix); err == nil {
+				received = fmt.Sprintf("2026-01-%02dT00:00:00Z", index+1)
+			}
+		}
+		responses = append(responses, map[string]any{
+			"id":      item.ID,
+			"status":  http.StatusOK,
+			"headers": headers,
+			"body": map[string]any{
+				"id":               messageID,
+				"conversationId":   conversationID,
+				"receivedDateTime": received,
+				"body": map[string]string{
+					"contentType": "text",
+					"content":     "Provider text for " + messageID,
+				},
+			},
+		})
+	}
+	body, err := json.Marshal(map[string]any{"responses": responses})
+	if err != nil {
+		t.Fatalf("encoding batch response: %v", err)
+	}
+	return graphJSONResponse(req, string(body))
 }

--- a/internal/graphapi/mail_body_preference_test.go
+++ b/internal/graphapi/mail_body_preference_test.go
@@ -1,0 +1,266 @@
+package graphapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseMessageBodyPreferenceRejectsUnknownRepresentation(t *testing.T) {
+	if _, err := ParseMessageBodyPreference("markdown"); err == nil {
+		t.Fatal("ParseMessageBodyPreference() error = nil, want unsupported representation rejection")
+	}
+}
+
+func TestGetMessageRequestsAndVerifiesProviderText(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("Prefer = %q, want provider text preference", got)
+		}
+		resp := graphJSONResponse(req, `{
+			"id":"message-one",
+			"body":{"contentType":"text","content":"Provider returned text"}
+		}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+
+	msg, err := client.GetMessage(context.Background(), "", "message-one", MessageBodyText)
+	if err != nil {
+		t.Fatalf("GetMessage() error = %v", err)
+	}
+	if msg.Body != "Provider returned text" || msg.BodyType != "text" {
+		t.Fatalf("GetMessage() body = %q type = %q, want verified provider text", msg.Body, msg.BodyType)
+	}
+}
+
+func TestGetMessageRequestsAndVerifiesProviderHTML(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="html"` {
+			t.Errorf("Prefer = %q, want provider HTML preference", got)
+		}
+		resp := graphJSONResponse(req, `{
+			"id":"message-one",
+			"body":{"contentType":"html","content":"<p>Provider returned HTML</p>"}
+		}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="html"`)
+		return resp
+	})
+
+	msg, err := client.GetMessage(context.Background(), "", "message-one", MessageBodyHTML)
+	if err != nil {
+		t.Fatalf("GetMessage() error = %v", err)
+	}
+	if msg.Body != "<p>Provider returned HTML</p>" || msg.BodyType != "html" {
+		t.Fatalf("GetMessage() body = %q type = %q, want verified provider HTML", msg.Body, msg.BodyType)
+	}
+}
+
+func TestGetMessageRejectsMissingProviderAcknowledgement(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		return graphJSONResponse(req, `{
+			"id":"message-one",
+			"body":{"contentType":"text","content":"Unacknowledged text"}
+		}`)
+	})
+
+	msg, err := client.GetMessage(context.Background(), "", "message-one", MessageBodyText)
+	if err == nil || !strings.Contains(err.Error(), "Preference-Applied") {
+		t.Fatalf("GetMessage() error = %v, want missing acknowledgement rejection", err)
+	}
+	if msg != nil {
+		t.Fatalf("GetMessage() message = %#v, want nil on representation contract failure", msg)
+	}
+}
+
+func TestGetMessageAllowsAcknowledgedEmptyProviderBody(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		resp := graphJSONResponse(req, `{"id":"message-one","body":{"contentType":"text","content":""}}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+
+	msg, err := client.GetMessage(context.Background(), "", "message-one", MessageBodyText)
+	if err != nil {
+		t.Fatalf("GetMessage() error = %v, want acknowledged empty body accepted", err)
+	}
+	if msg.Body != "" || msg.BodyType != "text" {
+		t.Fatalf("GetMessage() body = %q type = %q, want empty provider text", msg.Body, msg.BodyType)
+	}
+}
+
+func TestGetMessageRejectsMismatchedProviderBodyType(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		resp := graphJSONResponse(req, `{"id":"message-one","body":{"contentType":"html","content":"<p>HTML</p>"}}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+
+	msg, err := client.GetMessage(context.Background(), "", "message-one", MessageBodyText)
+	if err == nil || !strings.Contains(err.Error(), "provider body") {
+		t.Fatalf("GetMessage() error = %v, want provider body rejection", err)
+	}
+	if msg != nil {
+		t.Fatalf("GetMessage() message = %#v, want nil on representation contract failure", msg)
+	}
+}
+
+func TestGetMessageDefaultDoesNotRequestOrRequirePreference(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != "" {
+			t.Errorf("Prefer = %q, want no provider body preference", got)
+		}
+		return graphJSONResponse(req, `{"id":"message-one","body":{"contentType":"html","content":""}}`)
+	})
+
+	if _, err := client.GetMessage(context.Background(), "", "message-one", MessageBodyDefault); err != nil {
+		t.Fatalf("GetMessage() error = %v, want unchanged default behavior", err)
+	}
+}
+
+func TestGetMessagesBatchRequestsAndVerifiesEveryProviderBody(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if req.URL.Path != "/v1.0/$batch" {
+			t.Errorf("request path = %q, want /v1.0/$batch", req.URL.Path)
+		}
+		var payload struct {
+			Requests []struct {
+				ID      string            `json:"id"`
+				Headers map[string]string `json:"headers"`
+			} `json:"requests"`
+		}
+		data, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading batch request: %v", err)
+		}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			t.Fatalf("decoding batch request: %v\n%s", err, data)
+		}
+		if len(payload.Requests) != 2 {
+			t.Fatalf("batch request count = %d, want 2", len(payload.Requests))
+		}
+		for _, item := range payload.Requests {
+			if got := headerValue(item.Headers, "Prefer"); got != `outlook.body-content-type="text"` {
+				t.Errorf("batch item %q Prefer = %q in %v, want provider text preference", item.ID, got, item.Headers)
+			}
+		}
+
+		return graphJSONResponse(req, `{"responses":[
+			{"id":"`+payload.Requests[0].ID+`","status":200,"headers":{"Content-Type":"application/json","Preference-Applied":"outlook.body-content-type=\"text\""},"body":{"id":"one","body":{"contentType":"text","content":""}}},
+			{"id":"`+payload.Requests[1].ID+`","status":200,"headers":{"Content-Type":"application/json","Preference-Applied":"outlook.body-content-type=\"text\""},"body":{"id":"two","body":{"contentType":"text","content":"Second"}}}
+		]}`)
+	})
+
+	messages, err := client.GetMessagesBatch(context.Background(), "", []string{"one", "two"}, MessageBodyText)
+	if err != nil {
+		t.Fatalf("GetMessagesBatch() error = %v", err)
+	}
+	got := []string{messages[0].Body, messages[1].Body}
+	if !reflect.DeepEqual(got, []string{"", "Second"}) {
+		t.Fatalf("GetMessagesBatch() bodies = %v, want [empty Second]", got)
+	}
+}
+
+func headerValue(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}
+
+func TestGetMessagesBatchFailsWholeResultOnRepresentationContractFailure(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		var payload struct {
+			Requests []struct {
+				ID string `json:"id"`
+			} `json:"requests"`
+		}
+		data, _ := io.ReadAll(req.Body)
+		if err := json.Unmarshal(data, &payload); err != nil {
+			t.Fatalf("decoding batch request: %v", err)
+		}
+		return graphJSONResponse(req, `{"responses":[
+			{"id":"`+payload.Requests[0].ID+`","status":200,"headers":{"Content-Type":"application/json","Preference-Applied":"outlook.body-content-type=\"text\""},"body":{"id":"one","body":{"contentType":"text","content":"First"}}},
+			{"id":"`+payload.Requests[1].ID+`","status":200,"headers":{"Content-Type":"application/json"},"body":{"id":"two","body":{"contentType":"text","content":"Second"}}}
+		]}`)
+	})
+
+	messages, err := client.GetMessagesBatch(context.Background(), "", []string{"one", "two"}, MessageBodyText)
+	if err == nil || !strings.Contains(err.Error(), "Preference-Applied") {
+		t.Fatalf("GetMessagesBatch() error = %v, want whole-call acknowledgement failure", err)
+	}
+	if messages != nil {
+		t.Fatalf("GetMessagesBatch() messages = %#v, want nil before partial output", messages)
+	}
+}
+
+func TestListThreadRequestsAndVerifiesProviderTextOnEveryPage(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("request %d Prefer = %q, want provider text preference", requests, got)
+		}
+		if requests == 1 && !strings.Contains(req.URL.Query().Get("$select"), "body") {
+			got := req.URL.Query().Get("$select")
+			t.Errorf("request %d $select = %q, want explicit body", requests, got)
+		}
+
+		var body string
+		switch requests {
+		case 1:
+			body = `{"value":[{"id":"one","receivedDateTime":"2026-01-01T00:00:00Z","body":{"contentType":"text","content":""}}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/me/messages?$skiptoken=second"}`
+		case 2:
+			body = `{"value":[{"id":"two","receivedDateTime":"2026-01-02T00:00:00Z","body":{"contentType":"text","content":"Second"}}]}`
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+		resp := graphJSONResponse(req, body)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+
+	messages, err := client.ListThread(context.Background(), "", "conversation-one", 2, MessageBodyText)
+	if err != nil {
+		t.Fatalf("ListThread() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("request count = %d, want 2", requests)
+	}
+	got := []string{messages[0].Body, messages[1].Body}
+	if !reflect.DeepEqual(got, []string{"", "Second"}) {
+		t.Fatalf("ListThread() bodies = %v, want [empty Second]", got)
+	}
+}
+
+func TestListThreadRejectsMissingContinuationAcknowledgement(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		var body string
+		if requests == 1 {
+			body = `{"value":[{"id":"one","body":{"contentType":"text","content":"First"}}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/me/messages?$skiptoken=second"}`
+		} else {
+			body = `{"value":[{"id":"two","body":{"contentType":"text","content":"Second"}}]}`
+		}
+		resp := graphJSONResponse(req, body)
+		if requests == 1 {
+			resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		}
+		return resp
+	})
+
+	messages, err := client.ListThread(context.Background(), "", "conversation-one", 2, MessageBodyText)
+	if err == nil || !strings.Contains(err.Error(), "Preference-Applied") {
+		t.Fatalf("ListThread() error = %v, want continuation acknowledgement failure", err)
+	}
+	if messages != nil {
+		t.Fatalf("ListThread() messages = %#v, want nil on representation contract failure", messages)
+	}
+}

--- a/internal/graphapi/mail_pages.go
+++ b/internal/graphapi/mail_pages.go
@@ -173,6 +173,10 @@ func parseGraphCollectionRoute(path string) (graphCollectionRoute, bool) {
 	default:
 		return graphCollectionRoute{}, false
 	}
+	if len(collection) == 1 && strings.EqualFold(collection[0], "messages") {
+		route.operation = graphMessageCollection
+		return route, true
+	}
 
 	if folderID, consumed, ok := graphMailFolderRoute(collection); ok {
 		route.folderID = folderID

--- a/internal/graphapi/mail_pages.go
+++ b/internal/graphapi/mail_pages.go
@@ -81,10 +81,13 @@ func collectMessagePages(
 	}
 }
 
-// graphContinuationScope limits a Graph continuation to one collection path.
-// A continuation is replayed through the authenticated SDK adapter, so both
-// its Graph host and operation path must be verified before the request.
+const defaultGraphAPIHost = "graph.microsoft.com"
+
+// graphContinuationScope limits a Graph continuation to one host and
+// collection. A continuation is replayed through the authenticated SDK
+// adapter, so both must be verified before the request.
 type graphContinuationScope struct {
+	host           string
 	collectionPath string
 }
 
@@ -107,13 +110,138 @@ func validateGraphContinuation(raw string, expected graphContinuationScope) erro
 	if port := u.Port(); port != "" && port != "443" {
 		return fmt.Errorf("refusing Graph continuation on port %q", port)
 	}
-	if !graphAPIHosts[strings.ToLower(u.Hostname())] {
-		return fmt.Errorf("refusing Graph continuation for untrusted host %q", u.Hostname())
+	expectedHost := strings.ToLower(expected.host)
+	if expectedHost == "" || !graphAPIHosts[expectedHost] {
+		return fmt.Errorf("refusing Graph continuation with invalid expected host")
 	}
-	if expected.collectionPath == "" || u.EscapedPath() != expected.collectionPath {
+	if actualHost := strings.ToLower(u.Hostname()); actualHost != expectedHost {
+		return fmt.Errorf("refusing Graph continuation for unexpected host %q", u.Hostname())
+	}
+	if !sameGraphCollection(u.EscapedPath(), expected.collectionPath) {
 		return fmt.Errorf("refusing Graph continuation outside expected collection")
 	}
 	return nil
+}
+
+type graphCollectionOperation uint8
+
+const (
+	graphMessageCollection graphCollectionOperation = iota + 1
+	graphMessageDeltaCollection
+	graphCalendarViewDeltaCollection
+	graphContactsDeltaCollection
+)
+
+type graphCollectionRoute struct {
+	isMe      bool
+	userID    string
+	folderID  string
+	operation graphCollectionOperation
+}
+
+func sameGraphCollection(actualPath, expectedPath string) bool {
+	actual, ok := parseGraphCollectionRoute(actualPath)
+	if !ok {
+		return false
+	}
+	expected, ok := parseGraphCollectionRoute(expectedPath)
+	return ok && actual == expected
+}
+
+func parseGraphCollectionRoute(path string) (graphCollectionRoute, bool) {
+	if !strings.HasPrefix(path, "/") || strings.HasSuffix(path, "/") {
+		return graphCollectionRoute{}, false
+	}
+	segments := strings.Split(path[1:], "/")
+	if len(segments) < 3 || !strings.EqualFold(segments[0], "v1.0") {
+		return graphCollectionRoute{}, false
+	}
+
+	route := graphCollectionRoute{}
+	var collection []string
+	switch {
+	case strings.EqualFold(segments[1], "me"):
+		route.isMe = true
+		collection = segments[2:]
+	case strings.EqualFold(segments[1], "users") && len(segments) >= 4:
+		userID, ok := graphPathSegment(segments[2])
+		if !ok || userID == "" {
+			return graphCollectionRoute{}, false
+		}
+		route.userID = userID
+		collection = segments[3:]
+	default:
+		return graphCollectionRoute{}, false
+	}
+
+	if folderID, consumed, ok := graphMailFolderRoute(collection); ok {
+		route.folderID = folderID
+		collection = collection[consumed:]
+		if len(collection) == 1 && strings.EqualFold(collection[0], "messages") {
+			route.operation = graphMessageCollection
+			return route, true
+		}
+		if len(collection) == 2 && strings.EqualFold(collection[0], "messages") && strings.EqualFold(collection[1], "delta") {
+			route.operation = graphMessageDeltaCollection
+			return route, true
+		}
+		return graphCollectionRoute{}, false
+	}
+
+	if len(collection) == 2 && strings.EqualFold(collection[0], "calendarView") && strings.EqualFold(collection[1], "delta") {
+		route.operation = graphCalendarViewDeltaCollection
+		return route, true
+	}
+	if len(collection) == 2 && strings.EqualFold(collection[0], "contacts") && strings.EqualFold(collection[1], "delta") {
+		route.operation = graphContactsDeltaCollection
+		return route, true
+	}
+	return graphCollectionRoute{}, false
+}
+
+func graphMailFolderRoute(segments []string) (string, int, bool) {
+	if len(segments) == 0 {
+		return "", 0, false
+	}
+	folder, ok := graphPathSegment(segments[0])
+	if !ok {
+		return "", 0, false
+	}
+	if strings.EqualFold(folder, "mailfolders") {
+		if len(segments) < 2 {
+			return "", 0, false
+		}
+		folderID, ok := graphPathSegment(segments[1])
+		return folderID, 2, ok && folderID != ""
+	}
+
+	const alternateKeyPrefix = "mailfolders('"
+	if len(folder) <= len(alternateKeyPrefix) || !strings.EqualFold(folder[:len(alternateKeyPrefix)], alternateKeyPrefix) || !strings.HasSuffix(folder, "')") {
+		return "", 0, false
+	}
+	folderID, ok := graphODataString(folder[len(alternateKeyPrefix) : len(folder)-2])
+	return folderID, 1, ok && folderID != ""
+}
+
+func graphPathSegment(raw string) (string, bool) {
+	value, err := url.PathUnescape(raw)
+	return value, err == nil
+}
+
+func graphODataString(raw string) (string, bool) {
+	var value strings.Builder
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '\'' {
+			value.WriteByte(raw[i])
+			continue
+		}
+		if i+1 >= len(raw) || raw[i+1] != '\'' {
+			return "", false
+		}
+		value.WriteByte('\'')
+		i++
+	}
+	return value.String(), true
 }
 
 func graphUserCollectionPath(target, collection string) string {
@@ -126,14 +254,15 @@ func graphUserCollectionPath(target, collection string) string {
 
 func mailMessagesDeltaScope(target, folderID string) graphContinuationScope {
 	return graphContinuationScope{
+		host:           defaultGraphAPIHost,
 		collectionPath: graphUserCollectionPath(target, "mailFolders/"+url.PathEscape(folderID)+"/messages/delta"),
 	}
 }
 
 func calendarViewDeltaScope(target string) graphContinuationScope {
-	return graphContinuationScope{collectionPath: graphUserCollectionPath(target, "calendarView/delta")}
+	return graphContinuationScope{host: defaultGraphAPIHost, collectionPath: graphUserCollectionPath(target, "calendarView/delta")}
 }
 
 func contactsDeltaScope(target string) graphContinuationScope {
-	return graphContinuationScope{collectionPath: graphUserCollectionPath(target, "contacts/delta")}
+	return graphContinuationScope{host: defaultGraphAPIHost, collectionPath: graphUserCollectionPath(target, "contacts/delta")}
 }

--- a/internal/graphapi/mail_pages.go
+++ b/internal/graphapi/mail_pages.go
@@ -1,0 +1,139 @@
+package graphapi
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+// messagePage is one page of Graph messages and its opaque continuation URL.
+type messagePage struct {
+	Values   []models.Messageable
+	NextLink string
+}
+
+// collectMessagePages gathers at most limit messages from successive Graph
+// pages. It requests no more than the remaining result count on each call and
+// rejects server responses that could loop or duplicate user-visible results.
+func collectMessagePages(
+	ctx context.Context,
+	limit int32,
+	first func(context.Context, int32) (messagePage, error),
+	next func(context.Context, string, int32) (messagePage, error),
+) ([]models.Messageable, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return []models.Messageable{}, nil
+	}
+
+	page, err := first(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]models.Messageable, 0, limit)
+	seenIDs := make(map[string]struct{}, limit)
+	seenLinks := make(map[string]struct{})
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if len(page.Values) == 0 && page.NextLink != "" {
+			return nil, fmt.Errorf("message continuation made no progress")
+		}
+
+		for _, message := range page.Values {
+			if int32(len(result)) == limit {
+				return result, nil
+			}
+			if message == nil || message.GetId() == nil || *message.GetId() == "" {
+				return nil, fmt.Errorf("message page contains a message without an ID")
+			}
+			id := *message.GetId()
+			if _, exists := seenIDs[id]; exists {
+				return nil, fmt.Errorf("message page contains duplicate message ID %q", id)
+			}
+			seenIDs[id] = struct{}{}
+			result = append(result, message)
+		}
+
+		if int32(len(result)) == limit || page.NextLink == "" {
+			return result, nil
+		}
+		if _, exists := seenLinks[page.NextLink]; exists {
+			return nil, fmt.Errorf("message continuation repeated a previous URL")
+		}
+		seenLinks[page.NextLink] = struct{}{}
+
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		remaining := limit - int32(len(result))
+		page, err = next(ctx, page.NextLink, remaining)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// graphContinuationScope limits a Graph continuation to one collection path.
+// A continuation is replayed through the authenticated SDK adapter, so both
+// its Graph host and operation path must be verified before the request.
+type graphContinuationScope struct {
+	collectionPath string
+}
+
+// validateGraphContinuation rejects a continuation URL that would replay an
+// authenticated request outside its expected Graph collection.
+func validateGraphContinuation(raw string, expected graphContinuationScope) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid Graph continuation")
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return fmt.Errorf("refusing non-HTTPS Graph continuation")
+	}
+	if u.User != nil {
+		return fmt.Errorf("refusing Graph continuation with userinfo")
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("refusing Graph continuation with fragment")
+	}
+	if port := u.Port(); port != "" && port != "443" {
+		return fmt.Errorf("refusing Graph continuation on port %q", port)
+	}
+	if !graphAPIHosts[strings.ToLower(u.Hostname())] {
+		return fmt.Errorf("refusing Graph continuation for untrusted host %q", u.Hostname())
+	}
+	if expected.collectionPath == "" || u.EscapedPath() != expected.collectionPath {
+		return fmt.Errorf("refusing Graph continuation outside expected collection")
+	}
+	return nil
+}
+
+func graphUserCollectionPath(target, collection string) string {
+	user := "me"
+	if target != "" {
+		user = "users/" + url.PathEscape(target)
+	}
+	return "/v1.0/" + user + "/" + collection
+}
+
+func mailMessagesDeltaScope(target, folderID string) graphContinuationScope {
+	return graphContinuationScope{
+		collectionPath: graphUserCollectionPath(target, "mailFolders/"+url.PathEscape(folderID)+"/messages/delta"),
+	}
+}
+
+func calendarViewDeltaScope(target string) graphContinuationScope {
+	return graphContinuationScope{collectionPath: graphUserCollectionPath(target, "calendarView/delta")}
+}
+
+func contactsDeltaScope(target string) graphContinuationScope {
+	return graphContinuationScope{collectionPath: graphUserCollectionPath(target, "contacts/delta")}
+}

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -92,10 +92,13 @@ func TestListMessagesDoesNotMutateAbsentOrderAcrossClassificationReuse(t *testin
 		queries = append(queries, req.URL.Query())
 		return graphJSONResponse(req, `{"value":[]}`)
 	})
-	opts := &ListMessagesOptions{Top: 25}
+	opts := &ListMessagesOptions{}
 
 	if _, err := client.ListMessages(context.Background(), "", opts); err != nil {
 		t.Fatalf("first ListMessages() error = %v", err)
+	}
+	if opts.Top != 0 {
+		t.Fatalf("first ListMessages() mutated Top = %d, want 0", opts.Top)
 	}
 	if opts.OrderBy != "" {
 		t.Fatalf("first ListMessages() mutated OrderBy = %q, want empty", opts.OrderBy)
@@ -104,6 +107,9 @@ func TestListMessagesDoesNotMutateAbsentOrderAcrossClassificationReuse(t *testin
 	opts.Filter = "inferenceClassification eq 'focused'"
 	if _, err := client.ListMessages(context.Background(), "", opts); err != nil {
 		t.Fatalf("reused ListMessages() error = %v", err)
+	}
+	if opts.Top != 0 {
+		t.Fatalf("reused ListMessages() mutated Top = %d, want 0", opts.Top)
 	}
 	if opts.OrderBy != "" {
 		t.Fatalf("reused ListMessages() mutated OrderBy = %q, want empty", opts.OrderBy)
@@ -114,8 +120,14 @@ func TestListMessagesDoesNotMutateAbsentOrderAcrossClassificationReuse(t *testin
 	if got := queries[0].Get("$orderby"); got != "receivedDateTime desc" {
 		t.Errorf("first $orderby = %q, want newest-first default", got)
 	}
+	if got := queries[0].Get("$top"); got != "25" {
+		t.Errorf("first $top = %q, want clamped default 25", got)
+	}
 	if got := queries[1].Get("$orderby"); got != "" {
 		t.Errorf("classification $orderby = %q, want provider order", got)
+	}
+	if got := queries[1].Get("$top"); got != "25" {
+		t.Errorf("classification $top = %q, want clamped default 25", got)
 	}
 }
 

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -22,16 +24,11 @@ func TestListMessagesCollectsPagesWithRequestedShape(t *testing.T) {
 			if req.URL.Path != "/v1.0/users/shared@example.com/mailFolders/inbox/messages" {
 				t.Errorf("first request path = %q, want inbox messages", req.URL.Path)
 			}
-			query := req.URL.Query()
-			if got := query.Get("$orderby"); got != "receivedDateTime asc" {
-				t.Errorf("first request $orderby = %q, want oldest-first", got)
-			}
-			if got := query.Get("$select"); got != "id,subject,receivedDateTime" {
-				t.Errorf("first request $select = %q, want exact projection", got)
-			}
-			if got := query.Get("$top"); got != "3" {
-				t.Errorf("first request $top = %q, want 3", got)
-			}
+			assertExactQuery(t, req.URL.Query(), url.Values{
+				"$orderby": {"receivedDateTime asc"},
+				"$select":  {"id,subject,receivedDateTime"},
+				"$top":     {"3"},
+			})
 			return graphJSONResponse(req, `{"value":[{"id":"one","subject":"first"},{"id":"two","subject":"second"}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/inbox/messages?$skiptoken=second"}`)
 		case 2:
 			if got := req.URL.String(); got != "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/inbox/messages?$skiptoken=second" {
@@ -66,6 +63,124 @@ func TestListMessagesCollectsPagesWithRequestedShape(t *testing.T) {
 	}
 }
 
+func TestListMessagesCollectsRootPages(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		target           string
+		firstPath        string
+		continuationPath string
+		continuationLink string
+	}{
+		{
+			name:             "me",
+			firstPath:        "/v1.0/users/me-token-to-replace/messages",
+			continuationPath: "/v1.0/me/messages",
+			continuationLink: "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=second",
+		},
+		{
+			name:             "delegated mailbox",
+			target:           "shared@example.com",
+			firstPath:        "/v1.0/users/shared@example.com/messages",
+			continuationPath: "/v1.0/users/shared@example.com/messages",
+			continuationLink: "https://graph.microsoft.com/v1.0/users/shared@example.com/messages?$skiptoken=second",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := 0
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				requests++
+				switch requests {
+				case 1:
+					if got := req.URL.Path; got != tc.firstPath {
+						t.Errorf("first request path = %q, want %q", got, tc.firstPath)
+					}
+					return graphJSONResponse(req, `{"value":[{"id":"one"}],"@odata.nextLink":"`+tc.continuationLink+`"}`)
+				case 2:
+					if got := req.URL.String(); got != tc.continuationLink {
+						t.Errorf("continuation request URL = %q, want %q", got, tc.continuationLink)
+					}
+					if got := req.URL.Path; got != tc.continuationPath {
+						t.Errorf("continuation request path = %q, want %q", got, tc.continuationPath)
+					}
+					return graphJSONResponse(req, `{"value":[{"id":"two"}]}`)
+				default:
+					t.Fatalf("unexpected request %d: %s", requests, req.URL)
+					return nil
+				}
+			})
+
+			messages, err := client.ListMessages(context.Background(), tc.target, &ListMessagesOptions{Top: 2})
+			if err != nil {
+				t.Fatalf("ListMessages() error = %v", err)
+			}
+			if requests != 2 {
+				t.Fatalf("request count = %d, want 2", requests)
+			}
+			if len(messages) != 2 {
+				t.Fatalf("message count = %d, want 2", len(messages))
+			}
+			if got := []string{messages[0].ID, messages[1].ID}; !reflect.DeepEqual(got, []string{"one", "two"}) {
+				t.Errorf("message IDs = %v, want [one two]", got)
+			}
+		})
+	}
+}
+
+func TestListMessagesRejectsNilSDKResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		target     string
+		folderID   string
+		nilRequest int
+		nextLink   string
+	}{
+		{
+			name:       "folder first page",
+			folderID:   "inbox",
+			nilRequest: 1,
+		},
+		{
+			name:       "folder continuation",
+			target:     "shared@example.com",
+			folderID:   "inbox",
+			nilRequest: 2,
+			nextLink:   "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/inbox/messages?$skiptoken=second",
+		},
+		{
+			name:       "root first page",
+			nilRequest: 1,
+		},
+		{
+			name:       "root continuation",
+			target:     "shared@example.com",
+			nilRequest: 2,
+			nextLink:   "https://graph.microsoft.com/v1.0/users/shared@example.com/messages?$skiptoken=second",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := 0
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				requests++
+				if requests == tc.nilRequest {
+					return graphEmptyResponse(req)
+				}
+				return graphJSONResponse(req, `{"value":[{"id":"one"}],"@odata.nextLink":"`+tc.nextLink+`"}`)
+			})
+
+			messages, err := client.ListMessages(context.Background(), tc.target, &ListMessagesOptions{FolderID: tc.folderID, Top: 2})
+			if err == nil || err.Error() != "listing messages: graph returned no message response" {
+				t.Fatalf("ListMessages() error = %v, want deterministic nil-response error", err)
+			}
+			if messages != nil {
+				t.Fatalf("ListMessages() messages = %v, want nil", messages)
+			}
+			if requests != tc.nilRequest {
+				t.Errorf("request count = %d, want %d", requests, tc.nilRequest)
+			}
+		})
+	}
+}
+
 type roundTripFunc func(*http.Request) *http.Response
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -90,6 +205,22 @@ func graphJSONResponse(req *http.Request, body string) *http.Response {
 		Body:          io.NopCloser(strings.NewReader(body)),
 		Request:       req,
 		ContentLength: int64(len(body)),
+	}
+}
+
+func graphEmptyResponse(req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       http.NoBody,
+		Request:    req,
+	}
+}
+
+func assertExactQuery(t *testing.T, actual, want url.Values) {
+	t.Helper()
+	if !reflect.DeepEqual(actual, want) {
+		t.Errorf("request query = %v, want exact %v", actual, want)
 	}
 }
 

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -63,6 +63,29 @@ func TestListMessagesCollectsPagesWithRequestedShape(t *testing.T) {
 	}
 }
 
+func TestListMessagesRejectsExplicitOrderWithInferenceClassificationWithoutRequest(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		return graphJSONResponse(req, `{"value":[]}`)
+	})
+
+	messages, err := client.ListMessages(context.Background(), "", &ListMessagesOptions{
+		Top:     25,
+		Filter:  "inferenceClassification eq 'focused'",
+		OrderBy: "receivedDateTime asc",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot combine orderBy with inferenceClassification") {
+		t.Fatalf("ListMessages() error = %v, want incompatible-order rejection", err)
+	}
+	if messages != nil {
+		t.Fatalf("ListMessages() messages = %v, want nil", messages)
+	}
+	if requests != 0 {
+		t.Errorf("request count = %d, want 0", requests)
+	}
+}
+
 func TestListMessagesCollectsRootPages(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -1,0 +1,214 @@
+package graphapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+func TestCollectMessagePagesCompletesTwoPages(t *testing.T) {
+	first := func(_ context.Context, top int32) (messagePage, error) {
+		if top != 3 {
+			t.Fatalf("first page top = %d, want 3", top)
+		}
+		return messagePage{Values: messages("one", "two"), NextLink: "next"}, nil
+	}
+	next := func(_ context.Context, link string, top int32) (messagePage, error) {
+		if link != "next" {
+			t.Fatalf("continuation link = %q, want next", link)
+		}
+		if top != 1 {
+			t.Fatalf("continuation top = %d, want 1", top)
+		}
+		return messagePage{Values: messages("three")}, nil
+	}
+
+	got, err := collectMessagePages(context.Background(), 3, first, next)
+	if err != nil {
+		t.Fatalf("collectMessagePages() error = %v", err)
+	}
+	assertMessageIDs(t, got, "one", "two", "three")
+}
+
+func TestCollectMessagePagesTruncatesFinalPageAtLimit(t *testing.T) {
+	first := func(_ context.Context, top int32) (messagePage, error) {
+		if top != 3 {
+			t.Fatalf("first page top = %d, want 3", top)
+		}
+		return messagePage{Values: messages("one", "two"), NextLink: "next"}, nil
+	}
+	next := func(_ context.Context, _ string, top int32) (messagePage, error) {
+		if top != 1 {
+			t.Fatalf("continuation top = %d, want 1", top)
+		}
+		return messagePage{Values: messages("three", "four")}, nil
+	}
+
+	got, err := collectMessagePages(context.Background(), 3, first, next)
+	if err != nil {
+		t.Fatalf("collectMessagePages() error = %v", err)
+	}
+	assertMessageIDs(t, got, "one", "two", "three")
+}
+
+func TestCollectMessagePagesReturnsTerminalShortMailbox(t *testing.T) {
+	got, err := collectMessagePages(context.Background(), 3,
+		func(_ context.Context, top int32) (messagePage, error) {
+			if top != 3 {
+				t.Fatalf("first page top = %d, want 3", top)
+			}
+			return messagePage{Values: messages("one", "two")}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			t.Fatal("unexpected continuation request")
+			return messagePage{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("collectMessagePages() error = %v", err)
+	}
+	assertMessageIDs(t, got, "one", "two")
+}
+
+func TestCollectMessagePagesRejectsDuplicateMessageID(t *testing.T) {
+	got, err := collectMessagePages(context.Background(), 2,
+		func(context.Context, int32) (messagePage, error) {
+			return messagePage{Values: messages("one"), NextLink: "next"}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			return messagePage{Values: messages("one")}, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("collectMessagePages() error = nil, want duplicate rejection")
+	}
+	if got != nil {
+		t.Fatalf("collectMessagePages() messages = %v, want nil on error", got)
+	}
+}
+
+func TestCollectMessagePagesRejectsEmptyPageWithContinuation(t *testing.T) {
+	got, err := collectMessagePages(context.Background(), 2,
+		func(context.Context, int32) (messagePage, error) {
+			return messagePage{NextLink: "next"}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			t.Fatal("unexpected continuation request")
+			return messagePage{}, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("collectMessagePages() error = nil, want zero-progress rejection")
+	}
+	if got != nil {
+		t.Fatalf("collectMessagePages() messages = %v, want nil on error", got)
+	}
+}
+
+func TestCollectMessagePagesRejectsRepeatedContinuationLink(t *testing.T) {
+	got, err := collectMessagePages(context.Background(), 3,
+		func(context.Context, int32) (messagePage, error) {
+			return messagePage{Values: messages("one"), NextLink: "next"}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			return messagePage{Values: messages("two"), NextLink: "next"}, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("collectMessagePages() error = nil, want repeated continuation rejection")
+	}
+	if got != nil {
+		t.Fatalf("collectMessagePages() messages = %v, want nil on error", got)
+	}
+}
+
+func TestCollectMessagePagesStopsOnCancellationBeforeContinuation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	got, err := collectMessagePages(ctx, 2,
+		func(context.Context, int32) (messagePage, error) {
+			cancel()
+			return messagePage{Values: messages("one"), NextLink: "next"}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			t.Fatal("unexpected continuation request after cancellation")
+			return messagePage{}, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectMessagePages() error = %v, want context cancellation", err)
+	}
+	if got != nil {
+		t.Fatalf("collectMessagePages() messages = %v, want nil on error", got)
+	}
+}
+
+func TestCollectMessagePagesStopsAtPageBound(t *testing.T) {
+	got, err := collectMessagePages(context.Background(), 2,
+		func(_ context.Context, top int32) (messagePage, error) {
+			if top != 2 {
+				t.Fatalf("first page top = %d, want 2", top)
+			}
+			return messagePage{Values: messages("one", "two"), NextLink: "next"}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			t.Fatal("unexpected continuation request after page bound")
+			return messagePage{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("collectMessagePages() error = %v", err)
+	}
+	assertMessageIDs(t, got, "one", "two")
+}
+
+func TestValidateGraphContinuation(t *testing.T) {
+	scope := graphContinuationScope{collectionPath: "/v1.0/me/mailFolders/inbox/messages"}
+	if err := validateGraphContinuation("https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$skiptoken=abc", scope); err != nil {
+		t.Fatalf("validateGraphContinuation() error = %v", err)
+	}
+
+	for _, raw := range []string{
+		"http://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages",
+		"https://user@graph.microsoft.com/v1.0/me/mailFolders/inbox/messages",
+		"https://graph.microsoft.com:444/v1.0/me/mailFolders/inbox/messages",
+		"https://evil.example.com/v1.0/me/mailFolders/inbox/messages",
+		"https://graph.microsoft.com/v1.0/me/mailFolders/archive/messages",
+		"https://graph.microsoft.com/v1.0/me/messages",
+		"https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages#fragment",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if err := validateGraphContinuation(raw, scope); err == nil {
+				t.Fatal("validateGraphContinuation() error = nil, want rejection")
+			}
+		})
+	}
+}
+
+func messages(ids ...string) []models.Messageable {
+	values := make([]models.Messageable, 0, len(ids))
+	for _, id := range ids {
+		message := models.NewMessage()
+		message.SetId(&id)
+		values = append(values, message)
+	}
+	return values
+}
+
+func assertMessageIDs(t *testing.T, got []models.Messageable, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("message count = %d, want %d", len(got), len(want))
+	}
+	for i, message := range got {
+		if message.GetId() == nil {
+			t.Fatalf("message %d has no ID", i)
+		}
+		if actual := *message.GetId(); actual != want[i] {
+			t.Errorf("message %d ID = %q, want %q", i, actual, want[i])
+		}
+	}
+}

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -86,6 +86,39 @@ func TestListMessagesRejectsExplicitOrderWithInferenceClassificationWithoutReque
 	}
 }
 
+func TestListMessagesDoesNotMutateAbsentOrderAcrossClassificationReuse(t *testing.T) {
+	var queries []url.Values
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		queries = append(queries, req.URL.Query())
+		return graphJSONResponse(req, `{"value":[]}`)
+	})
+	opts := &ListMessagesOptions{Top: 25}
+
+	if _, err := client.ListMessages(context.Background(), "", opts); err != nil {
+		t.Fatalf("first ListMessages() error = %v", err)
+	}
+	if opts.OrderBy != "" {
+		t.Fatalf("first ListMessages() mutated OrderBy = %q, want empty", opts.OrderBy)
+	}
+
+	opts.Filter = "inferenceClassification eq 'focused'"
+	if _, err := client.ListMessages(context.Background(), "", opts); err != nil {
+		t.Fatalf("reused ListMessages() error = %v", err)
+	}
+	if opts.OrderBy != "" {
+		t.Fatalf("reused ListMessages() mutated OrderBy = %q, want empty", opts.OrderBy)
+	}
+	if len(queries) != 2 {
+		t.Fatalf("request count = %d, want 2", len(queries))
+	}
+	if got := queries[0].Get("$orderby"); got != "receivedDateTime desc" {
+		t.Errorf("first $orderby = %q, want newest-first default", got)
+	}
+	if got := queries[1].Get("$orderby"); got != "" {
+		t.Errorf("classification $orderby = %q, want provider order", got)
+	}
+}
+
 func TestListMessagesCollectsRootPages(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -3,10 +3,95 @@ package graphapi
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
+	absauth "github.com/microsoft/kiota-abstractions-go/authentication"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
+
+func TestListMessagesCollectsPagesWithRequestedShape(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		switch requests {
+		case 1:
+			if req.URL.Path != "/v1.0/users/shared@example.com/mailFolders/inbox/messages" {
+				t.Errorf("first request path = %q, want inbox messages", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if got := query.Get("$orderby"); got != "receivedDateTime asc" {
+				t.Errorf("first request $orderby = %q, want oldest-first", got)
+			}
+			if got := query.Get("$select"); got != "id,subject,receivedDateTime" {
+				t.Errorf("first request $select = %q, want exact projection", got)
+			}
+			if got := query.Get("$top"); got != "3" {
+				t.Errorf("first request $top = %q, want 3", got)
+			}
+			return graphJSONResponse(req, `{"value":[{"id":"one","subject":"first"},{"id":"two","subject":"second"}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/inbox/messages?$skiptoken=second"}`)
+		case 2:
+			if got := req.URL.String(); got != "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/inbox/messages?$skiptoken=second" {
+				t.Errorf("continuation request URL = %q, want opaque nextLink", got)
+			}
+			return graphJSONResponse(req, `{"value":[{"id":"three","subject":"third"},{"id":"four","subject":"fourth"}]}`)
+		default:
+			t.Fatalf("unexpected request %d: %s", requests, req.URL)
+			return nil
+		}
+	})
+
+	messages, err := client.ListMessages(context.Background(), "shared@example.com", &ListMessagesOptions{
+		FolderID: "inbox",
+		Top:      3,
+		OrderBy:  "receivedDateTime asc",
+		Select:   []string{"id", "subject", "receivedDateTime"},
+	})
+	if err != nil {
+		t.Fatalf("ListMessages() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("request count = %d, want 2", requests)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("message count = %d, want 3", len(messages))
+	}
+	for index, want := range []string{"one", "two", "three"} {
+		if got := messages[index].ID; got != want {
+			t.Errorf("message %d ID = %q, want %q", index, got, want)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func testGraphClient(t *testing.T, responder roundTripFunc) *Client {
+	t.Helper()
+	adapter, err := msgraphsdk.NewGraphRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(
+		&absauth.AnonymousAuthenticationProvider{}, nil, nil, &http.Client{Transport: responder},
+	)
+	if err != nil {
+		t.Fatalf("creating Graph request adapter: %v", err)
+	}
+	return &Client{inner: msgraphsdk.NewGraphServiceClient(adapter)}
+}
+
+func graphJSONResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		Request:       req,
+		ContentLength: int64(len(body)),
+	}
+}
 
 func TestCollectMessagePagesCompletesTwoPages(t *testing.T) {
 	first := func(_ context.Context, top int32) (messagePage, error) {

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	absauth "github.com/microsoft/kiota-abstractions-go/authentication"
+	khttp "github.com/microsoft/kiota-http-go"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
@@ -258,7 +259,9 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 func testGraphClient(t *testing.T, responder roundTripFunc) *Client {
 	t.Helper()
 	adapter, err := msgraphsdk.NewGraphRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(
-		&absauth.AnonymousAuthenticationProvider{}, nil, nil, &http.Client{Transport: responder},
+		&absauth.AnonymousAuthenticationProvider{}, nil, nil, &http.Client{
+			Transport: khttp.NewCustomTransportWithParentTransport(responder, khttp.NewHeadersInspectionHandler()),
+		},
 	)
 	if err != nil {
 		t.Fatalf("creating Graph request adapter: %v", err)

--- a/internal/graphapi/mail_pages_test.go
+++ b/internal/graphapi/mail_pages_test.go
@@ -124,6 +124,24 @@ func TestCollectMessagePagesRejectsRepeatedContinuationLink(t *testing.T) {
 	}
 }
 
+func TestCollectMessagePagesReturnsNoPartialResultAfterContinuationError(t *testing.T) {
+	wantErr := errors.New("continuation failed")
+	got, err := collectMessagePages(context.Background(), 2,
+		func(context.Context, int32) (messagePage, error) {
+			return messagePage{Values: messages("one"), NextLink: "next"}, nil
+		},
+		func(context.Context, string, int32) (messagePage, error) {
+			return messagePage{}, wantErr
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("collectMessagePages() error = %v, want %v", err, wantErr)
+	}
+	if got != nil {
+		t.Fatalf("collectMessagePages() messages = %v, want nil on error", got)
+	}
+}
+
 func TestCollectMessagePagesStopsOnCancellationBeforeContinuation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -166,7 +184,7 @@ func TestCollectMessagePagesStopsAtPageBound(t *testing.T) {
 }
 
 func TestValidateGraphContinuation(t *testing.T) {
-	scope := graphContinuationScope{collectionPath: "/v1.0/me/mailFolders/inbox/messages"}
+	scope := continuationScope("graph.microsoft.com", "/v1.0/me/mailFolders/inbox/messages")
 	if err := validateGraphContinuation("https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$skiptoken=abc", scope); err != nil {
 		t.Fatalf("validateGraphContinuation() error = %v", err)
 	}
@@ -178,11 +196,75 @@ func TestValidateGraphContinuation(t *testing.T) {
 		"https://evil.example.com/v1.0/me/mailFolders/inbox/messages",
 		"https://graph.microsoft.com/v1.0/me/mailFolders/archive/messages",
 		"https://graph.microsoft.com/v1.0/me/messages",
+		"https://graph.microsoft.com/v1.0/users/other@example.com/mailFolders/inbox/messages",
 		"https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages#fragment",
 	} {
 		t.Run(raw, func(t *testing.T) {
 			if err := validateGraphContinuation(raw, scope); err == nil {
 				t.Fatal("validateGraphContinuation() error = nil, want rejection")
+			}
+		})
+	}
+}
+
+func TestValidateGraphContinuationAllowsDocumentedMailDeltaLinkForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope graphContinuationScope
+		url   string
+	}{
+		{
+			name:  "me nextLink segment form",
+			scope: continuationScope("graph.microsoft.com", "/v1.0/me/mailFolders/AQMk/messages/delta"),
+			url:   "https://graph.microsoft.com/v1.0/me/mailFolders/AQMk/messages/delta?$skiptoken=next",
+		},
+		{
+			name:  "me deltaLink alternate key form",
+			scope: continuationScope("graph.microsoft.com", "/v1.0/me/mailFolders/AQMk/messages/delta"),
+			url:   "https://graph.microsoft.com/v1.0/me/mailfolders('AQMk')/messages/delta?$deltatoken=done",
+		},
+		{
+			name:  "delegated nextLink segment form",
+			scope: continuationScope("graph.microsoft.com", "/v1.0/users/shared@example.com/mailFolders/AQMk/messages/delta"),
+			url:   "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/AQMk/messages/delta?$skiptoken=next",
+		},
+		{
+			name:  "delegated deltaLink alternate key form",
+			scope: continuationScope("graph.microsoft.com", "/v1.0/users/shared@example.com/mailFolders/AQMk/messages/delta"),
+			url:   "https://graph.microsoft.com/v1.0/users/shared@example.com/mailfolders('AQMk')/messages/delta?$deltatoken=done",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateGraphContinuation(tc.url, tc.scope); err != nil {
+				t.Fatalf("validateGraphContinuation() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateGraphContinuationRejectsOtherGraphCloud(t *testing.T) {
+	scope := continuationScope("graph.microsoft.com", "/v1.0/me/mailFolders/AQMk/messages/delta")
+	if err := validateGraphContinuation("https://graph.microsoft.us/v1.0/me/mailFolders/AQMk/messages/delta?$skiptoken=next", scope); err == nil {
+		t.Fatal("validateGraphContinuation() error = nil, want cross-cloud rejection")
+	}
+}
+
+func TestValidateGraphContinuationBindsExpectedGraphCloud(t *testing.T) {
+	for _, tc := range []struct {
+		expectedHost string
+		actualHost   string
+	}{
+		{expectedHost: "GRAPH.MICROSOFT.COM", actualHost: "graph.microsoft.com"},
+		{expectedHost: "graph.microsoft.us", actualHost: "graph.microsoft.us"},
+		{expectedHost: "dod-graph.microsoft.us", actualHost: "dod-graph.microsoft.us"},
+		{expectedHost: "microsoftgraph.chinacloudapi.cn", actualHost: "microsoftgraph.chinacloudapi.cn"},
+	} {
+		t.Run(tc.actualHost, func(t *testing.T) {
+			scope := continuationScope(tc.expectedHost, "/v1.0/me/mailFolders/AQMk/messages/delta")
+			url := "https://" + tc.actualHost + "/v1.0/me/mailFolders/AQMk/messages/delta?$skiptoken=next"
+			if err := validateGraphContinuation(url, scope); err != nil {
+				t.Fatalf("validateGraphContinuation() error = %v", err)
 			}
 		})
 	}
@@ -211,4 +293,8 @@ func assertMessageIDs(t *testing.T, got []models.Messageable, want ...string) {
 			t.Errorf("message %d ID = %q, want %q", i, actual, want[i])
 		}
 	}
+}
+
+func continuationScope(host, collectionPath string) graphContinuationScope {
+	return graphContinuationScope{host: host, collectionPath: collectionPath}
 }


### PR DESCRIPTION
﻿## What changed

- make `mail list --top` a total result bound across Microsoft Graph continuation pages
- add `--order newest|oldest` with exact oldest-first behavior for ordinary folder lists
- apply `--select` to the Graph projection and selected JSON output while preserving untrusted/concise safeguards
- reject unsafe continuations, duplicates, non-progressing pages, partial traversal, invalid projections, and unsupported explicit ordering with Focused/Other
- document terminal-short and fail-closed traversal semantics

## Why

`mail list` previously returned only the first provider page and discarded the continuation link, so callers could not obtain an exact bounded oldest-first inventory. This made large mailbox review incomplete even when `--top` requested a larger total.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./internal/graphapi -count=1`
- `go test ./internal/cmd -count=1`
- live guarded read: exactly 1,000 unique Inbox IDs returned in nondecreasing `receivedDateTime` order, with no Outlook GUI process change
- `git diff --check`

`go test ./...` has one pre-existing Windows-only `internal/config/TestPaths_HonorsEnvOverride` path-separator failure; the package and test are byte-unchanged from the base commit. Race execution is unavailable on this Windows host because CGO is disabled.
