### PR TITLE
fix(mail): show Cc and Bcc in send and draft dry runs

### DIFF
--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -93,8 +93,14 @@ func (c *MailDraftsCreateCmd) Run(ctx *RunContext) error {
 	}
 
 	if ctx.Flags.DryRun {
-		fmt.Printf("Would create draft:\n  To: %s\n  Subject: %s\n  Body: %s\n",
-			strings.Join(c.To, ", "), outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
+		fmt.Printf("Would create draft:\n  To: %s\n", strings.Join(c.To, ", "))
+		if len(c.CC) > 0 {
+			fmt.Printf("  Cc: %s\n", strings.Join(c.CC, ", "))
+		}
+		if len(c.BCC) > 0 {
+			fmt.Printf("  Bcc: %s\n", strings.Join(c.BCC, ", "))
+		}
+		fmt.Printf("  Subject: %s\n  Body: %s\n", outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
 		return nil
 	}
 

--- a/internal/cmd/mail_dryrun_test.go
+++ b/internal/cmd/mail_dryrun_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestDryRunPreviewsShowAllRecipientClasses pins the recipient block of the
+// `mail send` and `mail drafts create` previews: every supplied class is
+// listed, the optional ones disappear when unused, and no Graph request is
+// made.
+func TestDryRunPreviewsShowAllRecipientClasses(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     []string
+		args     []string
+		expected string
+	}{
+		{
+			name: "send with every recipient class",
+			path: []string{"mail", "send"},
+			args: []string{
+				"--to", "to-one@example.com,to-two@example.com",
+				"--cc", "cc@example.com",
+				"--bcc", "bcc@example.com",
+				"--subject", "Preview",
+				"--body", "Body",
+			},
+			expected: "Would send email:\n" +
+				"  To: to-one@example.com, to-two@example.com\n" +
+				"  Cc: cc@example.com\n" +
+				"  Bcc: bcc@example.com\n" +
+				"  Subject: Preview\n" +
+				"  Body: Body\n",
+		},
+		{
+			name: "send without optional recipients",
+			path: []string{"mail", "send"},
+			args: []string{
+				"--to", "to-one@example.com",
+				"--subject", "Preview",
+				"--body", "Body",
+			},
+			expected: "Would send email:\n" +
+				"  To: to-one@example.com\n" +
+				"  Subject: Preview\n" +
+				"  Body: Body\n",
+		},
+		{
+			name: "send with cc only",
+			path: []string{"mail", "send"},
+			args: []string{
+				"--to", "to-one@example.com",
+				"--cc", "cc@example.com",
+				"--subject", "Preview",
+				"--body", "Body",
+			},
+			expected: "Would send email:\n" +
+				"  To: to-one@example.com\n" +
+				"  Cc: cc@example.com\n" +
+				"  Subject: Preview\n" +
+				"  Body: Body\n",
+		},
+		{
+			name: "draft with every recipient class",
+			path: []string{"mail", "drafts", "create"},
+			args: []string{
+				"--to", "to-one@example.com,to-two@example.com",
+				"--cc", "cc-one@example.com,cc-two@example.com",
+				"--bcc", "bcc@example.com",
+				"--subject", "Preview",
+				"--body", "Body",
+			},
+			expected: "Would create draft:\n" +
+				"  To: to-one@example.com, to-two@example.com\n" +
+				"  Cc: cc-one@example.com, cc-two@example.com\n" +
+				"  Bcc: bcc@example.com\n" +
+				"  Subject: Preview\n" +
+				"  Body: Body\n",
+		},
+		{
+			name: "draft without optional recipients",
+			path: []string{"mail", "drafts", "create"},
+			args: []string{
+				"--to", "to-one@example.com",
+				"--subject", "Preview",
+				"--body", "Body",
+			},
+			expected: "Would create draft:\n" +
+				"  To: to-one@example.com\n" +
+				"  Subject: Preview\n" +
+				"  Body: Body\n",
+		},
+		{
+			name: "draft with multiple bcc only",
+			path: []string{"mail", "drafts", "create"},
+			args: []string{
+				"--to", "to-one@example.com",
+				"--bcc", "bcc-one@example.com,bcc-two@example.com",
+				"--subject", "Preview",
+				"--body", "Body",
+			},
+			expected: "Would create draft:\n" +
+				"  To: to-one@example.com\n" +
+				"  Bcc: bcc-one@example.com, bcc-two@example.com\n" +
+				"  Subject: Preview\n" +
+				"  Body: Body\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, calls, err := runMailCommand(
+				t,
+				tc.path,
+				append([]string{"--dry-run"}, tc.args...),
+				func(req *http.Request) *http.Response {
+					t.Errorf("unexpected Graph request during dry run: %s %s", req.Method, req.URL.Path)
+					return graphJSONResponse(req, `{}`)
+				},
+			)
+			if err != nil {
+				t.Fatalf("dry run: %v", err)
+			}
+			if calls != 0 {
+				t.Fatalf("Graph handler calls = %d, want 0", calls)
+			}
+			if output != tc.expected {
+				t.Fatalf("preview =\n%q\nwant\n%q", output, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -93,7 +93,14 @@ func (c *MailSendCmd) Run(ctx *RunContext) error {
 	}
 
 	if ctx.Flags.DryRun {
-		fmt.Printf("Would send email:\n  To: %s\n  Subject: %s\n  Body: %s\n", strings.Join(c.To, ", "), outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
+		fmt.Printf("Would send email:\n  To: %s\n", strings.Join(c.To, ", "))
+		if len(c.CC) > 0 {
+			fmt.Printf("  Cc: %s\n", strings.Join(c.CC, ", "))
+		}
+		if len(c.BCC) > 0 {
+			fmt.Printf("  Bcc: %s\n", strings.Join(c.BCC, ", "))
+		}
+		fmt.Printf("  Subject: %s\n  Body: %s\n", outfmt.Sanitize(c.Subject), outfmt.Sanitize(body))
 		if len(attachments) > 0 {
 			fmt.Printf("  Attachments: %d file(s)\n", len(attachments))
 		}


### PR DESCRIPTION
Closes #90.

`mail send` and `mail drafts create` both accept `--cc` and `--bcc`, and both
pass those slices to Graph. Their dry-run previews listed only the To
recipients, so a preview looked complete while two of the three recipient
classes were missing from it. Checking who a message is about to reach is the
one thing a dry run is for, and it could not do that.

Each optional class now prints between the To and Subject lines when it has
addresses, and stays absent otherwise:

```console
$ olk --dry-run mail send --to to-one@example.com,to-two@example.com \
    --cc cc@example.com --bcc bcc@example.com --subject Preview --body Body
Would send email:
  To: to-one@example.com, to-two@example.com
  Cc: cc@example.com
  Bcc: bcc@example.com
  Subject: Preview
  Body: Body
```

The `olk send` shortcut delegates to `MailSendCmd`, so it is covered too.
Recipients are joined the way the existing To line joins them; every address has
already passed `ValidateEmail` by the time the preview runs, so no further
escaping applies.

## Tests

A table test drives both commands with `--dry-run` and compares the whole
preview, which pins the labels, the ordering and the omission of unused classes
in one assertion. It also asserts that no Graph request is made. The six cases
cover every recipient class, multiple addresses in each of the three, and each
optional class alone. Reverting either print site fails them.

`make test` passes. `make lint` reports only the 50 pre-existing `goconst`
findings that clean `main` also produces.

## Adjacent gap, not addressed here

`calendar create --dry-run` has the same shape of omission: it accepts
`--attendees` and passes them to `CreateEvent`, but the preview at
`internal/cmd/calendar.go:203` prints only the subject and the times. Left for a
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DapREy7kidntFhvdWKj8JS