### PR TITLE
feat(mail): send and draft as a delegated shared mailbox

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -341,6 +341,11 @@ olk mail folders --mailbox boss@example.com
 olk mail send --mailbox team@example.com --to person@example.com --subject "..." --body "..."
 olk mail send --mailbox team@example.com --to person@example.com --subject "..." --dry-run   # shows the sending address
 
+# Leave a draft in a shared mailbox for a human to send (needs Mail.ReadWrite.Shared
+# and Full Access, but NOT Send As) — the lower-privilege alternative
+olk mail drafts create --mailbox team@example.com --to person@example.com --subject "..." --body "..."
+olk mail drafts list --mailbox team@example.com
+
 # Calendar (also: view, get, calendars)
 olk calendar events --mailbox boss@example.com
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -318,7 +318,14 @@ olk whoami    # name, email, job title, department, office, phone
 
 ## Delegated Mailbox Access (executive-assistant pattern)
 
-Use when the signed-in account needs to read another user's mailbox under Microsoft 365 mailbox delegation. The signed-in identity is your own (or a service account), Exchange ACLs control which mailboxes you can reach, and the OAuth scope controls what you can do inside them. **Read-only** for now — sending mail or modifying anything in a delegated mailbox is not supported.
+Use when the signed-in account needs to reach another user's mailbox under Microsoft 365 mailbox delegation. The signed-in identity is your own (or a service account), Exchange ACLs control which mailboxes you can reach, and the OAuth scope controls what you can do inside them.
+
+Reads are the common case. **Sending as a shared mailbox is supported**, and needs two grants that are separate from each other and from read access:
+
+- the `Mail.Send.Shared` scope on the token — `olk auth login --scope Mail.Send.Shared`; and
+- **Send As** or **Send on Behalf Of** on the mailbox in Exchange, which is a different delegation from the Full Access that lets you read it.
+
+Holding one tells you nothing about the other, and `Full Access` grants neither. Without both, `mail send --mailbox` fails with `Access is denied` and names what is missing. Everything else in a delegated mailbox remains read-only.
 
 ```bash
 # One-time login with shared scopes
@@ -329,6 +336,10 @@ olk mail list --mailbox boss@example.com
 olk mail get <ID> --mailbox boss@example.com
 olk mail search "from:partner@example.com" --mailbox boss@example.com
 olk mail folders --mailbox boss@example.com
+
+# Send as a shared mailbox (needs Mail.Send.Shared + Send As in Exchange)
+olk mail send --mailbox team@example.com --to person@example.com --subject "..." --body "..."
+olk mail send --mailbox team@example.com --to person@example.com --subject "..." --dry-run   # shows the sending address
 
 # Calendar (also: view, get, calendars)
 olk calendar events --mailbox boss@example.com

--- a/SKILL.md
+++ b/SKILL.md
@@ -325,7 +325,9 @@ Reads are the common case. **Sending as a shared mailbox is supported**, and nee
 - the `Mail.Send.Shared` scope on the token — `olk auth login --scope Mail.Send.Shared`; and
 - **Send As** or **Send on Behalf Of** on the mailbox in Exchange, which is a different delegation from the Full Access that lets you read it.
 
-Holding one tells you nothing about the other, and `Full Access` grants neither. Without both, `mail send --mailbox` fails with `Access is denied` and names what is missing. Everything else in a delegated mailbox remains read-only.
+Holding one tells you nothing about the other, and `Full Access` grants neither. Without both, `mail send --mailbox` fails with `Access is denied` and names what is missing.
+
+Sending and the draft commands are the writes that honour `--mailbox`. Everything else ignores it and acts on your own mailbox — including `mail reply` and `mail forward`, which will fail to find a message ID belonging to a shared mailbox, since IDs are scoped to the mailbox they were listed from.
 
 ```bash
 # One-time login with shared scopes

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -40,7 +40,14 @@ olk --account person@example.com mail list
 ```
 
 Delegated mailbox reads use `--mailbox EMAIL` and require the matching `.Shared`
-scope plus Exchange delegation. Writes remain scoped to the signed-in user.
+scope plus Exchange delegation.
+
+`mail send --mailbox EMAIL` sends *as* that mailbox, which needs `Mail.Send.Shared`
+on the token **and** Send As or Send on Behalf Of on the mailbox in Exchange —
+a separate delegation from the Full Access that permits reading it. Being able to
+read a shared mailbox therefore does not imply being able to send from it. Confirm
+the sending address with `--dry-run`, which prints the mailbox a send will leave
+from. Other writes remain scoped to the signed-in user.
 
 ## macOS Keychain
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -47,7 +47,17 @@ on the token **and** Send As or Send on Behalf Of on the mailbox in Exchange —
 a separate delegation from the Full Access that permits reading it. Being able to
 read a shared mailbox therefore does not imply being able to send from it. Confirm
 the sending address with `--dry-run`, which prints the mailbox a send will leave
-from. Other writes remain scoped to the signed-in user.
+from.
+
+The draft commands honour `--mailbox` too, and are the lower-privilege path:
+leaving a draft in a shared mailbox needs `Mail.ReadWrite.Shared` and Full
+Access, but not Send As. Sending that draft afterwards does need Send As, since
+creating a draft somewhere confers no right to send it.
+
+Every other command ignores `--mailbox` and acts on the signed-in user's own
+mailbox. That includes `mail reply` and `mail forward`, which will fail to find a
+message ID belonging to a shared mailbox, because IDs are scoped to the mailbox
+they were listed from.
 
 ## macOS Keychain
 

--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -29,7 +29,12 @@ func (c *MailDraftsListCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	drafts, err := client.ListDrafts(ctx.Ctx, c.Top)
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
+	drafts, err := client.ListDrafts(ctx.Ctx, target, c.Top)
 	if err != nil {
 		return err
 	}
@@ -69,6 +74,11 @@ func (c *MailDraftsCreateCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
 	body := c.Body
 	// Read from stdin if no body provided
 	if body == "" {
@@ -93,17 +103,17 @@ func (c *MailDraftsCreateCmd) Run(ctx *RunContext) error {
 	}
 
 	if ctx.Flags.DryRun {
-		fmt.Printf("Would create draft:\n  To: %s\n  Subject: %s\n  Body: %s\n",
-			strings.Join(c.To, ", "), outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
+		fmt.Printf("Would create draft:\n  In: %s\n  To: %s\n  Subject: %s\n  Body: %s\n",
+			describeMailbox(target), strings.Join(c.To, ", "), outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
 		return nil
 	}
 
-	draft, err := client.CreateDraft(ctx.Ctx, c.Subject, body, c.To, c.CC, c.BCC, c.HTML)
+	draft, err := client.CreateDraft(ctx.Ctx, target, c.Subject, body, c.To, c.CC, c.BCC, c.HTML)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Draft created: %s (ID: %s)\n", outfmt.Sanitize(draft.Subject), outfmt.Sanitize(draft.ID))
+	fmt.Printf("Draft created in %s: %s (ID: %s)\n", describeMailbox(target), outfmt.Sanitize(draft.Subject), outfmt.Sanitize(draft.ID))
 	return nil
 }
 
@@ -118,12 +128,17 @@ func (c *MailDraftsSendCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
 	if ctx.Flags.DryRun {
-		fmt.Printf("Would send draft %s\n", outfmt.Sanitize(c.ID))
+		fmt.Printf("Would send draft %s from %s\n", outfmt.Sanitize(c.ID), describeMailbox(target))
 		return nil
 	}
 
-	err = client.SendDraft(ctx.Ctx, c.ID)
+	err = client.SendDraft(ctx.Ctx, target, c.ID)
 	if err != nil {
 		return err
 	}
@@ -143,20 +158,35 @@ func (c *MailDraftsDeleteCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
 	if !ctx.Flags.Force {
 		return fmt.Errorf("delete draft %s: use --force to confirm deletion", outfmt.Sanitize(c.ID))
 	}
 
 	if ctx.Flags.DryRun {
-		fmt.Printf("Would delete draft %s\n", outfmt.Sanitize(c.ID))
+		fmt.Printf("Would delete draft %s from %s\n", outfmt.Sanitize(c.ID), describeMailbox(target))
 		return nil
 	}
 
-	err = client.DeleteDraft(ctx.Ctx, c.ID)
+	err = client.DeleteDraft(ctx.Ctx, target, c.ID)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Draft deleted.")
 	return nil
+}
+
+// describeMailbox names the mailbox an operation acts on, so that output and dry
+// runs distinguish your own Drafts folder from a shared one. A draft left in the
+// wrong mailbox is invisible to the person waiting for it.
+func describeMailbox(target string) string {
+	if target == "" {
+		return "your own mailbox"
+	}
+	return target
 }

--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -186,7 +186,7 @@ func (c *MailDraftsDeleteCmd) Run(ctx *RunContext) error {
 // wrong mailbox is invisible to the person waiting for it.
 func describeMailbox(target string) string {
 	if target == "" {
-		return "your own mailbox"
+		return ownMailboxLabel
 	}
 	return target
 }

--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -143,7 +143,7 @@ func (c *MailDraftsSendCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	fmt.Println("Draft sent.")
+	fmt.Printf("Draft sent from %s.\n", describeMailbox(target))
 	return nil
 }
 
@@ -177,7 +177,7 @@ func (c *MailDraftsDeleteCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	fmt.Println("Draft deleted.")
+	fmt.Printf("Draft deleted from %s.\n", describeMailbox(target))
 	return nil
 }
 

--- a/internal/cmd/mail_drafts_target_test.go
+++ b/internal/cmd/mail_drafts_target_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "testing"
+
+// A draft left in the wrong mailbox is invisible to the person waiting for it,
+// so both the dry run and the success line name the mailbox explicitly.
+func TestDescribeMailbox_EmptyTargetNamesOwnMailbox(t *testing.T) {
+	if got := describeMailbox(""); got != "your own mailbox" {
+		t.Fatalf("describeMailbox(%q) = %q", "", got)
+	}
+}
+
+func TestDescribeMailbox_SharedTargetIsNamedVerbatim(t *testing.T) {
+	if got := describeMailbox("expenses@example.com"); got != "expenses@example.com" {
+		t.Fatalf("describeMailbox() = %q, want the shared address", got)
+	}
+}

--- a/internal/cmd/mail_drafts_target_test.go
+++ b/internal/cmd/mail_drafts_target_test.go
@@ -5,7 +5,7 @@ import "testing"
 // A draft left in the wrong mailbox is invisible to the person waiting for it,
 // so both the dry run and the success line name the mailbox explicitly.
 func TestDescribeMailbox_EmptyTargetNamesOwnMailbox(t *testing.T) {
-	if got := describeMailbox(""); got != "your own mailbox" {
+	if got := describeMailbox(""); got != ownMailboxLabel {
 		t.Fatalf("describeMailbox(%q) = %q", "", got)
 	}
 }

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -133,7 +133,7 @@ func (c *MailSendCmd) Run(ctx *RunContext) error {
 // wrong is silent otherwise: the message simply arrives from the wrong address.
 func describeSender(target string) string {
 	if target == "" {
-		return "your own mailbox"
+		return ownMailboxLabel
 	}
 	return target
 }

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -37,6 +37,11 @@ func (c *MailSendCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+
 	body := c.Body
 	// Read from stdin if no body provided
 	if body == "" {
@@ -93,18 +98,42 @@ func (c *MailSendCmd) Run(ctx *RunContext) error {
 	}
 
 	if ctx.Flags.DryRun {
-		fmt.Printf("Would send email:\n  To: %s\n  Subject: %s\n  Body: %s\n", strings.Join(c.To, ", "), outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
+		fmt.Printf("Would send email:\n  From: %s\n  To: %s\n  Subject: %s\n  Body: %s\n", describeSender(target), strings.Join(c.To, ", "), outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
 		if len(attachments) > 0 {
 			fmt.Printf("  Attachments: %d file(s)\n", len(attachments))
 		}
 		return nil
 	}
 
-	err = client.SendMessage(ctx.Ctx, c.Subject, body, c.To, c.CC, c.BCC, c.HTML, attachments, c.Importance, c.ReadReceipt)
+	err = client.SendMessage(ctx.Ctx, target, &graphapi.SendMessageOptions{
+		Subject:     c.Subject,
+		Body:        body,
+		To:          c.To,
+		CC:          c.CC,
+		BCC:         c.BCC,
+		IsHTML:      c.HTML,
+		Attachments: attachments,
+		Importance:  c.Importance,
+		ReadReceipt: c.ReadReceipt,
+	})
 	if err != nil {
 		return err
 	}
 
+	if target != "" {
+		fmt.Printf("Message sent from %s.\n", target)
+		return nil
+	}
 	fmt.Println("Message sent.")
 	return nil
+}
+
+// describeSender names the mailbox a send will leave from, so that a dry run
+// shows the sending identity rather than only the recipients. Getting this
+// wrong is silent otherwise: the message simply arrives from the wrong address.
+func describeSender(target string) string {
+	if target == "" {
+		return "your own mailbox"
+	}
+	return target
 }

--- a/internal/cmd/mail_send_sender_test.go
+++ b/internal/cmd/mail_send_sender_test.go
@@ -6,8 +6,8 @@ import "testing"
 // that goes from the wrong mailbox reports success and is only discovered by the
 // recipient.
 func TestDescribeSender_EmptyTargetNamesOwnMailbox(t *testing.T) {
-	if got := describeSender(""); got != "your own mailbox" {
-		t.Fatalf("describeSender(%q) = %q, want %q", "", got, "your own mailbox")
+	if got := describeSender(""); got != ownMailboxLabel {
+		t.Fatalf("describeSender(%q) = %q, want %q", "", got, ownMailboxLabel)
 	}
 }
 

--- a/internal/cmd/mail_send_sender_test.go
+++ b/internal/cmd/mail_send_sender_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import "testing"
+
+// The sending identity is the one thing a dry run cannot afford to omit: a send
+// that goes from the wrong mailbox reports success and is only discovered by the
+// recipient.
+func TestDescribeSender_EmptyTargetNamesOwnMailbox(t *testing.T) {
+	if got := describeSender(""); got != "your own mailbox" {
+		t.Fatalf("describeSender(%q) = %q, want %q", "", got, "your own mailbox")
+	}
+}
+
+func TestDescribeSender_TargetIsNamedVerbatim(t *testing.T) {
+	if got := describeSender("expenses@example.com"); got != "expenses@example.com" {
+		t.Fatalf("describeSender() = %q, want the target address", got)
+	}
+}
+
+// resolveMailboxTarget is what makes --mailbox reach the send path at all.
+// Before this change mail send never called it, so the flag was accepted and
+// silently ignored.
+func TestResolveMailboxTarget_FeedsTheSendPath(t *testing.T) {
+	target, err := resolveMailboxTarget("expenses@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != "expenses@example.com" {
+		t.Fatalf("target = %q, want the shared mailbox address", target)
+	}
+}
+
+func TestResolveMailboxTarget_RejectsNonAddress(t *testing.T) {
+	if _, err := resolveMailboxTarget("not-an-address"); err == nil {
+		t.Fatal("expected an error for a non-address --mailbox value")
+	}
+}

--- a/internal/cmd/paging.go
+++ b/internal/cmd/paging.go
@@ -68,3 +68,7 @@ func parseDateTime(s string) string {
 	}
 	return ""
 }
+
+// ownMailboxLabel names the signed-in user's own mailbox in command output,
+// distinguishing it from a delegated one.
+const ownMailboxLabel = "your own mailbox"

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -29,7 +29,7 @@ type RootFlags struct {
 	JSON         bool         `help:"Output as JSON" env:"OLK_JSON"`
 	Plain        bool         `help:"Output as plain TSV" env:"OLK_PLAIN"`
 	Account      string       `help:"Account email to use" env:"OLK_ACCOUNT"`
-	Mailbox      string       `help:"Target a different user's mailbox via delegated access (requires Mail.Read.Shared at login)" env:"OLK_MAILBOX"`
+	Mailbox      string       `help:"Target a different user's mailbox via delegated access (reading requires Mail.Read.Shared at login; sending also requires Mail.Send.Shared plus Send As on the mailbox)" env:"OLK_MAILBOX"`
 	Verbose      bool         `help:"Verbose output" short:"v" env:"OLK_VERBOSE"`
 	DryRun       bool         `help:"Dry run mode" env:"OLK_DRY_RUN"`
 	Force        bool         `help:"Force operation" env:"OLK_FORCE"`

--- a/internal/graphapi/client_guards_test.go
+++ b/internal/graphapi/client_guards_test.go
@@ -33,6 +33,18 @@ func TestNoWriteGuardBlocksMutations(t *testing.T) {
 			return err
 		}},
 		{"SendMessage", func() error { return c.SendMessage(ctx, "", &SendMessageOptions{Subject: "s", Body: "b"}) }},
+		// Draft writes can land in someone else's mailbox now, so the guard
+		// matters more than when they could only touch your own.
+		{"CreateDraft", func() error {
+			_, err := c.CreateDraft(ctx, "", "s", "b", []string{"a@b.com"}, nil, nil, false)
+			return err
+		}},
+		{"CreateDraft into a shared mailbox", func() error {
+			_, err := c.CreateDraft(ctx, "shared@example.com", "s", "b", []string{"a@b.com"}, nil, nil, false)
+			return err
+		}},
+		{"DeleteDraft", func() error { return c.DeleteDraft(ctx, "", "id") }},
+		{"DeleteDraft from a shared mailbox", func() error { return c.DeleteDraft(ctx, "shared@example.com", "id") }},
 	}
 	for _, tc := range checks {
 		if err := tc.call(); !errors.Is(err, ErrNoWrite) {
@@ -52,7 +64,8 @@ func TestNoSendGuardBlocksSends(t *testing.T) {
 		{"SendMessage", func() error { return c.SendMessage(ctx, "", &SendMessageOptions{Subject: "s", Body: "b"}) }},
 		{"ReplyMessage", func() error { return c.ReplyMessage(ctx, "id", "c", false) }},
 		{"ForwardMessage", func() error { return c.ForwardMessage(ctx, "id", "c", []string{"a@b.com"}) }},
-		{"SendDraft", func() error { return c.SendDraft(ctx, "id") }},
+		{"SendDraft", func() error { return c.SendDraft(ctx, "", "id") }},
+		{"SendDraft from a shared mailbox", func() error { return c.SendDraft(ctx, "shared@example.com", "id") }},
 		{"RespondToEvent", func() error { return c.RespondToEvent(ctx, "id", "accept") }},
 		{"CreateEvent w/ attendees", func() error {
 			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "", "", nil)

--- a/internal/graphapi/client_guards_test.go
+++ b/internal/graphapi/client_guards_test.go
@@ -32,7 +32,7 @@ func TestNoWriteGuardBlocksMutations(t *testing.T) {
 			_, err := c.CreateEvent(ctx, "", "s", time.Now(), time.Now(), "", []string{"a@b.com"}, false, false, "", "", nil)
 			return err
 		}},
-		{"SendMessage", func() error { return c.SendMessage(ctx, "s", "b", nil, nil, nil, false, nil, "", false) }},
+		{"SendMessage", func() error { return c.SendMessage(ctx, "", &SendMessageOptions{Subject: "s", Body: "b"}) }},
 	}
 	for _, tc := range checks {
 		if err := tc.call(); !errors.Is(err, ErrNoWrite) {
@@ -49,7 +49,7 @@ func TestNoSendGuardBlocksSends(t *testing.T) {
 		name string
 		call func() error
 	}{
-		{"SendMessage", func() error { return c.SendMessage(ctx, "s", "b", nil, nil, nil, false, nil, "", false) }},
+		{"SendMessage", func() error { return c.SendMessage(ctx, "", &SendMessageOptions{Subject: "s", Body: "b"}) }},
 		{"ReplyMessage", func() error { return c.ReplyMessage(ctx, "id", "c", false) }},
 		{"ForwardMessage", func() error { return c.ForwardMessage(ctx, "id", "c", []string{"a@b.com"}) }},
 		{"SendDraft", func() error { return c.SendDraft(ctx, "id") }},

--- a/internal/graphapi/drafts.go
+++ b/internal/graphapi/drafts.go
@@ -112,6 +112,9 @@ func (c *Client) SendDraft(ctx context.Context, target, draftID string) error {
 	}
 	err := c.targetUser(target).Messages().ByMessageId(draftID).Send().Post(ctx, nil)
 	if err != nil {
+		if target != "" {
+			return fmt.Errorf("sending draft from %s: %w\n\nSending a draft that lives in another mailbox needs the Mail.Send.Shared scope (sign in again with --scope Mail.Send.Shared) and Send As or Send on Behalf Of on that mailbox in Exchange. The Full Access that allowed the draft to be created there does not confer the right to send it", target, err)
+		}
 		return fmt.Errorf("sending draft: %w", err)
 	}
 	return nil

--- a/internal/graphapi/drafts.go
+++ b/internal/graphapi/drafts.go
@@ -17,12 +17,13 @@ type DraftMessage struct {
 	Created string   `json:"createdDateTime"`
 }
 
-// ListDrafts lists messages in the Drafts folder
-func (c *Client) ListDrafts(ctx context.Context, top int32) ([]DraftMessage, error) {
+// ListDrafts lists messages in the Drafts folder of the target mailbox, or of
+// the signed-in user's own mailbox when target is empty.
+func (c *Client) ListDrafts(ctx context.Context, target string, top int32) ([]DraftMessage, error) {
 	top = clampTop(top)
 
 	selectFields := []string{"id", "subject", "toRecipients", "body", "createdDateTime"}
-	resp, err := c.inner.Me().MailFolders().ByMailFolderId("drafts").Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+	resp, err := c.targetUser(target).MailFolders().ByMailFolderId("drafts").Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
 			Top:    &top,
 			Select: selectFields,
@@ -39,8 +40,15 @@ func (c *Client) ListDrafts(ctx context.Context, top int32) ([]DraftMessage, err
 	return drafts, nil
 }
 
-// CreateDraft creates a draft message without sending it
-func (c *Client) CreateDraft(ctx context.Context, subject, body string, to, cc, bcc []string, isHTML bool) (*DraftMessage, error) {
+// CreateDraft leaves a draft in the target mailbox, or in the signed-in user's
+// own mailbox when target is empty.
+//
+// Drafting into a shared mailbox is the lower-privilege alternative to sending
+// as one: it needs the Mail.ReadWrite.Shared scope and Full Access on the
+// mailbox, but *not* Send As or Send on Behalf Of. The draft lands in that
+// mailbox's Drafts folder for a person who does hold those rights to review and
+// send, which keeps a human at the point where the message actually leaves.
+func (c *Client) CreateDraft(ctx context.Context, target, subject, body string, to, cc, bcc []string, isHTML bool) (*DraftMessage, error) {
 	if err := c.ensureWritable(); err != nil {
 		return nil, err
 	}
@@ -79,8 +87,11 @@ func (c *Client) CreateDraft(ctx context.Context, subject, body string, to, cc, 
 		msg.SetBccRecipients(bccR)
 	}
 
-	result, err := c.inner.Me().Messages().Post(ctx, msg, nil)
+	result, err := c.targetUser(target).Messages().Post(ctx, msg, nil)
 	if err != nil {
+		if target != "" {
+			return nil, fmt.Errorf("creating draft in %s: %w\n\nDrafting into another mailbox needs the Mail.ReadWrite.Shared scope (sign in again with --scope Mail.ReadWrite.Shared) and Full Access on that mailbox in Exchange. Read-only access to a mailbox is not enough to leave a draft in it", target, err)
+		}
 		return nil, fmt.Errorf("creating draft: %w", err)
 	}
 
@@ -88,30 +99,34 @@ func (c *Client) CreateDraft(ctx context.Context, subject, body string, to, cc, 
 	return &draft, nil
 }
 
-// SendDraft sends an existing draft message
-func (c *Client) SendDraft(ctx context.Context, draftID string) error {
+// SendDraft sends an existing draft from the target mailbox, or from the
+// signed-in user's own mailbox when target is empty. Sending a draft that lives
+// in someone else's mailbox still needs Send As or Send on Behalf Of — creating
+// the draft does not confer the right to send it.
+func (c *Client) SendDraft(ctx context.Context, target, draftID string) error {
 	if err := c.ensureMaySend(); err != nil {
 		return err
 	}
 	if err := validateID(draftID, "draft ID"); err != nil {
 		return err
 	}
-	err := c.inner.Me().Messages().ByMessageId(draftID).Send().Post(ctx, nil)
+	err := c.targetUser(target).Messages().ByMessageId(draftID).Send().Post(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("sending draft: %w", err)
 	}
 	return nil
 }
 
-// DeleteDraft deletes a draft message
-func (c *Client) DeleteDraft(ctx context.Context, draftID string) error {
+// DeleteDraft deletes a draft from the target mailbox, or from the signed-in
+// user's own mailbox when target is empty.
+func (c *Client) DeleteDraft(ctx context.Context, target, draftID string) error {
 	if err := c.ensureWritable(); err != nil {
 		return err
 	}
 	if err := validateID(draftID, "draft ID"); err != nil {
 		return err
 	}
-	err := c.inner.Me().Messages().ByMessageId(draftID).Delete(ctx, nil)
+	err := c.targetUser(target).Messages().ByMessageId(draftID).Delete(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("deleting draft: %w", err)
 	}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -283,20 +283,55 @@ func (c *Client) GetMessage(ctx context.Context, target, messageID string, prefe
 	return &m, nil
 }
 
-func (c *Client) SendMessage(ctx context.Context, subject, body string, toRecipients, ccRecipients, bccRecipients []string, isHTML bool, attachments []AttachmentInput, importance string, readReceipt bool) error {
+// SendMessageOptions carries the content of an outgoing message. It exists so
+// that SendMessage can take a mailbox target without growing an eleventh
+// positional parameter.
+type SendMessageOptions struct {
+	Subject     string
+	Body        string
+	To          []string
+	CC          []string
+	BCC         []string
+	IsHTML      bool
+	Attachments []AttachmentInput
+	Importance  string
+	ReadReceipt bool
+}
+
+// SendMessage sends from the target mailbox, or from the signed-in user's own
+// mailbox when target is empty.
+//
+// Sending as another mailbox needs two grants that are easy to confuse, and
+// holding one tells you nothing about the other:
+//
+//   - the token must carry the Mail.Send.Shared scope claim, requested at login
+//     with `--scope Mail.Send.Shared`; and
+//   - the calling user must hold Send As or Send on Behalf Of on the target
+//     mailbox in Exchange, which is a different delegation from the Full Access
+//     that makes reading it work.
+//
+// Before this took a target, a send with --mailbox set silently went out from
+// the caller's own address and still reported success, which is the failure
+// mode this signature exists to prevent.
+func (c *Client) SendMessage(ctx context.Context, target string, opts *SendMessageOptions) error {
 	if err := c.ensureMaySend(); err != nil {
 		return err
 	}
+	if opts == nil {
+		return fmt.Errorf("send options are required")
+	}
+	subject, body := opts.Subject, opts.Body
 	msg := models.NewMessage()
 	msg.SetSubject(&subject)
 
-	if readReceipt {
+	if opts.ReadReceipt {
+		readReceipt := true
 		msg.SetIsReadReceiptRequested(&readReceipt)
 	}
 
 	bodyObj := models.NewItemBody()
 	bodyObj.SetContent(&body)
-	if isHTML {
+	if opts.IsHTML {
 		html := models.HTML_BODYTYPE
 		bodyObj.SetContentType(&html)
 	} else {
@@ -305,29 +340,29 @@ func (c *Client) SendMessage(ctx context.Context, subject, body string, toRecipi
 	}
 	msg.SetBody(bodyObj)
 
-	toR, err := makeRecipients(toRecipients)
+	toR, err := makeRecipients(opts.To)
 	if err != nil {
 		return fmt.Errorf("invalid to recipient: %w", err)
 	}
 	msg.SetToRecipients(toR)
-	if len(ccRecipients) > 0 {
-		ccR, err := makeRecipients(ccRecipients)
+	if len(opts.CC) > 0 {
+		ccR, err := makeRecipients(opts.CC)
 		if err != nil {
 			return fmt.Errorf("invalid cc recipient: %w", err)
 		}
 		msg.SetCcRecipients(ccR)
 	}
-	if len(bccRecipients) > 0 {
-		bccR, err := makeRecipients(bccRecipients)
+	if len(opts.BCC) > 0 {
+		bccR, err := makeRecipients(opts.BCC)
 		if err != nil {
 			return fmt.Errorf("invalid bcc recipient: %w", err)
 		}
 		msg.SetBccRecipients(bccR)
 	}
 
-	if len(attachments) > 0 {
+	if len(opts.Attachments) > 0 {
 		var atts []models.Attachmentable
-		for _, a := range attachments {
+		for _, a := range opts.Attachments {
 			fileAtt := models.NewFileAttachment()
 			odataType := "#microsoft.graph.fileAttachment"
 			fileAtt.SetOdataType(&odataType)
@@ -341,9 +376,9 @@ func (c *Client) SendMessage(ctx context.Context, subject, body string, toRecipi
 		msg.SetAttachments(atts)
 	}
 
-	if importance != "" {
+	if opts.Importance != "" {
 		var imp models.Importance
-		switch importance {
+		switch opts.Importance {
 		case importanceLow:
 			imp = models.LOW_IMPORTANCE
 		case importanceNormal:
@@ -351,7 +386,7 @@ func (c *Client) SendMessage(ctx context.Context, subject, body string, toRecipi
 		case importanceHigh:
 			imp = models.HIGH_IMPORTANCE
 		default:
-			return fmt.Errorf("invalid importance: %q (must be low, normal, or high)", importance)
+			return fmt.Errorf("invalid importance: %q (must be low, normal, or high)", opts.Importance)
 		}
 		msg.SetImportance(&imp)
 	}
@@ -361,7 +396,10 @@ func (c *Client) SendMessage(ctx context.Context, subject, body string, toRecipi
 	saveToSent := true
 	sendBody.SetSaveToSentItems(&saveToSent)
 
-	if err := c.inner.Me().SendMail().Post(ctx, sendBody, nil); err != nil {
+	if err := c.targetUser(target).SendMail().Post(ctx, sendBody, nil); err != nil {
+		if target != "" {
+			return fmt.Errorf("sending message as %s: %w\n\nSending as another mailbox needs both the Mail.Send.Shared scope (sign in again with --scope Mail.Send.Shared) and Send As or Send on Behalf Of on that mailbox in Exchange. Read access to a mailbox does not imply either", target, err)
+		}
 		return fmt.Errorf("sending message: %w", err)
 	}
 	return nil

--- a/internal/graphapi/mail_send_target_test.go
+++ b/internal/graphapi/mail_send_target_test.go
@@ -1,0 +1,40 @@
+package graphapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// SendMessage must reject a nil options struct rather than send an empty message.
+func TestSendMessage_NilOptionsRejected(t *testing.T) {
+	c := &Client{}
+	err := c.SendMessage(context.Background(), "", nil)
+	if err == nil || !strings.Contains(err.Error(), "send options are required") {
+		t.Fatalf("want a nil-options error, got %v", err)
+	}
+}
+
+// The send guard must still win over everything else, including a target.
+func TestSendMessage_NoSendGuardBeatsTarget(t *testing.T) {
+	c := &Client{}
+	c.SetGuards(false, true)
+	err := c.SendMessage(context.Background(), "shared@example.com", &SendMessageOptions{Subject: "s"})
+	if err == nil {
+		t.Fatal("expected --no-send to block a send to a shared mailbox target")
+	}
+}
+
+// An invalid importance is rejected before any network call, for a shared
+// target just as for the caller's own mailbox.
+func TestSendMessage_InvalidImportanceRejected(t *testing.T) {
+	c := &Client{}
+	err := c.SendMessage(context.Background(), "", &SendMessageOptions{
+		Subject:    "s",
+		To:         []string{"someone@example.com"},
+		Importance: "urgent",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid importance") {
+		t.Fatalf("want an importance error, got %v", err)
+	}
+}

--- a/internal/msauth/scopes.go
+++ b/internal/msauth/scopes.go
@@ -4,8 +4,14 @@ import "strings"
 
 // Microsoft Graph API scopes
 const (
-	ScopeMail            = "Mail.ReadWrite"
-	ScopeMailSend        = "Mail.Send"
+	ScopeMail     = "Mail.ReadWrite"
+	ScopeMailSend = "Mail.Send"
+	// ScopeMailSendShared permits sending as a mailbox other than your own.
+	// It is not requested by default: personal Microsoft accounts cannot
+	// consent to it, and it is only useful alongside a Send As or Send on
+	// Behalf Of delegation granted separately in Exchange. Request it at
+	// login with `--scope Mail.Send.Shared`.
+	ScopeMailSendShared  = "Mail.Send.Shared"
 	ScopeCalendar        = "Calendars.ReadWrite"
 	ScopeContacts        = "Contacts.ReadWrite"
 	ScopeTasks           = "Tasks.ReadWrite"


### PR DESCRIPTION
`olk mail send --mailbox EMAIL` now actually sends from that mailbox. Before this
change the send path never read the `--mailbox` flag: the flag was accepted, the
message went out from the signed-in user's own address, and the command reported
success. The failure was silent and only visible to the recipient.

## What this does

- `mail send` resolves `--mailbox` and posts to that mailbox's `sendMail`.
- `mail drafts` (list, create, send, delete) resolve `--mailbox` too, so a draft
  can be left in a shared mailbox for a person who holds sending rights to review
  and send. That is the lower-privilege path: it needs `Mail.ReadWrite.Shared`
  and Full Access, but not Send As.
- Dry runs and success lines name the mailbox being acted on, so the sending
  identity is visible before and after the fact.
- Failures against a shared mailbox explain which of the two grants is likely
  missing, rather than surfacing a bare `Access is denied`.

## The two grants

Sending as another mailbox needs both, and holding one implies nothing about the
other:

- the `Mail.Send.Shared` scope on the token, requested at login with
  `--scope Mail.Send.Shared`; and
- Send As or Send on Behalf Of on the mailbox in Exchange, which is a separate
  delegation from the Full Access that permits reading it.

`Mail.Send.Shared` is not requested by default — personal Microsoft accounts
cannot consent to it, and it is useless without the Exchange delegation.

## Interface change

`Client.SendMessage` took ten positional parameters. Adding a mailbox target
would have made eleven, so the message content moved into a
`SendMessageOptions` struct and the target is a separate argument. The draft
methods take the target as a leading parameter.

## Agent exposure

The Model Context Protocol (MCP) tool schemas are built from each command's own
flags, and `--mailbox` is a global flag, so it does not appear in any tool's
schema. An agent calling `mail_send` or `mail_drafts_create` cannot redirect the
message to another mailbox; the target comes only from the operator's launch-time
flag or environment.

## Known limitation

`mail reply` and `mail forward` still do not read `--mailbox`. Because message
IDs are scoped to a mailbox, the usual delegated flow — list a shared mailbox,
then reply to one of its messages — fails with an item-not-found error rather
than sending from the wrong address: replying from a shared mailbox is currently
not possible at all, rather than silently mis-attributed. Not addressed here.

## Verification

`go build`, `go vet`, `gofmt`, `go test -race -count=1 ./...` and `golangci-lint
run` all pass, checked against the golangci-lint version CI actually runs
(v2.11.4), which reports zero issues. An earlier revision of this description
claimed a baseline of 50 pre-existing `goconst` findings; that was an artifact of
a newer local linter, not the project's state.
