### PR TITLE
feat: add provider parity and calendar controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Works with both **personal Microsoft accounts** and **enterprise (Azure AD / Ent
 - **Calendar view** with expanded recurring event occurrences
 - **Recurring events** displayed with human-readable recurrence patterns
 - **Create events** with location, attendees, all-day, online meeting, and recurrence support
+- **Provider event controls** with retry-safe transaction IDs, reminder disabling, location clearing, and all-day/timed updates
+- **Calendar synchronization metadata** including stable IDs, revisions, lifecycle/series state, attendee responses, and structured recurrence
 - **Update and delete** events
 - **Respond** to invitations (accept, decline, tentative)
 - **List calendars** across your account
@@ -519,12 +521,12 @@ olk mail rules delete <ID> --force                   Delete an inbox rule
 ### Calendar
 
 ```
-olk calendar events [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 25]
-olk calendar view [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 50]
+olk calendar events [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 25] [--body-format text|html]
+olk calendar view [-d 7] [--after DATE] [--before DATE] [--calendar ID] [-n 50] [--body-format text|html]
 olk calendar delta [-d 30] [--after DATE] [--before DATE] [--token TOKEN] [-n N]  Incremental sync of events
-olk calendar get <ID>
-olk calendar create --subject X --start Y --end Z [--calendar ID] [--location L] [--attendees A] [--all-day] [--online-meeting] [-r daily|weekdays|weekly|monthly|yearly]
-olk calendar update <ID> [--subject X] [--start Y] [--end Z] [--location L]
+olk calendar get <ID> [--body-format text|html]
+olk calendar create --subject X --start Y --end Z [--calendar ID] [--location L] [--attendees A] [--all-day] [--online-meeting] [--transaction-id ID] [--no-reminder] [-r daily|weekdays|weekly|monthly|yearly]
+olk calendar update <ID> [--subject X] [--start Y] [--end Z] [--location L|none] [--all-day|--timed] [--no-reminder]
 olk calendar delete <ID> [--force]
 olk calendar respond <ID> accept|decline|tentative
 olk calendar calendars

--- a/SKILL.md
+++ b/SKILL.md
@@ -185,15 +185,15 @@ Focused/other filters use provider order and cannot be combined with
 ## Calendar
 
 ```bash
-olk calendar events [-d DAYS] [--after DATE] [--before DATE] [--calendar ID] [-n 25]   # default: next 7 days
-olk calendar get <ID>
-olk calendar create --subject "Standup" --start 2025-06-15T09:00 --end 2025-06-15T09:30
+olk calendar events [-d DAYS] [--after DATE] [--before DATE] [--calendar ID] [-n 25] [--body-format text|html]   # default: next 7 days
+olk calendar get <ID> [--body-format text|html]
+olk calendar create --subject "Standup" --start 2025-06-15T09:00 --end 2025-06-15T09:30 [--transaction-id ID] [--no-reminder]
 olk calendar create --calendar ID --subject "Appointment" --start 2025-06-15T09:00 --end 2025-06-15T09:30
 olk calendar create --subject "Sync" --start 2025-06-15T10:00 --end 2025-06-15T10:30 --attendees a@b.com --attendees c@d.com
 olk calendar create --subject "Offsite" --start 2025-06-15 --end 2025-06-16 --all-day
 olk calendar create --subject "Call" --start 2025-06-15T14:00 --end 2025-06-15T14:30 --online-meeting   # Teams link
 olk calendar create --subject "Standup" --start 2025-06-15T09:00 --end 2025-06-15T09:15 -r daily        # recurring
-olk calendar update <ID> [--subject X] [--start Y] [--end Z] [--location L]
+olk calendar update <ID> [--subject X] [--start Y] [--end Z] [--location L|none] [--all-day|--timed] [--no-reminder]
 olk calendar delete <ID> --force
 olk calendar respond <ID> accept|decline|tentative
 olk calendar calendars
@@ -203,6 +203,9 @@ olk calendar find-times --attendees a@b.com --attendees c@d.com [-d 60] [--after
 ```
 
 Recurrence options: `daily`, `weekdays` (Mon–Fri), `weekly`, `monthly`, `yearly`.
+
+JSON calendar output also includes provider synchronization metadata, structured
+attendee responses, and lossless recurrence details when Graph returns them.
 
 ## People / Directory
 

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rlrghb/olkcli/internal/graphapi"
 	"github.com/rlrghb/olkcli/internal/outfmt"
 )
 
@@ -23,11 +24,12 @@ type CalendarCmd struct {
 }
 
 type CalendarEventsCmd struct {
-	Days     int    `help:"Number of days to look ahead" default:"7" short:"d"`
-	After    string `help:"Start date (ISO 8601)"`
-	Before   string `help:"End date (ISO 8601)"`
-	Calendar string `help:"Calendar ID"`
-	Top      int32  `help:"Max events to return" default:"25" short:"n"`
+	Days       int     `help:"Number of days to look ahead" default:"7" short:"d"`
+	After      string  `help:"Start date (ISO 8601)"`
+	Before     string  `help:"End date (ISO 8601)"`
+	Calendar   string  `help:"Calendar ID"`
+	Top        int32   `help:"Max events to return" default:"25" short:"n"`
+	BodyFormat *string `help:"Request provider-returned event body representation" enum:"text,html"`
 }
 
 func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
@@ -72,7 +74,15 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	events, err := client.ListEvents(ctx.Ctx, target, start, end, c.Calendar, c.Top)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	events, err := client.ListEvents(ctx.Ctx, target, start, end, c.Calendar, c.Top, preference)
 	if err != nil {
 		return err
 	}
@@ -98,7 +108,8 @@ func (c *CalendarEventsCmd) Run(ctx *RunContext) error {
 }
 
 type CalendarGetCmd struct {
-	ID string `arg:"" help:"Event ID"`
+	ID         string  `arg:"" help:"Event ID"`
+	BodyFormat *string `help:"Request provider-returned event body representation" enum:"text,html"`
 }
 
 func (c *CalendarGetCmd) Run(ctx *RunContext) error {
@@ -112,7 +123,15 @@ func (c *CalendarGetCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	event, err := client.GetEvent(ctx.Ctx, target, c.ID)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	event, err := client.GetEvent(ctx.Ctx, target, c.ID, preference)
 	if err != nil {
 		return err
 	}
@@ -158,6 +177,8 @@ type CalendarCreateCmd struct {
 	AllDay        bool     `help:"All-day event"`
 	OnlineMeeting bool     `help:"Create online meeting"`
 	Recurrence    string   `help:"Recurrence: daily|weekdays|weekly|monthly|yearly" short:"r"`
+	TransactionID string   `help:"Retry-safe provider transaction ID" name:"transaction-id"`
+	NoReminder    bool     `help:"Disable event reminders" name:"no-reminder"`
 }
 
 func (c *CalendarCreateCmd) Run(ctx *RunContext) error {
@@ -187,7 +208,12 @@ func (c *CalendarCreateCmd) Run(ctx *RunContext) error {
 		return nil
 	}
 
-	event, err := client.CreateEvent(ctx.Ctx, c.Calendar, c.Subject, start, end, c.Location, c.Attendees, c.AllDay, c.OnlineMeeting, c.Recurrence)
+	var reminderOn *bool
+	if c.NoReminder {
+		v := false
+		reminderOn = &v
+	}
+	event, err := client.CreateEvent(ctx.Ctx, c.Calendar, c.Subject, start, end, c.Location, c.Attendees, c.AllDay, c.OnlineMeeting, c.Recurrence, c.TransactionID, reminderOn)
 	if err != nil {
 		return err
 	}
@@ -200,11 +226,14 @@ func (c *CalendarCreateCmd) Run(ctx *RunContext) error {
 }
 
 type CalendarUpdateCmd struct {
-	ID       string `arg:"" help:"Event ID"`
-	Subject  string `help:"New subject" short:"s"`
-	Start    string `help:"New start time (ISO 8601)"`
-	End      string `help:"New end time (ISO 8601)"`
-	Location string `help:"New location" short:"l"`
+	ID         string `arg:"" help:"Event ID"`
+	Subject    string `help:"New subject" short:"s"`
+	Start      string `help:"New start time (ISO 8601)"`
+	End        string `help:"New end time (ISO 8601)"`
+	Location   string `help:"New location" short:"l"`
+	AllDay     *bool  `help:"Convert event to an all-day event" name:"all-day"`
+	Timed      *bool  `help:"Convert event to a timed event"`
+	NoReminder bool   `help:"Disable event reminders" name:"no-reminder"`
 }
 
 func (c *CalendarUpdateCmd) Run(ctx *RunContext) error {
@@ -220,7 +249,11 @@ func (c *CalendarUpdateCmd) Run(ctx *RunContext) error {
 		subject = &c.Subject
 	}
 	if c.Location != "" {
-		location = &c.Location
+		value := c.Location
+		if strings.EqualFold(value, "none") {
+			value = ""
+		}
+		location = &value
 	}
 	if c.Start != "" {
 		t, err := parseTime(c.Start)
@@ -237,7 +270,26 @@ func (c *CalendarUpdateCmd) Run(ctx *RunContext) error {
 		end = &t
 	}
 
-	event, err := client.UpdateEvent(ctx.Ctx, c.ID, subject, start, end, location)
+	if c.AllDay != nil && c.Timed != nil {
+		return fmt.Errorf("--all-day and --timed are mutually exclusive")
+	}
+	var allDay *bool
+	if c.AllDay != nil {
+		allDay = c.AllDay
+	}
+	if c.Timed != nil {
+		v := false
+		allDay = &v
+	}
+	if allDay != nil && *allDay && (start == nil || end == nil || start.UTC().Hour() != 0 || start.UTC().Minute() != 0 || start.UTC().Second() != 0 || end.UTC().Hour() != 0 || end.UTC().Minute() != 0 || end.UTC().Second() != 0 || !end.After(*start)) {
+		return fmt.Errorf("all-day updates require --start and --end at midnight")
+	}
+	var reminderOn *bool
+	if c.NoReminder {
+		v := false
+		reminderOn = &v
+	}
+	event, err := client.UpdateEvent(ctx.Ctx, c.ID, subject, start, end, location, allDay, reminderOn)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/calendar_view.go
+++ b/internal/cmd/calendar_view.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rlrghb/olkcli/internal/graphapi"
 	"github.com/rlrghb/olkcli/internal/outfmt"
 )
 
 type CalendarViewCmd struct {
-	Days     int    `help:"Number of days to show" default:"7" short:"d"`
-	After    string `help:"Start date (ISO 8601)"`
-	Before   string `help:"End date (ISO 8601)"`
-	Calendar string `help:"Calendar ID"`
-	Top      int32  `help:"Max events to return" default:"50" short:"n"`
+	Days       int     `help:"Number of days to show" default:"7" short:"d"`
+	After      string  `help:"Start date (ISO 8601)"`
+	Before     string  `help:"End date (ISO 8601)"`
+	Calendar   string  `help:"Calendar ID"`
+	Top        int32   `help:"Max events to return" default:"50" short:"n"`
+	BodyFormat *string `help:"Request provider-returned event body representation" enum:"text,html"`
 }
 
 func (c *CalendarViewCmd) Run(ctx *RunContext) error {
@@ -51,7 +53,15 @@ func (c *CalendarViewCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	events, err := client.ListCalendarView(ctx.Ctx, target, start, end, c.Calendar, c.Top)
+	bodyFormat := ""
+	if c.BodyFormat != nil {
+		bodyFormat = *c.BodyFormat
+	}
+	preference, err := graphapi.ParseBodyPreference(bodyFormat)
+	if err != nil {
+		return err
+	}
+	events, err := client.ListCalendarView(ctx.Ctx, target, start, end, c.Calendar, c.Top, preference)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_list_test.go
+++ b/internal/cmd/mail_list_test.go
@@ -95,7 +95,7 @@ func TestMailListSelectDrivesGraphProjectionAndJSONKeys(t *testing.T) {
 
 func TestMailListPlainSelectUsesOutputProjectionOnly(t *testing.T) {
 	query, output := runMailList(t, "--plain", "--select", "subject,id")
-	if got := query.Get("$select"); got != "id,subject,from,toRecipients,ccRecipients,bccRecipients,replyTo,receivedDateTime,isRead,hasAttachments,bodyPreview,categories,conversationId" {
+	if got := query.Get("$select"); got != "id,subject,from,toRecipients,ccRecipients,bccRecipients,replyTo,receivedDateTime,isRead,hasAttachments,bodyPreview,categories,conversationId,internetMessageId,createdDateTime,lastModifiedDateTime" {
 		t.Errorf("$select = %q, want default mail-list projection", got)
 	}
 	if got, want := output, "Hello\tmessage-id\n"; got != want {

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -15,6 +15,14 @@ type versionInfo struct {
 }
 
 var advertisedCapabilities = []string{
+	"calendar.provider-body-format-v1",
+	"calendar.provider-metadata-v1",
+	"calendar.structured-recurrence-v1",
+	"calendar.structured-attendance-v1",
+	"calendar.retry-safe-create-v1",
+	"calendar.explicit-update-controls-v1",
+	"mail.provider-metadata-v1",
+	"contacts.provider-metadata-v1",
 	"cli.json-error-v1",
 	"mail.folders.well-known-v1",
 	"mail.get.parent-folder-v1",

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -24,6 +24,14 @@ func TestVersionJSONAdvertisesStructuredMailCapabilities(t *testing.T) {
 		t.Fatalf("decoding version JSON: %v\n%s", err, stdout)
 	}
 	if want := []string{
+		"calendar.provider-body-format-v1",
+		"calendar.provider-metadata-v1",
+		"calendar.structured-recurrence-v1",
+		"calendar.structured-attendance-v1",
+		"calendar.retry-safe-create-v1",
+		"calendar.explicit-update-controls-v1",
+		"mail.provider-metadata-v1",
+		"contacts.provider-metadata-v1",
 		"cli.json-error-v1",
 		"mail.folders.well-known-v1",
 		"mail.get.parent-folder-v1",

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -189,9 +189,9 @@ func verifyCalendarBody(events []CalendarEvent, preference BodyPreference) error
 	if preference == BodyDefault {
 		return nil
 	}
-	for _, event := range events {
-		if !strings.EqualFold(event.BodyType, string(preference)) {
-			return fmt.Errorf("provider body type = %q, want %q", event.BodyType, preference)
+	for i := range events {
+		if !strings.EqualFold(events[i].BodyType, string(preference)) {
+			return fmt.Errorf("provider body type = %q, want %q", events[i].BodyType, preference)
 		}
 	}
 	return nil

--- a/internal/graphapi/calendar.go
+++ b/internal/graphapi/calendar.go
@@ -17,20 +17,58 @@ var dayNameTitle = cases.Title(language.English)
 
 // CalendarEvent is a simplified calendar event for output
 type CalendarEvent struct {
-	ID          string   `json:"id"`
-	Subject     string   `json:"subject" untrusted:"true"`
-	Start       string   `json:"start"`
-	End         string   `json:"end"`
-	Location    string   `json:"location" untrusted:"true"`
-	Organizer   string   `json:"organizer" untrusted:"true"`
-	Attendees   []string `json:"attendees,omitempty" untrusted:"true" concise:"omit"`
-	IsAllDay    bool     `json:"isAllDay"`
-	IsOnline    bool     `json:"isOnlineMeeting"`
-	OnlineURL   string   `json:"onlineMeetingUrl,omitempty" untrusted:"true"`
-	Status      string   `json:"showAs"`
-	Recurrence  string   `json:"recurrence,omitempty"`
-	BodyPreview string   `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
-	Body        string   `json:"body,omitempty" untrusted:"true" concise:"omit"`
+	ID                string               `json:"id"`
+	Subject           string               `json:"subject" untrusted:"true"`
+	Start             string               `json:"start"`
+	End               string               `json:"end"`
+	Location          string               `json:"location" untrusted:"true"`
+	Organizer         string               `json:"organizer" untrusted:"true"`
+	Attendees         []string             `json:"attendees,omitempty" untrusted:"true" concise:"omit"`
+	IsAllDay          bool                 `json:"isAllDay"`
+	IsOnline          bool                 `json:"isOnlineMeeting"`
+	OnlineURL         string               `json:"onlineMeetingUrl,omitempty" untrusted:"true"`
+	Status            string               `json:"showAs"`
+	Recurrence        string               `json:"recurrence,omitempty"`
+	BodyPreview       string               `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
+	Body              string               `json:"body,omitempty" untrusted:"true" concise:"omit"`
+	BodyType          string               `json:"bodyType,omitempty"`
+	ICalUID           string               `json:"iCalUId,omitempty"`
+	ChangeKey         string               `json:"changeKey,omitempty"`
+	CreatedAt         string               `json:"createdDateTime,omitempty"`
+	ModifiedAt        string               `json:"lastModifiedDateTime,omitempty"`
+	EventType         string               `json:"type,omitempty"`
+	SeriesMasterID    string               `json:"seriesMasterId,omitempty"`
+	OriginalStart     string               `json:"originalStart,omitempty"`
+	IsCancelled       bool                 `json:"isCancelled"`
+	IsReminderOn      *bool                `json:"isReminderOn,omitempty"`
+	TransactionID     string               `json:"transactionId,omitempty"`
+	AttendeeDetails   []AttendeeDetails    `json:"attendeeDetails,omitempty" concise:"omit"`
+	ResponseStatus    *EventResponseStatus `json:"responseStatus,omitempty" concise:"omit"`
+	RecurrenceDetails *RecurrenceDetails   `json:"recurrenceDetails,omitempty" concise:"omit"`
+}
+
+type AttendeeDetails struct {
+	Name         string `json:"name,omitempty" untrusted:"true"`
+	Address      string `json:"address,omitempty" untrusted:"true"`
+	Type         string `json:"type,omitempty"`
+	Response     string `json:"response,omitempty"`
+	ResponseTime string `json:"responseTime,omitempty"`
+}
+type EventResponseStatus struct {
+	Response string `json:"response,omitempty"`
+	Time     string `json:"time,omitempty"`
+}
+type RecurrenceDetails struct {
+	PatternType         string   `json:"patternType,omitempty"`
+	Interval            int32    `json:"interval,omitempty"`
+	DaysOfWeek          []string `json:"daysOfWeek,omitempty"`
+	DayOfMonth          int32    `json:"dayOfMonth,omitempty"`
+	Month               int32    `json:"month,omitempty"`
+	Index               string   `json:"index,omitempty"`
+	RangeType           string   `json:"rangeType,omitempty"`
+	StartDate           string   `json:"startDate,omitempty"`
+	EndDate             string   `json:"endDate,omitempty"`
+	NumberOfOccurrences int32    `json:"numberOfOccurrences,omitempty"`
 }
 
 // CalendarInfo is a simplified calendar representation
@@ -45,9 +83,13 @@ type CalendarInfo struct {
 // mailbox, or the signed-in user's calendar when target is empty. Targeting
 // another mailbox requires the calling token to carry Calendars.Read.Shared
 // and the calling user to have Exchange Full Access delegation on the target.
-func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
+func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32, preference BodyPreference) ([]CalendarEvent, error) {
 	top = clampTop(top)
 
+	headers, options, contract, err := newBodyResponseContract(preference)
+	if err != nil {
+		return nil, err
+	}
 	startStr := startTime.UTC().Format("2006-01-02T15:04:05")
 	endStr := endTime.UTC().Format("2006-01-02T15:04:05")
 
@@ -55,8 +97,11 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 		StartDateTime: &startStr,
 		EndDateTime:   &endStr,
 		Top:           &top,
-		Select:        []string{"id", "subject", "start", "end", "location", "organizer", "attendees", "isAllDay", "isOnlineMeeting", "onlineMeetingUrl", "showAs", "bodyPreview", "recurrence"},
+		Select:        []string{"id", "subject", "start", "end", "location", "organizer", "attendees", "isAllDay", "isOnlineMeeting", "onlineMeetingUrl", "showAs", "bodyPreview", "recurrence", "iCalUId", "changeKey", "type", "seriesMasterId", "originalStart", "isCancelled", "isReminderOn", "responseStatus", "transactionId"},
 		Orderby:       []string{"start/dateTime"},
+	}
+	if preference != BodyDefault {
+		queryParams.Select = append(queryParams.Select, "body")
 	}
 
 	if calendarID != "" {
@@ -64,6 +109,7 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 			return nil, err
 		}
 		calConfig := &users.ItemCalendarsItemCalendarViewRequestBuilderGetRequestConfiguration{
+			Headers: headers, Options: options,
 			QueryParameters: &users.ItemCalendarsItemCalendarViewRequestBuilderGetQueryParameters{
 				StartDateTime: &startStr,
 				EndDateTime:   &endStr,
@@ -76,14 +122,21 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 		if err != nil {
 			return nil, fmt.Errorf("listing events: %w", err)
 		}
+		if err := contract.verify(); err != nil {
+			return nil, fmt.Errorf("listing events: %w", err)
+		}
 		events := make([]CalendarEvent, 0, len(resp.GetValue()))
 		for _, e := range resp.GetValue() {
 			events = append(events, convertEvent(e))
+		}
+		if err := verifyCalendarBody(events, preference); err != nil {
+			return nil, fmt.Errorf("listing events: %w", err)
 		}
 		return events, nil
 	}
 
 	config := &users.ItemCalendarViewRequestBuilderGetRequestConfiguration{
+		Headers: headers, Options: options,
 		QueryParameters: queryParams,
 	}
 
@@ -91,32 +144,60 @@ func (c *Client) ListEvents(ctx context.Context, target string, startTime, endTi
 	if err != nil {
 		return nil, fmt.Errorf("listing events: %w", err)
 	}
+	if err := contract.verify(); err != nil {
+		return nil, fmt.Errorf("listing events: %w", err)
+	}
 
 	events := make([]CalendarEvent, 0, len(resp.GetValue()))
 	for _, e := range resp.GetValue() {
 		events = append(events, convertEvent(e))
+	}
+	if err := verifyCalendarBody(events, preference); err != nil {
+		return nil, fmt.Errorf("listing events: %w", err)
 	}
 	return events, nil
 }
 
 // GetEvent returns a single event from the target mailbox, or the signed-in
 // user's calendar when target is empty. See ListEvents for scope requirements.
-func (c *Client) GetEvent(ctx context.Context, target, eventID string) (*CalendarEvent, error) {
+func (c *Client) GetEvent(ctx context.Context, target, eventID string, preference BodyPreference) (*CalendarEvent, error) {
 	if err := validateID(eventID, "event ID"); err != nil {
 		return nil, err
 	}
-	event, err := c.targetUser(target).Events().ByEventId(eventID).Get(ctx, nil)
+	headers, options, contract, err := newBodyResponseContract(preference)
 	if err != nil {
+		return nil, err
+	}
+	event, err := c.targetUser(target).Events().ByEventId(eventID).Get(ctx, &users.ItemEventsEventItemRequestBuilderGetRequestConfiguration{Headers: headers, Options: options})
+	if err != nil {
+		return nil, fmt.Errorf("getting event: %w", err)
+	}
+	if err := contract.verify(); err != nil {
 		return nil, fmt.Errorf("getting event: %w", err)
 	}
 	e := convertEvent(event)
 	if event.GetBody() != nil && event.GetBody().GetContent() != nil {
 		e.Body = *event.GetBody().GetContent()
 	}
+	if err := verifyCalendarBody([]CalendarEvent{e}, preference); err != nil {
+		return nil, fmt.Errorf("getting event: %w", err)
+	}
 	return &e, nil
 }
 
-func (c *Client) CreateEvent(ctx context.Context, calendarID, subject string, start, end time.Time, location string, attendees []string, isAllDay, isOnlineMeeting bool, recurrence string) (*CalendarEvent, error) {
+func verifyCalendarBody(events []CalendarEvent, preference BodyPreference) error {
+	if preference == BodyDefault {
+		return nil
+	}
+	for _, event := range events {
+		if !strings.EqualFold(event.BodyType, string(preference)) {
+			return fmt.Errorf("provider body type = %q, want %q", event.BodyType, preference)
+		}
+	}
+	return nil
+}
+
+func (c *Client) CreateEvent(ctx context.Context, calendarID, subject string, start, end time.Time, location string, attendees []string, isAllDay, isOnlineMeeting bool, recurrence, transactionID string, reminderOn *bool) (*CalendarEvent, error) {
 	if err := c.ensureWritable(); err != nil {
 		return nil, err
 	}
@@ -129,6 +210,9 @@ func (c *Client) CreateEvent(ctx context.Context, calendarID, subject string, st
 		if err := validateID(calendarID, "calendar ID"); err != nil {
 			return nil, err
 		}
+	}
+	if err := ValidateTransactionID(transactionID); err != nil {
+		return nil, err
 	}
 	event := models.NewEvent()
 	event.SetSubject(&subject)
@@ -148,6 +232,12 @@ func (c *Client) CreateEvent(ctx context.Context, calendarID, subject string, st
 
 	event.SetIsAllDay(&isAllDay)
 	event.SetIsOnlineMeeting(&isOnlineMeeting)
+	if reminderOn != nil {
+		event.SetIsReminderOn(reminderOn)
+	}
+	if transactionID != "" {
+		event.SetTransactionId(&transactionID)
+	}
 
 	if location != "" {
 		loc := models.NewLocation()
@@ -195,7 +285,7 @@ func (c *Client) CreateEvent(ctx context.Context, calendarID, subject string, st
 	return &e, nil
 }
 
-func (c *Client) UpdateEvent(ctx context.Context, eventID string, subject *string, start, end *time.Time, location *string) (*CalendarEvent, error) {
+func (c *Client) UpdateEvent(ctx context.Context, eventID string, subject *string, start, end *time.Time, location *string, allDay, reminderOn *bool) (*CalendarEvent, error) {
 	if err := c.ensureWritable(); err != nil {
 		return nil, err
 	}
@@ -227,6 +317,12 @@ func (c *Client) UpdateEvent(ctx context.Context, eventID string, subject *strin
 		loc := models.NewLocation()
 		loc.SetDisplayName(location)
 		event.SetLocation(loc)
+	}
+	if allDay != nil {
+		event.SetIsAllDay(allDay)
+	}
+	if reminderOn != nil {
+		event.SetIsReminderOn(reminderOn)
 	}
 
 	updated, err := c.inner.Me().Events().ByEventId(eventID).Patch(ctx, event, nil)
@@ -326,6 +422,32 @@ func convertEvent(e models.Eventable) CalendarEvent {
 			if a.GetEmailAddress() != nil && a.GetEmailAddress().GetAddress() != nil {
 				ev.Attendees = append(ev.Attendees, *a.GetEmailAddress().GetAddress())
 			}
+			d := AttendeeDetails{}
+			if a.GetEmailAddress() != nil {
+				d.Name = derefStr(a.GetEmailAddress().GetName())
+				d.Address = derefStr(a.GetEmailAddress().GetAddress())
+			}
+			if a.GetTypeEscaped() != nil {
+				d.Type = a.GetTypeEscaped().String()
+			}
+			if a.GetStatus() != nil {
+				if a.GetStatus().GetResponse() != nil {
+					d.Response = a.GetStatus().GetResponse().String()
+				}
+				if a.GetStatus().GetTime() != nil {
+					d.ResponseTime = a.GetStatus().GetTime().Format(time.RFC3339)
+				}
+			}
+			ev.AttendeeDetails = append(ev.AttendeeDetails, d)
+		}
+	}
+	if s := e.GetResponseStatus(); s != nil {
+		ev.ResponseStatus = &EventResponseStatus{}
+		if s.GetResponse() != nil {
+			ev.ResponseStatus.Response = s.GetResponse().String()
+		}
+		if s.GetTime() != nil {
+			ev.ResponseStatus.Time = s.GetTime().Format(time.RFC3339)
 		}
 	}
 	if e.GetIsAllDay() != nil {
@@ -343,10 +465,89 @@ func convertEvent(e models.Eventable) CalendarEvent {
 	if e.GetBodyPreview() != nil {
 		ev.BodyPreview = *e.GetBodyPreview()
 	}
+	if e.GetBody() != nil {
+		if e.GetBody().GetContent() != nil {
+			ev.Body = *e.GetBody().GetContent()
+		}
+		if e.GetBody().GetContentType() != nil {
+			ev.BodyType = e.GetBody().GetContentType().String()
+		}
+	}
+	if e.GetICalUId() != nil {
+		ev.ICalUID = *e.GetICalUId()
+	}
+	if e.GetChangeKey() != nil {
+		ev.ChangeKey = *e.GetChangeKey()
+	}
+	if e.GetCreatedDateTime() != nil {
+		ev.CreatedAt = e.GetCreatedDateTime().Format(time.RFC3339)
+	}
+	if e.GetLastModifiedDateTime() != nil {
+		ev.ModifiedAt = e.GetLastModifiedDateTime().Format(time.RFC3339)
+	}
+	if e.GetTypeEscaped() != nil {
+		ev.EventType = e.GetTypeEscaped().String()
+	}
+	if e.GetSeriesMasterId() != nil {
+		ev.SeriesMasterID = *e.GetSeriesMasterId()
+	}
+	if e.GetOriginalStart() != nil {
+		ev.OriginalStart = e.GetOriginalStart().Format(time.RFC3339)
+	}
+	if e.GetIsCancelled() != nil {
+		ev.IsCancelled = *e.GetIsCancelled()
+	}
+	if e.GetIsReminderOn() != nil {
+		v := *e.GetIsReminderOn()
+		ev.IsReminderOn = &v
+	}
+	if e.GetTransactionId() != nil {
+		ev.TransactionID = *e.GetTransactionId()
+	}
 	if e.GetRecurrence() != nil {
 		ev.Recurrence = formatRecurrence(e.GetRecurrence())
+		ev.RecurrenceDetails = convertRecurrenceDetails(e.GetRecurrence())
 	}
 	return ev
+}
+
+func convertRecurrenceDetails(r models.PatternedRecurrenceable) *RecurrenceDetails {
+	d := &RecurrenceDetails{}
+	if p := r.GetPattern(); p != nil {
+		if p.GetTypeEscaped() != nil {
+			d.PatternType = p.GetTypeEscaped().String()
+		}
+		if p.GetInterval() != nil {
+			d.Interval = *p.GetInterval()
+		}
+		for _, day := range p.GetDaysOfWeek() {
+			d.DaysOfWeek = append(d.DaysOfWeek, day.String())
+		}
+		if p.GetDayOfMonth() != nil {
+			d.DayOfMonth = *p.GetDayOfMonth()
+		}
+		if p.GetMonth() != nil {
+			d.Month = *p.GetMonth()
+		}
+		if p.GetIndex() != nil {
+			d.Index = p.GetIndex().String()
+		}
+	}
+	if rr := r.GetRangeEscaped(); rr != nil {
+		if rr.GetTypeEscaped() != nil {
+			d.RangeType = rr.GetTypeEscaped().String()
+		}
+		if rr.GetStartDate() != nil {
+			d.StartDate = rr.GetStartDate().String()
+		}
+		if rr.GetEndDate() != nil {
+			d.EndDate = rr.GetEndDate().String()
+		}
+		if rr.GetNumberOfOccurrences() != nil {
+			d.NumberOfOccurrences = *rr.GetNumberOfOccurrences()
+		}
+	}
+	return d
 }
 
 // buildRecurrence creates a PatternedRecurrence from a simple recurrence string.
@@ -500,8 +701,8 @@ func formatDaysOfWeek(days []models.DayOfWeek) string {
 // ListCalendarView returns expanded occurrences (including recurring) in a date range.
 // ListCalendarView is an alias for ListEvents (which already calls the
 // calendarView endpoint and expands recurrences). Kept for caller clarity.
-func (c *Client) ListCalendarView(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32) ([]CalendarEvent, error) {
-	return c.ListEvents(ctx, target, startTime, endTime, calendarID, top)
+func (c *Client) ListCalendarView(ctx context.Context, target string, startTime, endTime time.Time, calendarID string, top int32, preference BodyPreference) ([]CalendarEvent, error) {
+	return c.ListEvents(ctx, target, startTime, endTime, calendarID, top, preference)
 }
 
 // MeetingTimeSuggestion represents a suggested meeting time

--- a/internal/graphapi/client_guards_test.go
+++ b/internal/graphapi/client_guards_test.go
@@ -29,7 +29,7 @@ func TestNoWriteGuardBlocksMutations(t *testing.T) {
 		{"CreateMailFolder", func() error { _, err := c.CreateMailFolder(ctx, "n"); return err }},
 		{"CreateUploadSession", func() error { _, err := c.CreateUploadSession(ctx, "d", "p", false); return err }},
 		{"CreateEvent", func() error {
-			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "")
+			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "", "", nil)
 			return err
 		}},
 		{"SendMessage", func() error { return c.SendMessage(ctx, "s", "b", nil, nil, nil, false, nil, "", false) }},
@@ -55,7 +55,7 @@ func TestNoSendGuardBlocksSends(t *testing.T) {
 		{"SendDraft", func() error { return c.SendDraft(ctx, "id") }},
 		{"RespondToEvent", func() error { return c.RespondToEvent(ctx, "id", "accept") }},
 		{"CreateEvent w/ attendees", func() error {
-			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "")
+			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "", "", nil)
 			return err
 		}},
 	}

--- a/internal/graphapi/contacts.go
+++ b/internal/graphapi/contacts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
@@ -26,7 +27,7 @@ var contactSelectFields = []string{
 	"emailAddresses", "businessPhones", "homePhones", "mobilePhone", "imAddresses",
 	"companyName", "jobTitle", "department", "officeLocation", "profession", "manager", "assistantName",
 	"birthday", "personalNotes", "spouseName", "children", "categories",
-	"businessHomePage", "businessAddress", "homeAddress", "otherAddress",
+	"businessHomePage", "businessAddress", "homeAddress", "otherAddress", "createdDateTime", "lastModifiedDateTime", "changeKey",
 }
 
 // buildEmailAddresses validates and converts a slice of email strings to Graph EmailAddressable objects.
@@ -84,6 +85,9 @@ type Contact struct {
 	BusinessAddress  *Address `json:"businessAddress,omitempty" concise:"omit"`
 	HomeAddress      *Address `json:"homeAddress,omitempty" concise:"omit"`
 	OtherAddress     *Address `json:"otherAddress,omitempty" concise:"omit"`
+	CreatedAt        string   `json:"createdDateTime,omitempty"`
+	ModifiedAt       string   `json:"lastModifiedDateTime,omitempty"`
+	ChangeKey        string   `json:"changeKey,omitempty"`
 }
 
 // ListContacts returns contacts from the target mailbox, or the signed-in
@@ -600,6 +604,15 @@ func convertContact(ct models.Contactable) Contact {
 	contact := Contact{}
 	if ct.GetId() != nil {
 		contact.ID = *ct.GetId()
+	}
+	if ct.GetCreatedDateTime() != nil {
+		contact.CreatedAt = ct.GetCreatedDateTime().Format(time.RFC3339)
+	}
+	if ct.GetLastModifiedDateTime() != nil {
+		contact.ModifiedAt = ct.GetLastModifiedDateTime().Format(time.RFC3339)
+	}
+	if ct.GetChangeKey() != nil {
+		contact.ChangeKey = *ct.GetChangeKey()
 	}
 	if ct.GetDisplayName() != nil {
 		contact.DisplayName = *ct.GetDisplayName()

--- a/internal/graphapi/delta.go
+++ b/internal/graphapi/delta.go
@@ -99,7 +99,10 @@ func (c *Client) DeltaMessages(ctx context.Context, target, folderID, token stri
 	var resp users.ItemMailFoldersItemMessagesDeltaGetResponseable
 	var err error
 	if token == "" {
-		cfg := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{Headers: maxPageSizeHeaders(top)}
+		cfg := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{
+			Headers:         maxPageSizeHeaders(top),
+			QueryParameters: &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetQueryParameters{Select: []string{"id", "subject", "changeKey", "internetMessageId", "createdDateTime", "lastModifiedDateTime"}},
+		}
 		resp, err = c.targetUser(target).MailFolders().ByMailFolderId(folderID).Messages().Delta().GetAsDeltaGetResponse(ctx, cfg)
 	} else {
 		if err := validateGraphContinuation(token, mailMessagesDeltaScope(target, folderID)); err != nil {
@@ -127,7 +130,7 @@ func (c *Client) DeltaCalendarView(ctx context.Context, target, token string, st
 	if token == "" {
 		s := start.UTC().Format(time.RFC3339)
 		e := end.UTC().Format(time.RFC3339)
-		qp := &users.ItemCalendarViewDeltaRequestBuilderGetQueryParameters{StartDateTime: &s, EndDateTime: &e}
+		qp := &users.ItemCalendarViewDeltaRequestBuilderGetQueryParameters{StartDateTime: &s, EndDateTime: &e, Select: []string{"id", "subject", "changeKey", "iCalUId", "type", "seriesMasterId", "originalStart", "isCancelled", "recurrence", "attendees", "responseStatus"}}
 		cfg := &users.ItemCalendarViewDeltaRequestBuilderGetRequestConfiguration{QueryParameters: qp, Headers: maxPageSizeHeaders(top)}
 		resp, err = c.targetUser(target).CalendarView().Delta().GetAsDeltaGetResponse(ctx, cfg)
 	} else {
@@ -153,7 +156,10 @@ func (c *Client) DeltaContacts(ctx context.Context, target, token string, top in
 	var resp users.ItemContactsDeltaGetResponseable
 	var err error
 	if token == "" {
-		cfg := &users.ItemContactsDeltaRequestBuilderGetRequestConfiguration{Headers: maxPageSizeHeaders(top)}
+		cfg := &users.ItemContactsDeltaRequestBuilderGetRequestConfiguration{
+			Headers:         maxPageSizeHeaders(top),
+			QueryParameters: &users.ItemContactsDeltaRequestBuilderGetQueryParameters{Select: contactSelectFields},
+		}
 		resp, err = c.targetUser(target).Contacts().Delta().GetAsDeltaGetResponse(ctx, cfg)
 	} else {
 		if err := validateGraphContinuation(token, contactsDeltaScope(target)); err != nil {

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
@@ -49,24 +50,27 @@ var allowedSelectFields = map[string]bool{
 
 // MailMessage is a simplified mail message for output
 type MailMessage struct {
-	ID             string            `json:"id"`
-	ParentFolderID string            `json:"parentFolderId,omitempty"`
-	ChangeKey      string            `json:"changeKey,omitempty"`
-	Subject        string            `json:"subject" untrusted:"true"`
-	From           string            `json:"from" untrusted:"true"`
-	To             []string          `json:"to" untrusted:"true"`
-	Cc             []string          `json:"cc" untrusted:"true"`
-	Bcc            []string          `json:"bcc" untrusted:"true"`
-	ReplyTo        []string          `json:"replyTo" untrusted:"true"`
-	ReceivedAt     string            `json:"receivedDateTime"`
-	IsRead         bool              `json:"isRead"`
-	HasAttachments bool              `json:"hasAttachments"`
-	BodyPreview    string            `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
-	Body           string            `json:"body,omitempty" untrusted:"true" concise:"omit"`
-	BodyType       string            `json:"bodyType,omitempty"`
-	Categories     []string          `json:"categories,omitempty"`
-	ConversationID string            `json:"conversationId,omitempty"`
-	Flag           *MailFollowupFlag `json:"flag,omitempty"`
+	ID                string            `json:"id"`
+	ParentFolderID    string            `json:"parentFolderId,omitempty"`
+	ChangeKey         string            `json:"changeKey,omitempty"`
+	Subject           string            `json:"subject" untrusted:"true"`
+	From              string            `json:"from" untrusted:"true"`
+	To                []string          `json:"to" untrusted:"true"`
+	Cc                []string          `json:"cc" untrusted:"true"`
+	Bcc               []string          `json:"bcc" untrusted:"true"`
+	ReplyTo           []string          `json:"replyTo" untrusted:"true"`
+	ReceivedAt        string            `json:"receivedDateTime"`
+	IsRead            bool              `json:"isRead"`
+	HasAttachments    bool              `json:"hasAttachments"`
+	BodyPreview       string            `json:"bodyPreview,omitempty" untrusted:"true" concise:"omit"`
+	Body              string            `json:"body,omitempty" untrusted:"true" concise:"omit"`
+	BodyType          string            `json:"bodyType,omitempty"`
+	Categories        []string          `json:"categories,omitempty"`
+	ConversationID    string            `json:"conversationId,omitempty"`
+	Flag              *MailFollowupFlag `json:"flag,omitempty"`
+	InternetMessageID string            `json:"internetMessageId,omitempty"`
+	CreatedAt         string            `json:"createdDateTime,omitempty"`
+	ModifiedAt        string            `json:"lastModifiedDateTime,omitempty"`
 }
 
 // MailFollowupFlag is the stable output shape for a provider follow-up flag.
@@ -79,7 +83,7 @@ type MailFollowupFlag struct {
 var messageDetailSelect = []string{
 	"id", "subject", "from", "toRecipients", "ccRecipients", "bccRecipients",
 	"receivedDateTime", "isRead", "hasAttachments", "body", "bodyPreview", "conversationId",
-	"parentFolderId", "changeKey", "flag",
+	"parentFolderId", "changeKey", "flag", "internetMessageId", "createdDateTime", "lastModifiedDateTime",
 }
 
 // MailFolder is a simplified folder representation
@@ -172,6 +176,7 @@ func (c *Client) ListMessages(ctx context.Context, target string, opts *ListMess
 			"id", "subject", "from", "toRecipients", "ccRecipients",
 			"bccRecipients", "replyTo", "receivedDateTime", "isRead",
 			"hasAttachments", "bodyPreview", "categories", "conversationId",
+			"internetMessageId", "createdDateTime", "lastModifiedDateTime",
 		}
 	}
 
@@ -777,6 +782,15 @@ func convertMessage(msg models.Messageable) MailMessage {
 	}
 	if msg.GetChangeKey() != nil {
 		m.ChangeKey = *msg.GetChangeKey()
+	}
+	if msg.GetInternetMessageId() != nil {
+		m.InternetMessageID = *msg.GetInternetMessageId()
+	}
+	if msg.GetCreatedDateTime() != nil {
+		m.CreatedAt = msg.GetCreatedDateTime().Format(time.RFC3339)
+	}
+	if msg.GetLastModifiedDateTime() != nil {
+		m.ModifiedAt = msg.GetLastModifiedDateTime().Format(time.RFC3339)
 	}
 	if msg.GetSubject() != nil {
 		m.Subject = *msg.GetSubject()

--- a/internal/graphapi/mail_body_preference.go
+++ b/internal/graphapi/mail_body_preference.go
@@ -13,6 +13,19 @@ const (
 	preferenceAppliedHeader = "Preference-Applied"
 )
 
+// BodyPreference is shared by mail and calendar body requests.
+type BodyPreference = MessageBodyPreference
+
+const (
+	BodyDefault = MessageBodyDefault
+	BodyText    = MessageBodyText
+	BodyHTML    = MessageBodyHTML
+)
+
+func ParseBodyPreference(value string) (BodyPreference, error) {
+	return ParseMessageBodyPreference(value)
+}
+
 // MessageBodyPreference is a typed request for the representation Graph must
 // return for a message body. The zero value preserves Graph's default.
 type MessageBodyPreference string
@@ -71,6 +84,10 @@ func newMessageBodyResponseContract(preference MessageBodyPreference) (*abs.Requ
 		preference: preference,
 		inspection: inspection,
 	}, nil
+}
+
+func newBodyResponseContract(preference BodyPreference) (*abs.RequestHeaders, []abs.RequestOption, *messageBodyResponseContract, error) {
+	return newMessageBodyResponseContract(preference)
 }
 
 func (c *messageBodyResponseContract) verify() error {

--- a/internal/graphapi/provider_metadata_test.go
+++ b/internal/graphapi/provider_metadata_test.go
@@ -1,0 +1,84 @@
+package graphapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListEventsPreservesProviderMetadataAndStructuredCalendarState(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		selectFields := req.URL.Query().Get("$select")
+		for _, field := range []string{"iCalUId", "changeKey", "type", "seriesMasterId", "originalStart", "isCancelled", "responseStatus", "body"} {
+			if !strings.Contains(selectFields, field) {
+				t.Errorf("$select = %q, missing %q", selectFields, field)
+			}
+		}
+		if got := req.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
+			t.Errorf("Prefer = %q, want text body preference", got)
+		}
+		resp := graphJSONResponse(req, `{"value":[{
+			"id":"event-1","subject":"Planning","iCalUId":"ical-1","changeKey":"key-2",
+			"type":"exception","seriesMasterId":"master-1","originalStart":"2026-08-18T09:00:00Z",
+			"isCancelled":false,"body":{"contentType":"text","content":"Agenda"},
+			"attendees":[{"emailAddress":{"name":"Alex","address":"alex@example.com"},"type":"optional","status":{"response":"accepted","time":"2026-08-17T12:00:00Z"}}],
+			"responseStatus":{"response":"tentativelyAccepted","time":"2026-08-17T12:00:00Z"},
+			"recurrence":{"pattern":{"type":"weekly","interval":1,"daysOfWeek":["monday"]},"range":{"type":"endDate","startDate":"2026-08-18","endDate":"2026-09-01"}}
+		}]}`)
+		resp.Header.Set("Preference-Applied", `outlook.body-content-type="text"`)
+		return resp
+	})
+
+	events, err := client.ListEvents(context.Background(), "", time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC), time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC), "", 25, BodyText)
+	if err != nil {
+		t.Fatalf("ListEvents() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.ICalUID != "ical-1" || event.ChangeKey != "key-2" || event.EventType != "exception" || event.SeriesMasterID != "master-1" {
+		t.Fatalf("provider metadata = %#v", event)
+	}
+	if event.Body != "Agenda" || event.BodyType != "text" || len(event.AttendeeDetails) != 1 || event.ResponseStatus == nil || event.RecurrenceDetails == nil {
+		t.Fatalf("structured event state = %#v", event)
+	}
+	if event.AttendeeDetails[0].Response != "accepted" || event.RecurrenceDetails.PatternType != "weekly" || event.RecurrenceDetails.RangeType != "endDate" {
+		t.Fatalf("structured event details = %#v", event)
+	}
+}
+
+func TestListMessagesAndContactsPreserveProviderMetadata(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		if strings.HasSuffix(req.URL.Path, "/messages") {
+			selectFields := req.URL.Query().Get("$select")
+			for _, field := range []string{"internetMessageId", "createdDateTime", "lastModifiedDateTime"} {
+				if !strings.Contains(selectFields, field) {
+					t.Errorf("message $select = %q, missing %q", selectFields, field)
+				}
+			}
+			return graphJSONResponse(req, `{"value":[{"id":"message-1","internetMessageId":"<message@example.com>","createdDateTime":"2026-08-17T10:00:00Z","lastModifiedDateTime":"2026-08-17T10:01:00Z"}]}`)
+		}
+		if strings.HasSuffix(req.URL.Path, "/contacts") {
+			return graphJSONResponse(req, `{"value":[{"id":"contact-1","displayName":"Alex","createdDateTime":"2026-08-17T10:00:00Z","lastModifiedDateTime":"2026-08-17T10:01:00Z","changeKey":"contact-key"}]}`)
+		}
+		t.Fatalf("unexpected request path %q", req.URL.Path)
+		return nil
+	})
+
+	messages, err := client.ListMessages(context.Background(), "", &ListMessagesOptions{Top: 1})
+	if err != nil || len(messages) != 1 || messages[0].InternetMessageID != "<message@example.com>" || messages[0].CreatedAt == "" || messages[0].ModifiedAt == "" {
+		t.Fatalf("messages = %#v, error = %v", messages, err)
+	}
+	contacts, err := client.ListContacts(context.Background(), "", 1, 0, "")
+	if err != nil || len(contacts) != 1 || contacts[0].ChangeKey != "contact-key" || contacts[0].CreatedAt == "" || contacts[0].ModifiedAt == "" {
+		t.Fatalf("contacts = %#v, error = %v", contacts, err)
+	}
+	if requests != 2 {
+		t.Fatalf("request count = %d, want 2", requests)
+	}
+}

--- a/internal/graphapi/validate.go
+++ b/internal/graphapi/validate.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
@@ -101,6 +102,21 @@ const maxContactNotesLen = 32000
 func ValidateContactFieldLen(value, label string, limit int) error {
 	if len(value) > limit {
 		return fmt.Errorf("%s too long: %d characters (max %d)", label, len(value), limit)
+	}
+	return nil
+}
+
+// ValidateTransactionID bounds the caller-supplied Graph idempotency key and
+// rejects control characters that could corrupt logs or diagnostics.
+func ValidateTransactionID(value string) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > 255 {
+		return fmt.Errorf("transaction ID too long: %d characters (max 255)", len(value))
+	}
+	if strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return fmt.Errorf("transaction ID contains control characters")
 	}
 	return nil
 }

--- a/internal/graphapi/validate_test.go
+++ b/internal/graphapi/validate_test.go
@@ -153,6 +153,18 @@ func TestValidateContactFieldLen(t *testing.T) {
 	}
 }
 
+func TestValidateTransactionID(t *testing.T) {
+	if err := ValidateTransactionID("retry-2026-08-17"); err != nil {
+		t.Fatalf("valid transaction ID rejected: %v", err)
+	}
+	if err := ValidateTransactionID(strings.Repeat("x", 256)); err == nil {
+		t.Fatal("overlong transaction ID accepted")
+	}
+	if err := ValidateTransactionID("retry\nkey"); err == nil {
+		t.Fatal("transaction ID with control character accepted")
+	}
+}
+
 func TestClampTop(t *testing.T) {
 	cases := []struct {
 		in, want int32


### PR DESCRIPTION
## Summary

- Add calendar provider body-format requests with response verification.
- Add calendar synchronization metadata, structured recurrence, attendee responses, lifecycle fields, and explicit update controls.
- Add retry-safe event creation and reminder/location/all-day controls.
- Expose mail and contact provider metadata across list/get/delta paths.
- Update README and SKILL.md command documentation and capability advertisements.
- Add provider metadata fixture tests and transaction-ID validation.

## Security and privacy

- Transaction IDs reject control characters and are bounded to 255 characters.
- All-day validation checks the UTC representation sent to Graph.
- Calendar body responses verify both Graph acknowledgement and returned body type.
- Existing no-write/no-send guards, output sanitization, and untrusted-content wrapping remain enforced.

## Validation

- `go test -race -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `git diff --check`
- Live read-only smoke test against configured Outlook.com consumer account

`make lint` remains blocked by the repository's existing `goconst` baseline findings.
