### PR TITLE
feat(calendar): support targeted event creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ olk calendar events [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 25
 olk calendar view [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 50]
 olk calendar delta [-d 30] [--after DATE] [--before DATE] [--token TOKEN] [-n N]  Incremental sync of events
 olk calendar get <ID>
-olk calendar create --subject X --start Y --end Z [--location L] [--attendees A] [--all-day] [--online-meeting] [-r daily|weekdays|weekly|monthly|yearly]
+olk calendar create --subject X --start Y --end Z [--calendar ID] [--location L] [--attendees A] [--all-day] [--online-meeting] [-r daily|weekdays|weekly|monthly|yearly]
 olk calendar update <ID> [--subject X] [--start Y] [--end Z] [--location L]
 olk calendar delete <ID> [--force]
 olk calendar respond <ID> accept|decline|tentative

--- a/SKILL.md
+++ b/SKILL.md
@@ -188,6 +188,7 @@ Focused/other filters use provider order and cannot be combined with
 olk calendar events [-d DAYS] [--after DATE] [--before DATE] [--calendar ID] [-n 25]   # default: next 7 days
 olk calendar get <ID>
 olk calendar create --subject "Standup" --start 2025-06-15T09:00 --end 2025-06-15T09:30
+olk calendar create --calendar ID --subject "Appointment" --start 2025-06-15T09:00 --end 2025-06-15T09:30
 olk calendar create --subject "Sync" --start 2025-06-15T10:00 --end 2025-06-15T10:30 --attendees a@b.com --attendees c@d.com
 olk calendar create --subject "Offsite" --start 2025-06-15 --end 2025-06-16 --all-day
 olk calendar create --subject "Call" --start 2025-06-15T14:00 --end 2025-06-15T14:30 --online-meeting   # Teams link

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -152,6 +152,7 @@ type CalendarCreateCmd struct {
 	Subject       string   `help:"Event subject" required:"" short:"s"`
 	Start         string   `help:"Start time (ISO 8601)" required:""`
 	End           string   `help:"End time (ISO 8601)" required:""`
+	Calendar      string   `help:"Calendar ID (default calendar when omitted)"`
 	Location      string   `help:"Event location" short:"l"`
 	Attendees     []string `help:"Attendee email addresses" short:"a"`
 	AllDay        bool     `help:"All-day event"`
@@ -180,14 +181,20 @@ func (c *CalendarCreateCmd) Run(ctx *RunContext) error {
 
 	if ctx.Flags.DryRun {
 		fmt.Printf("Would create event:\n  Subject: %s\n  Start: %s\n  End: %s\n", outfmt.Sanitize(c.Subject), c.Start, c.End)
+		if c.Calendar != "" {
+			fmt.Printf("  Calendar: %s\n", outfmt.Sanitize(c.Calendar))
+		}
 		return nil
 	}
 
-	event, err := client.CreateEvent(ctx.Ctx, c.Subject, start, end, c.Location, c.Attendees, c.AllDay, c.OnlineMeeting, c.Recurrence)
+	event, err := client.CreateEvent(ctx.Ctx, c.Calendar, c.Subject, start, end, c.Location, c.Attendees, c.AllDay, c.OnlineMeeting, c.Recurrence)
 	if err != nil {
 		return err
 	}
 
+	if ctx.Flags.JSON {
+		return ctx.Printer().PrintJSON(event, 1, "")
+	}
 	fmt.Printf("Event created: %s (ID: %s)\n", outfmt.Sanitize(event.Subject), event.ID)
 	return nil
 }

--- a/internal/cmd/calendar_create_test.go
+++ b/internal/cmd/calendar_create_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCalendarCreateRoutesAndReturnsJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		calendarID   string
+		expectedPath string
+	}{
+		{name: "default calendar", expectedPath: "/v1.0/me/events"},
+		{name: "selected calendar", calendarID: "calendar-id", expectedPath: "/v1.0/me/calendars/calendar-id/events"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{
+				"--json",
+				"--subject", "Proof event",
+				"--start", "2026-08-14T19:00:00Z",
+				"--end", "2026-08-14T19:15:00Z",
+			}
+			if tc.calendarID != "" {
+				args = append(args, "--calendar", tc.calendarID)
+			}
+
+			output, calls, err := runMailCommand(
+				t,
+				[]string{"calendar", "create"},
+				args,
+				func(req *http.Request) *http.Response {
+					if req.Method != http.MethodPost {
+						t.Errorf("request method = %s, want POST", req.Method)
+					}
+					if req.URL.Path != tc.expectedPath {
+						t.Errorf("request path = %q, want %q", req.URL.Path, tc.expectedPath)
+					}
+					return graphJSONResponse(req, `{
+						"id":"event-id",
+						"subject":"Proof event",
+						"start":{"dateTime":"2026-08-14T19:00:00","timeZone":"UTC"},
+						"end":{"dateTime":"2026-08-14T19:15:00","timeZone":"UTC"}
+					}`)
+				},
+			)
+			if err != nil {
+				t.Fatalf("calendar create: %v", err)
+			}
+			if calls != 1 {
+				t.Fatalf("Graph handler calls = %d, want 1", calls)
+			}
+
+			var envelope struct {
+				Results struct {
+					ID      string `json:"id"`
+					Subject string `json:"subject"`
+				} `json:"results"`
+				Count int `json:"count"`
+			}
+			if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+				t.Fatalf("decode JSON output: %v\n%s", err, output)
+			}
+			if envelope.Count != 1 || envelope.Results.ID != "event-id" || envelope.Results.Subject != "Proof event" {
+				t.Fatalf("created event receipt = %#v, want event-id and Proof event", envelope)
+			}
+		})
+	}
+}
+
+func TestCalendarCreateRejectsInvalidCalendarIDWithoutRequest(t *testing.T) {
+	_, calls, err := runMailCommand(
+		t,
+		[]string{"calendar", "create"},
+		[]string{
+			"--calendar", "not a calendar id",
+			"--subject", "Proof event",
+			"--start", "2026-08-14T19:00:00Z",
+			"--end", "2026-08-14T19:15:00Z",
+		},
+		func(req *http.Request) *http.Response {
+			t.Fatalf("unexpected Graph request: %s", req.URL)
+			return nil
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "calendar ID contains invalid characters") {
+		t.Fatalf("error = %v, want invalid calendar ID rejection", err)
+	}
+	if calls != 0 {
+		t.Fatalf("Graph handler calls = %d, want 0", calls)
+	}
+}

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -116,12 +116,17 @@ func (c *Client) GetEvent(ctx context.Context, target, eventID string) (*Calenda
 	return &e, nil
 }
 
-func (c *Client) CreateEvent(ctx context.Context, subject string, start, end time.Time, location string, attendees []string, isAllDay, isOnlineMeeting bool, recurrence string) (*CalendarEvent, error) {
+func (c *Client) CreateEvent(ctx context.Context, calendarID, subject string, start, end time.Time, location string, attendees []string, isAllDay, isOnlineMeeting bool, recurrence string) (*CalendarEvent, error) {
 	if err := c.ensureWritable(); err != nil {
 		return nil, err
 	}
 	if len(attendees) > 0 {
 		if err := c.ensureMaySend(); err != nil {
+			return nil, err
+		}
+	}
+	if calendarID != "" {
+		if err := validateID(calendarID, "calendar ID"); err != nil {
 			return nil, err
 		}
 	}
@@ -176,7 +181,13 @@ func (c *Client) CreateEvent(ctx context.Context, subject string, start, end tim
 		event.SetRecurrence(rec)
 	}
 
-	created, err := c.inner.Me().Events().Post(ctx, event, nil)
+	var created models.Eventable
+	var err error
+	if calendarID == "" {
+		created, err = c.inner.Me().Events().Post(ctx, event, nil)
+	} else {
+		created, err = c.inner.Me().Calendars().ByCalendarId(calendarID).Events().Post(ctx, event, nil)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("creating event: %w", err)
 	}

--- a/internal/graphapi/client_guards_test.go
+++ b/internal/graphapi/client_guards_test.go
@@ -29,7 +29,7 @@ func TestNoWriteGuardBlocksMutations(t *testing.T) {
 		{"CreateMailFolder", func() error { _, err := c.CreateMailFolder(ctx, "n"); return err }},
 		{"CreateUploadSession", func() error { _, err := c.CreateUploadSession(ctx, "d", "p", false); return err }},
 		{"CreateEvent", func() error {
-			_, err := c.CreateEvent(ctx, "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "")
+			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "")
 			return err
 		}},
 		{"SendMessage", func() error { return c.SendMessage(ctx, "s", "b", nil, nil, nil, false, nil, "", false) }},
@@ -55,7 +55,7 @@ func TestNoSendGuardBlocksSends(t *testing.T) {
 		{"SendDraft", func() error { return c.SendDraft(ctx, "id") }},
 		{"RespondToEvent", func() error { return c.RespondToEvent(ctx, "id", "accept") }},
 		{"CreateEvent w/ attendees", func() error {
-			_, err := c.CreateEvent(ctx, "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "")
+			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "")
 			return err
 		}},
 	}


### PR DESCRIPTION
## What changed

- add `--calendar <id>` to `olk calendar create`
- route selected-calendar creation through `/me/calendars/{id}/events`
- preserve the existing default-calendar route when the flag is omitted
- return the created event through the normal JSON envelope when `--json` is set
- document the new flag in the README and agent skill

## Why

Calendar reads already accept a calendar ID, but event creation always targeted the default event collection. Scripts and agents therefore could not create an event in a calendar they had resolved with `calendar calendars`, and JSON callers did not receive the provider-assigned event ID as structured output.

The selected-calendar route uses the documented Microsoft Graph v1.0 API and works with delegated personal Microsoft accounts as well as work/school accounts.

## Live verification

Built the branch and exercised it against a personal Outlook.com account:

1. created a no-attendee disposable event in an empty, account-owned secondary calendar using its explicit calendar ID
2. received the created event and provider ID in the JSON envelope
3. read the event back from that secondary calendar
4. confirmed the same time window in the default calendar was empty
5. deleted the event and confirmed the secondary-calendar window was empty again

## Validation

- `go mod tidy` with no `go.mod` or `go.sum` drift
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./...`
- `golangci-lint run ./...`
- `git diff --check`

Closes #71
