### PR TITLE
feat(calendar): support provider body formats

### DIFF
--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rlrghb/olkcli/internal/graphapi"
 	"github.com/rlrghb/olkcli/internal/outfmt"
 )
 
@@ -23,11 +24,12 @@ type CalendarCmd struct {
 }
 
 type CalendarEventsCmd struct {
-	Days     int    `help:"Number of days to look ahead" default:"7" short:"d"`
-	After    string `help:"Start date (ISO 8601)"`
-	Before   string `help:"End date (ISO 8601)"`
-	Calendar string `help:"Calendar ID"`
-	Top      int32  `help:"Max events to return" default:"25" short:"n"`
+	Days       int     `help:"Number of days to look ahead" default:"7" short:"d"`
+	After      string  `help:"Start date (ISO 8601)"`
+	Before     string  `help:"End date (ISO 8601)"`
+	Calendar   string  `help:"Calendar ID"`
+	Top        int32   `help:"Max events to return" default:"25" short:"n"`
+	BodyFormat *string `help:"Request provider-returned event body representation" enum:"text,html"`
 }
 
 func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
@@ -72,7 +74,15 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	events, err := client.ListEvents(ctx.Ctx, target, start, end, c.Calendar, c.Top)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	events, err := client.ListEvents(ctx.Ctx, target, start, end, c.Calendar, c.Top, preference)
 	if err != nil {
 		return err
 	}
@@ -98,7 +108,8 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 }
 
 type CalendarGetCmd struct {
-	ID string `arg:"" help:"Event ID"`
+	ID         string  `arg:"" help:"Event ID"`
+	BodyFormat *string `help:"Request provider-returned event body representation" enum:"text,html"`
 }
 
 func (c *CalendarGetCmd) Run(ctx *RunContext) error {
@@ -112,7 +123,15 @@ func (c *CalendarGetCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	event, err := client.GetEvent(ctx.Ctx, target, c.ID)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	event, err := client.GetEvent(ctx.Ctx, target, c.ID, preference)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/calendar_view.go
+++ b/internal/cmd/calendar_view.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rlrghb/olkcli/internal/graphapi"
 	"github.com/rlrghb/olkcli/internal/outfmt"
 )
 
 type CalendarViewCmd struct {
-	Days     int    `help:"Number of days to show" default:"7" short:"d"`
-	After    string `help:"Start date (ISO 8601)"`
-	Before   string `help:"End date (ISO 8601)"`
-	Calendar string `help:"Calendar ID"`
-	Top      int32  `help:"Max events to return" default:"50" short:"n"`
+	Days       int     `help:"Number of days to show" default:"7" short:"d"`
+	After      string  `help:"Start date (ISO 8601)"`
+	Before     string  `help:"End date (ISO 8601)"`
+	Calendar   string  `help:"Calendar ID"`
+	Top        int32   `help:"Max events to return" default:"50" short:"n"`
+	BodyFormat *string `help:"Request provider-returned event body representation" enum:"text,html"`
 }
 
 func (c *CalendarViewCmd) Run(ctx *RunContext) error {
@@ -51,7 +53,15 @@ func (c *CalendarViewCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	events, err := client.ListCalendarView(ctx.Ctx, target, start, end, c.Calendar, c.Top)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	events, err := client.ListCalendarView(ctx.Ctx, target, start, end, c.Calendar, c.Top, preference)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -15,6 +15,7 @@ type versionInfo struct {
 }
 
 var advertisedCapabilities = []string{
+	"calendar.provider-body-format-v1",
 	"cli.json-error-v1",
 	"mail.folders.well-known-v1",
 	"mail.get.parent-folder-v1",

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -24,6 +24,7 @@ func TestVersionJSONAdvertisesStructuredMailCapabilities(t *testing.T) {
 		t.Fatalf("decoding version JSON: %v\n%s", err, stdout)
 	}
 	if want := []string{
+		"calendar.provider-body-format-v1",
 		"cli.json-error-v1",
 		"mail.folders.well-known-v1",
 		"mail.get.parent-folder-v1",

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -31,6 +31,7 @@ type CalendarEvent struct {
 	Recurrence  string   `json:"recurrence,omitempty"`
 	BodyPreview string   `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
 	Body        string   `json:"body,omitempty" untrusted:"true" concise:"omit"`
+	BodyType    string   `json:"bodyType,omitempty"`
 }
 
 // CalendarInfo is a simplified calendar representation
@@ -45,17 +46,25 @@ type CalendarInfo struct {
 // mailbox, or the signed-in user's calendar when target is empty. Targeting
 // another mailbox requires the calling token to carry Calendars.Read.Shared
 // and the calling user to have Exchange Full Access delegation on the target.
-func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
+func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32, preference BodyPreference) ([]CalendarEvent, error) {
 	top = clampTop(top)
+	headers, options, contract, err := newBodyResponseContract(preference)
+	if err != nil {
+		return nil, err
+	}
 
 	startStr := startTime.UTC().Format("2006-01-02T15:04:05")
 	endStr := endTime.UTC().Format("2006-01-02T15:04:05")
 
+	selected := []string{"id", "subject", "start", "end", "location", "organizer", "attendees", "isAllDay", "isOnlineMeeting", "onlineMeetingUrl", "showAs", "bodyPreview", "recurrence"}
+	if preference != BodyDefault {
+		selected = append(selected, "body")
+	}
 	queryParams := &users.ItemCalendarViewRequestBuilderGetQueryParameters{
 		StartDateTime: &startStr,
 		EndDateTime:   &endStr,
 		Top:           &top,
-		Select:        []string{"id", "subject", "start", "end", "location", "organizer", "attendees", "isAllDay", "isOnlineMeeting", "onlineMeetingUrl", "showAs", "bodyPreview", "recurrence"},
+		Select:        selected,
 		Orderby:       []string{"start/dateTime"},
 	}
 
@@ -64,6 +73,8 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 			return nil, err
 		}
 		calConfig := &users.ItemCalendarsItemCalendarViewRequestBuilderGetRequestConfiguration{
+			Headers: headers,
+			Options: options,
 			QueryParameters: &users.ItemCalendarsItemCalendarViewRequestBuilderGetQueryParameters{
 				StartDateTime: &startStr,
 				EndDateTime:   &endStr,
@@ -76,6 +87,9 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 		if err != nil {
 			return nil, fmt.Errorf("listing events: %w", err)
 		}
+		if err := contract.verify(); err != nil {
+			return nil, fmt.Errorf("listing events: %w", err)
+		}
 		events := make([]CalendarEvent, 0, len(resp.GetValue()))
 		for _, e := range resp.GetValue() {
 			events = append(events, convertEvent(e))
@@ -84,11 +98,16 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 	}
 
 	config := &users.ItemCalendarViewRequestBuilderGetRequestConfiguration{
+		Headers:         headers,
+		Options:         options,
 		QueryParameters: queryParams,
 	}
 
 	resp, err := c.targetUser(target).CalendarView().Get(ctx, config)
 	if err != nil {
+		return nil, fmt.Errorf("listing events: %w", err)
+	}
+	if err := contract.verify(); err != nil {
 		return nil, fmt.Errorf("listing events: %w", err)
 	}
 
@@ -101,18 +120,25 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 
 // GetEvent returns a single event from the target mailbox, or the signed-in
 // user's calendar when target is empty. See ListEvents for scope requirements.
-func (c *Client) GetEvent(ctx context.Context, target, eventID string) (*CalendarEvent, error) {
+func (c *Client) GetEvent(ctx context.Context, target, eventID string, preference BodyPreference) (*CalendarEvent, error) {
 	if err := validateID(eventID, "event ID"); err != nil {
 		return nil, err
 	}
-	event, err := c.targetUser(target).Events().ByEventId(eventID).Get(ctx, nil)
+	headers, options, contract, err := newBodyResponseContract(preference)
+	if err != nil {
+		return nil, err
+	}
+	event, err := c.targetUser(target).Events().ByEventId(eventID).Get(ctx, &users.ItemEventsEventItemRequestBuilderGetRequestConfiguration{
+		Headers: headers,
+		Options: options,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("getting event: %w", err)
 	}
-	e := convertEvent(event)
-	if event.GetBody() != nil && event.GetBody().GetContent() != nil {
-		e.Body = *event.GetBody().GetContent()
+	if err := contract.verify(); err != nil {
+		return nil, fmt.Errorf("getting event: %w", err)
 	}
+	e := convertEvent(event)
 	return &e, nil
 }
 
@@ -343,6 +369,14 @@ func convertEvent(e models.Eventable) CalendarEvent {
 	if e.GetBodyPreview() != nil {
 		ev.BodyPreview = *e.GetBodyPreview()
 	}
+	if e.GetBody() != nil {
+		if e.GetBody().GetContent() != nil {
+			ev.Body = *e.GetBody().GetContent()
+		}
+		if e.GetBody().GetContentType() != nil {
+			ev.BodyType = e.GetBody().GetContentType().String()
+		}
+	}
 	if e.GetRecurrence() != nil {
 		ev.Recurrence = formatRecurrence(e.GetRecurrence())
 	}
@@ -500,8 +534,8 @@ func formatDaysOfWeek(days []models.DayOfWeek) string {
 // ListCalendarView returns expanded occurrences (including recurring) in a date range.
 // ListCalendarView is an alias for ListEvents (which already calls the
 // calendarView endpoint and expands recurrences). Kept for caller clarity.
-func (c *Client) ListCalendarView(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
-	return c.ListEvents(ctx, target, startTime, endTime, calendarID, top)
+func (c *Client) ListCalendarView(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32, preference BodyPreference) ([]CalendarEvent, error) {
+	return c.ListEvents(ctx, target, startTime, endTime, calendarID, top, preference)
 }
 
 // MeetingTimeSuggestion represents a suggested meeting time

--- a/internal/graphapi/calendar_body_preference_test.go
+++ b/internal/graphapi/calendar_body_preference_test.go
@@ -1,0 +1,77 @@
+package graphapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListEventsRequestsProviderTextBodies(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("Prefer = %q, want provider text preference", got)
+		}
+		if !strings.Contains(req.URL.Query().Get("$select"), "body") {
+			t.Errorf("$select = %q, want body", req.URL.Query().Get("$select"))
+		}
+		response := graphJSONResponse(req, `{"value":[{
+			"id":"event-one",
+			"subject":"Event",
+			"start":{"dateTime":"2026-08-14T19:00:00","timeZone":"UTC"},
+			"end":{"dateTime":"2026-08-14T20:00:00","timeZone":"UTC"},
+			"body":{"contentType":"text","content":"Complete event body"}
+		}]}`)
+		response.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return response
+	})
+
+	events, err := client.ListEvents(
+		context.Background(), "", time.Now(), time.Now().Add(time.Hour), "", 25, BodyText,
+	)
+	if err != nil {
+		t.Fatalf("ListEvents() error = %v", err)
+	}
+	if len(events) != 1 || events[0].Body != "Complete event body" || events[0].BodyType != "text" {
+		t.Fatalf("ListEvents() events = %#v, want complete provider text body", events)
+	}
+}
+
+func TestGetEventRequestsProviderTextBody(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("Prefer = %q, want provider text preference", got)
+		}
+		response := graphJSONResponse(req, `{
+			"id":"event-one",
+			"body":{"contentType":"text","content":"Complete event body"}
+		}`)
+		response.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return response
+	})
+
+	event, err := client.GetEvent(context.Background(), "", "event-one", BodyText)
+	if err != nil {
+		t.Fatalf("GetEvent() error = %v", err)
+	}
+	if event.Body != "Complete event body" || event.BodyType != "text" {
+		t.Fatalf("GetEvent() body = %q type = %q, want provider text", event.Body, event.BodyType)
+	}
+}
+
+func TestListEventsRejectsMissingProviderAcknowledgement(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		return graphJSONResponse(req, `{"value":[]}`)
+	})
+
+	events, err := client.ListEvents(
+		context.Background(), "", time.Now(), time.Now().Add(time.Hour), "", 25, BodyText,
+	)
+	if err == nil || !strings.Contains(err.Error(), "Preference-Applied") {
+		t.Fatalf("ListEvents() error = %v, want missing acknowledgement rejection", err)
+	}
+	if events != nil {
+		t.Fatalf("ListEvents() events = %#v, want nil", events)
+	}
+}

--- a/internal/graphapi/mail_body_preference.go
+++ b/internal/graphapi/mail_body_preference.go
@@ -13,53 +13,64 @@ const (
 	preferenceAppliedHeader = "Preference-Applied"
 )
 
-// MessageBodyPreference is a typed request for the representation Graph must
-// return for a message body. The zero value preserves Graph's default.
-type MessageBodyPreference string
+// BodyPreference is a typed request for the body representation Graph must
+// return. The zero value preserves Graph's default.
+type BodyPreference string
 
 const (
-	MessageBodyDefault MessageBodyPreference = ""
-	MessageBodyText    MessageBodyPreference = "text"
-	MessageBodyHTML    MessageBodyPreference = "html"
+	BodyDefault BodyPreference = ""
+	BodyText    BodyPreference = "text"
+	BodyHTML    BodyPreference = "html"
+
+	MessageBodyDefault = BodyDefault
+	MessageBodyText    = BodyText
+	MessageBodyHTML    = BodyHTML
 )
 
-// ParseMessageBodyPreference converts a CLI-facing value into the closed set
-// accepted by the Graph request layer.
-func ParseMessageBodyPreference(value string) (MessageBodyPreference, error) {
+// MessageBodyPreference remains as an alias for existing mail callers.
+type MessageBodyPreference = BodyPreference
+
+// ParseBodyPreference converts a CLI-facing value into the closed set accepted
+// by the Graph request layer.
+func ParseBodyPreference(value string) (BodyPreference, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "":
-		return MessageBodyDefault, nil
-	case string(MessageBodyText):
-		return MessageBodyText, nil
-	case string(MessageBodyHTML):
-		return MessageBodyHTML, nil
+		return BodyDefault, nil
+	case string(BodyText):
+		return BodyText, nil
+	case string(BodyHTML):
+		return BodyHTML, nil
 	default:
-		return MessageBodyDefault, fmt.Errorf("invalid body format %q: must be text or html", value)
+		return BodyDefault, fmt.Errorf("invalid body format %q: must be text or html", value)
 	}
 }
 
-func (p MessageBodyPreference) headerValue() (string, error) {
+func ParseMessageBodyPreference(value string) (MessageBodyPreference, error) {
+	return ParseBodyPreference(value)
+}
+
+func (p BodyPreference) headerValue() (string, error) {
 	switch p {
-	case MessageBodyDefault:
+	case BodyDefault:
 		return "", nil
-	case MessageBodyText, MessageBodyHTML:
+	case BodyText, BodyHTML:
 		return fmt.Sprintf("outlook.body-content-type=%q", p), nil
 	default:
 		return "", fmt.Errorf("invalid message body preference %q", p)
 	}
 }
 
-type messageBodyResponseContract struct {
-	preference MessageBodyPreference
+type bodyResponseContract struct {
+	preference BodyPreference
 	inspection *khttp.HeadersInspectionOptions
 }
 
-func newMessageBodyResponseContract(preference MessageBodyPreference) (*abs.RequestHeaders, []abs.RequestOption, *messageBodyResponseContract, error) {
+func newBodyResponseContract(preference BodyPreference) (*abs.RequestHeaders, []abs.RequestOption, *bodyResponseContract, error) {
 	value, err := preference.headerValue()
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if preference == MessageBodyDefault {
+	if preference == BodyDefault {
 		return nil, nil, nil, nil
 	}
 
@@ -67,20 +78,24 @@ func newMessageBodyResponseContract(preference MessageBodyPreference) (*abs.Requ
 	headers.Add(preferHeader, value)
 	inspection := khttp.NewHeadersInspectionOptions()
 	inspection.InspectResponseHeaders = true
-	return headers, []abs.RequestOption{inspection}, &messageBodyResponseContract{
+	return headers, []abs.RequestOption{inspection}, &bodyResponseContract{
 		preference: preference,
 		inspection: inspection,
 	}, nil
 }
 
-func (c *messageBodyResponseContract) verify() error {
+func newMessageBodyResponseContract(preference MessageBodyPreference) (*abs.RequestHeaders, []abs.RequestOption, *bodyResponseContract, error) {
+	return newBodyResponseContract(preference)
+}
+
+func (c *bodyResponseContract) verify() error {
 	if c == nil {
 		return nil
 	}
 	return verifyPreferenceApplied(c.inspection.GetResponseHeaders().Get(preferenceAppliedHeader), c.preference)
 }
 
-func verifyPreferenceApplied(values []string, preference MessageBodyPreference) error {
+func verifyPreferenceApplied(values []string, preference BodyPreference) error {
 	expected, err := preference.headerValue()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Adds opt-in `--body-format text|html` support to calendar events, view, and get.

- Reuses the verified Graph body-preference contract.
- Selects full event bodies only when requested.
- Advertises `calendar.provider-body-format-v1`.
- Leaves default calendar output unchanged.

## Why

Microsoft Graph supports selecting the provider-returned event body representation through `Prefer: outlook.body-content-type`. Exposing that capability lets CLI consumers request text or HTML explicitly without changing existing output defaults.

## Validation

An authenticated read-only calendar request confirmed that Graph honored the requested text representation and returned full bodies without performing calendar writes. No mailbox content or account-specific values are included here.

Checks:

- `go test -race -count=1 ./...`
- `golangci-lint v2.11.4 run ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `go build ./...`

Closes #74