### PR TITLE
feat(mail): support nested folder paths

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ olk auth clean --force                          # remove ALL stored accounts and
 ## Mail
 
 ```bash
-olk mail list [-n 25] [-f FOLDER] [-u] [--from SENDER] [--after DATE] [--before DATE] [--focused] [--other] [--order newest|oldest] [--select FIELDS]
+olk mail list [-n 25] [-f FOLDER_ID_OR_PATH] [-u] [--from SENDER] [--after DATE] [--before DATE] [--focused] [--other] [--order newest|oldest] [--select FIELDS]
 # --order cannot be combined with --focused or --other
 olk mail get <ID> [--format full|text|html]
 olk mail send --to a@b.com --subject "Hi" --body "Hello"                  # plain
@@ -78,10 +78,10 @@ olk mail search "from:boss@co.com subject:urgent" [-n 25]                 # KQL
 olk mail thread <CONVERSATION_ID> [--top 50 | --complete]               # one conversation
 olk mail reply <ID> --body "Thanks" [--reply-all]
 olk mail forward <ID> --to a@b.com [--comment "FYI"]
-olk mail move <ID> <FOLDER>
+olk mail move <ID> <FOLDER_ID_OR_PATH>                                 # e.g. Inbox/2026
 olk mail delete <ID> --force
 olk mail mark <ID> --read | --unread
-olk mail folders                                                          # list folders
+olk mail folders                                                          # list all visible folders recursively
 olk mail folders create -n "Project X"
 olk mail folders rename <FOLDER_ID> -n "New Name"
 olk mail folders delete <FOLDER_ID> --force
@@ -95,6 +95,11 @@ For a bounded mail inventory, use:
 ```bash
 olk mail list --folder inbox --top 1000 --order oldest --json --results-only
 ```
+
+`--folder` and the `mail move` destination accept slash-separated display-name
+paths such as `Inbox/2026`; paths are resolved to Graph folder IDs by walking
+each level. A single display name such as `2026` is not a path and can be
+ambiguous, so use either its ID or its full path.
 
 `--order` accepts `newest` (the default) or `oldest`. `--top` bounds the total
 result, not each provider page. `olk` follows pages internally until it reaches

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,7 +26,7 @@ olk whoami
 ## Mail
 
 ```bash
-olk mail list [-n N] [--folder ID] [--from EMAIL] [--unread] [--focused|--other]
+olk mail list [-n N] [--folder ID_OR_PATH] [--from EMAIL] [--unread] [--focused|--other]
 olk mail get <ID> [--body-format text|html]
 olk mail search <KQL>
 olk mail batch <ID> [--id ID ...]
@@ -36,10 +36,10 @@ olk mail send --to EMAIL --subject SUBJECT --body BODY [--html]
 olk mail reply <ID> --body BODY [--all]
 olk mail forward <ID> --to EMAIL
 olk mail mark <ID> read|unread
-olk mail move <ID> --folder ID
+olk mail move <ID> ID_OR_PATH
 olk mail delete <ID> --force
 olk mail attachments <ID> --attachment-id ID
-olk mail folders list|create|rename|delete
+olk mail folders list|create|rename|delete  # list traverses visible child folders
 olk mail drafts list|create|send|delete
 olk mail flag <ID> flagged|complete|notFlagged
 olk mail categorize <ID> --category NAME

--- a/internal/cmd/mail_delta.go
+++ b/internal/cmd/mail_delta.go
@@ -6,7 +6,7 @@ import "github.com/rlrghb/olkcli/internal/outfmt"
 // endpoint. Omit --token for a fresh sync; pass the returned token next time to
 // get only what changed since.
 type MailDeltaCmd struct {
-	Folder string `help:"Mail folder ID or well-known name" short:"f" default:"inbox"`
+	Folder string `help:"Mail folder ID, well-known name, or path (for example Inbox/2026)" short:"f" default:"inbox"`
 	Token  string `help:"Delta token from a previous call (omit to start a fresh sync)"`
 	Top    int32  `help:"Max items per page" short:"n"`
 }
@@ -21,7 +21,11 @@ func (c *MailDeltaCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	items, page, err := client.DeltaMessages(ctx.Ctx, target, c.Folder, c.Token, c.Top)
+	folderID, err := client.ResolveMailFolderPath(ctx.Ctx, target, c.Folder)
+	if err != nil {
+		return err
+	}
+	items, page, err := client.DeltaMessages(ctx.Ctx, target, folderID, c.Token, c.Top)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/mail_folder_paths_test.go
+++ b/internal/cmd/mail_folder_paths_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestMailListResolvesDelegatedFolderPath(t *testing.T) {
+	requests := 0
+	output, calls, err := runMailCommand(
+		t,
+		[]string{"mail", "list"},
+		[]string{"--json", "--mailbox", "shared@example.com", "--folder", "Inbox/2026"},
+		func(req *http.Request) *http.Response {
+			requests++
+			switch requests {
+			case 1:
+				if got := req.URL.Path; got != "/v1.0/users/shared@example.com/mailFolders" {
+					t.Errorf("folder root request = %q", got)
+				}
+				return graphJSONResponse(req, `{"value":[{"id":"inbox-id","displayName":"Inbox","childFolderCount":1}]}`)
+			case 2:
+				if got := req.URL.Path; got != "/v1.0/users/shared@example.com/mailFolders/inbox-id/childFolders" {
+					t.Errorf("child-folder request = %q", got)
+				}
+				return graphJSONResponse(req, `{"value":[{"id":"year-id","displayName":"2026","childFolderCount":0}]}`)
+			case 3:
+				if got := req.URL.Path; got != "/v1.0/users/shared@example.com/mailFolders/year-id/messages" {
+					t.Errorf("message-list request = %q, want resolved folder ID", got)
+				}
+				return graphMessageListResponse(req)
+			default:
+				t.Fatalf("unexpected Graph request: %s", req.URL)
+				return nil
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("mail list: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("Graph requests = %d, want 3", calls)
+	}
+	if !strings.Contains(output, `"id": "message-id"`) {
+		t.Errorf("mail list output omitted message: %s", output)
+	}
+}
+
+func TestMailDeltaResolvesFolderPath(t *testing.T) {
+	requests := 0
+	_, calls, err := runMailCommand(
+		t,
+		[]string{"mail", "delta"},
+		[]string{"--json", "--folder", "Inbox/2026"},
+		func(req *http.Request) *http.Response {
+			requests++
+			switch requests {
+			case 1:
+				return graphJSONResponse(req, `{"value":[{"id":"inbox-id","displayName":"Inbox","childFolderCount":1}]}`)
+			case 2:
+				return graphJSONResponse(req, `{"value":[{"id":"year-id","displayName":"2026","childFolderCount":0}]}`)
+			case 3:
+				if !strings.HasSuffix(req.URL.Path, "/mailFolders/year-id/messages/delta()") {
+					t.Errorf("delta request path = %q, want resolved folder ID", req.URL.Path)
+				}
+				return graphJSONResponse(req, `{"value":[],"@odata.deltaLink":"https://graph.microsoft.com/v1.0/me/mailFolders/year-id/messages/delta?$deltatoken=done"}`)
+			default:
+				t.Fatalf("unexpected Graph request: %s", req.URL)
+				return nil
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("mail delta: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("Graph requests = %d, want 3", calls)
+	}
+}
+
+func TestMailMoveResolvesFolderPathToDestinationID(t *testing.T) {
+	requests := 0
+	_, calls, err := runMailCommand(
+		t,
+		[]string{"mail", "move"},
+		[]string{"message-id", "Inbox/2026"},
+		func(req *http.Request) *http.Response {
+			requests++
+			switch requests {
+			case 1:
+				return graphJSONResponse(req, `{"value":[{"id":"inbox-id","displayName":"Inbox","childFolderCount":1}]}`)
+			case 2:
+				return graphJSONResponse(req, `{"value":[{"id":"year-id","displayName":"2026","childFolderCount":0}]}`)
+			case 3:
+				if !strings.HasSuffix(req.URL.Path, "/messages/message-id/move") {
+					t.Errorf("move request path = %q", req.URL.Path)
+				}
+				var payload struct {
+					DestinationID string `json:"destinationId"`
+				}
+				if err := decodeGraphJSON(req.Body, &payload); err != nil {
+					t.Fatalf("decode move request: %v", err)
+				}
+				if payload.DestinationID != "year-id" {
+					t.Errorf("destination ID = %q, want resolved year-id", payload.DestinationID)
+				}
+				return graphJSONResponse(req, `{"id":"moved-id"}`)
+			default:
+				t.Fatalf("unexpected Graph request: %s", req.URL)
+				return nil
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("mail move: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("Graph requests = %d, want 3", calls)
+	}
+}
+
+func TestMailMoveDryRunDoesNotResolveFolderPath(t *testing.T) {
+	output, calls, err := runMailCommand(
+		t,
+		[]string{"mail", "move"},
+		[]string{"--dry-run", "message-id", "Inbox/2026"},
+		func(req *http.Request) *http.Response {
+			t.Fatalf("unexpected Graph request during dry run: %s", req.URL)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("mail move --dry-run: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("Graph requests = %d, want 0", calls)
+	}
+	if got, want := output, "Would move message message-id to folder Inbox/2026\n"; got != want {
+		t.Fatalf("dry-run output = %q, want %q", got, want)
+	}
+}

--- a/internal/cmd/mail_folders.go
+++ b/internal/cmd/mail_folders.go
@@ -9,13 +9,13 @@ import (
 
 // MailFoldersCmd manages mail folders
 type MailFoldersCmd struct {
-	List   MailFoldersListCmd   `cmd:"" default:"1" help:"List mail folders"`
+	List   MailFoldersListCmd   `cmd:"" default:"1" help:"List all visible mail folders recursively"`
 	Create MailFoldersCreateCmd `cmd:"" help:"Create a mail folder"`
 	Rename MailFoldersRenameCmd `cmd:"" help:"Rename a mail folder"`
 	Delete MailFoldersDeleteCmd `cmd:"" help:"Delete a mail folder"`
 }
 
-// MailFoldersListCmd lists all mail folders (default subcommand)
+// MailFoldersListCmd lists all visible mail folders recursively (default subcommand)
 type MailFoldersListCmd struct {
 	WellKnown string `help:"Resolve one guarded destination by canonical Graph name (archive, deleteditems, inbox, or junkemail)"`
 }

--- a/internal/cmd/mail_list.go
+++ b/internal/cmd/mail_list.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MailListCmd struct {
-	Folder  string  `help:"Mail folder ID or well-known name" short:"f" env:"OLK_MAIL_FOLDER"`
+	Folder  string  `help:"Mail folder ID, well-known name, or path (for example Inbox/2026)" short:"f" env:"OLK_MAIL_FOLDER"`
 	Top     int32   `help:"Number of messages to return" default:"25" short:"n"`
 	Unread  bool    `help:"Show only unread messages" short:"u"`
 	From    string  `help:"Filter by sender email"`
@@ -125,8 +125,12 @@ func (c *MailListCmd) Run(ctx *RunContext) error {
 	if c.Focused || c.Other {
 		orderBy = ""
 	}
+	folderID, err := client.ResolveMailFolderPath(ctx.Ctx, target, c.Folder)
+	if err != nil {
+		return err
+	}
 	opts := graphapi.ListMessagesOptions{
-		FolderID: c.Folder,
+		FolderID: folderID,
 		Top:      c.Top,
 		Filter:   filter,
 		OrderBy:  orderBy,

--- a/internal/cmd/mail_move.go
+++ b/internal/cmd/mail_move.go
@@ -9,7 +9,7 @@ import (
 
 type MailMoveCmd struct {
 	ID     string `arg:"" help:"Message ID"`
-	Folder string `arg:"" help:"Destination folder ID or well-known name"`
+	Folder string `arg:"" help:"Destination folder ID, well-known name, or path (for example Inbox/2026)"`
 }
 
 func (c *MailMoveCmd) Run(ctx *RunContext) error {
@@ -23,7 +23,13 @@ func (c *MailMoveCmd) Run(ctx *RunContext) error {
 		return nil
 	}
 
-	receipt, err := client.MoveMessage(ctx.Ctx, c.ID, c.Folder)
+	// MoveMessage is intentionally an own-mailbox operation, so resolve a path
+	// against that same mailbox rather than the global delegated read target.
+	folderID, err := client.ResolveMailFolderPath(ctx.Ctx, "", c.Folder)
+	if err != nil {
+		return err
+	}
+	receipt, err := client.MoveMessage(ctx.Ctx, c.ID, folderID)
 	if err != nil {
 		return err
 	}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -88,12 +88,13 @@ var messageDetailSelect = []string{
 
 // MailFolder is a simplified folder representation
 type MailFolder struct {
-	ID             string `json:"id"`
-	WellKnownName  string `json:"wellKnownName,omitempty"`
-	DisplayName    string `json:"displayName" untrusted:"true"`
-	TotalCount     int32  `json:"totalItemCount"`
-	UnreadCount    int32  `json:"unreadItemCount"`
-	ParentFolderID string `json:"parentFolderId,omitempty"`
+	ID               string `json:"id"`
+	WellKnownName    string `json:"wellKnownName,omitempty"`
+	DisplayName      string `json:"displayName" untrusted:"true"`
+	TotalCount       int32  `json:"totalItemCount"`
+	UnreadCount      int32  `json:"unreadItemCount"`
+	ChildFolderCount int32  `json:"childFolderCount"`
+	ParentFolderID   string `json:"parentFolderId,omitempty"`
 }
 
 // protectedWellKnownMailFolders is the canonical folder set used by guarded
@@ -610,26 +611,6 @@ func (c *Client) MarkMessage(ctx context.Context, messageID string, isRead bool)
 	return nil
 }
 
-// ListMailFolders returns folders from the target mailbox, or the signed-in
-// user's mailbox when target is empty. See ListMessages for scope requirements.
-func (c *Client) ListMailFolders(ctx context.Context, target string) ([]MailFolder, error) {
-	var top int32 = 100
-	resp, err := c.targetUser(target).MailFolders().Get(ctx, &users.ItemMailFoldersRequestBuilderGetRequestConfiguration{
-		QueryParameters: &users.ItemMailFoldersRequestBuilderGetQueryParameters{
-			Top: &top,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("listing folders: %w", err)
-	}
-
-	folders := make([]MailFolder, 0, len(resp.GetValue()))
-	for _, f := range resp.GetValue() {
-		folders = append(folders, convertMailFolder(f))
-	}
-	return folders, nil
-}
-
 // GetWellKnownMailFolder resolves one guarded move destination by its canonical
 // Graph identifier. It intentionally does not infer identity from localized or
 // user-editable display names.
@@ -985,6 +966,9 @@ func convertMailFolder(value models.MailFolderable) MailFolder {
 	}
 	if value.GetUnreadItemCount() != nil {
 		folder.UnreadCount = *value.GetUnreadItemCount()
+	}
+	if value.GetChildFolderCount() != nil {
+		folder.ChildFolderCount = *value.GetChildFolderCount()
 	}
 	if value.GetParentFolderId() != nil {
 		folder.ParentFolderID = *value.GetParentFolderId()

--- a/internal/graphapi/mail_folders.go
+++ b/internal/graphapi/mail_folders.go
@@ -1,0 +1,235 @@
+package graphapi
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
+)
+
+const (
+	mailFolderPageSize         int32 = 100
+	mailFolderDisplayNameField       = "displayName"
+	mailFolderParentIDField          = "parentFolderId"
+)
+
+var mailFolderSelectFields = []string{
+	"id",
+	mailFolderDisplayNameField,
+	"totalItemCount",
+	"unreadItemCount",
+	"childFolderCount",
+	mailFolderParentIDField,
+}
+
+type mailFolderPage struct {
+	values   []models.MailFolderable
+	nextLink string
+}
+
+// ListMailFolders returns every visible folder in the target mailbox, or in
+// the signed-in user's mailbox when target is empty. Graph's /mailFolders
+// collection contains only the folders immediately below the mailbox root, so
+// each folder that reports children is traversed through /childFolders.
+func (c *Client) ListMailFolders(ctx context.Context, target string) ([]MailFolder, error) {
+	rootFolders, err := c.listMailFolderCollection(ctx, target, "")
+	if err != nil {
+		return nil, fmt.Errorf("listing folders: %w", err)
+	}
+
+	result := make([]MailFolder, 0, len(rootFolders))
+	queue := append([]models.MailFolderable(nil), rootFolders...)
+	seen := make(map[string]struct{}, len(rootFolders))
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		value := queue[0]
+		queue = queue[1:]
+		if value == nil || value.GetId() == nil || *value.GetId() == "" {
+			return nil, fmt.Errorf("folder collection contains a folder without an ID")
+		}
+		id := *value.GetId()
+		if _, exists := seen[id]; exists {
+			return nil, fmt.Errorf("folder traversal contains duplicate folder ID %q", id)
+		}
+		seen[id] = struct{}{}
+		result = append(result, convertMailFolder(value))
+
+		if value.GetChildFolderCount() == nil || *value.GetChildFolderCount() == 0 {
+			continue
+		}
+		children, err := c.listMailFolderCollection(ctx, target, id)
+		if err != nil {
+			return nil, fmt.Errorf("listing child folders under folder %q: %w", id, err)
+		}
+		queue = append(queue, children...)
+	}
+	return result, nil
+}
+
+// ResolveMailFolderPath turns a display-name path such as Inbox/2026 into the
+// ID Graph requires. A slash-bearing value whose first component does not name
+// a top-level folder is left unchanged so existing Graph IDs containing slash
+// characters remain valid inputs.
+func (c *Client) ResolveMailFolderPath(ctx context.Context, target, reference string) (string, error) {
+	if !strings.Contains(reference, "/") {
+		return reference, nil
+	}
+	parts := strings.Split(reference, "/")
+	rootFolders, err := c.listMailFolderCollection(ctx, target, "")
+	if err != nil {
+		return "", fmt.Errorf("resolving mail folder path %q: %w", reference, err)
+	}
+
+	current, err := matchMailFolderName(rootFolders, parts[0])
+	if err != nil {
+		return "", fmt.Errorf("resolving mail folder path %q: %w", reference, err)
+	}
+	if current == nil {
+		return reference, nil
+	}
+	for i := 1; i < len(parts); i++ {
+		if parts[i] == "" {
+			return "", fmt.Errorf("mail folder path %q contains an empty component", reference)
+		}
+		children, err := c.listMailFolderCollection(ctx, target, derefStr(current.GetId()))
+		if err != nil {
+			return "", fmt.Errorf("resolving mail folder path %q below %q: %w", reference, parts[i-1], err)
+		}
+		next, err := matchMailFolderName(children, parts[i])
+		if err != nil {
+			return "", fmt.Errorf("resolving mail folder path %q: %w", reference, err)
+		}
+		if next == nil {
+			return "", fmt.Errorf("mail folder path %q: component %q not found below %q", reference, parts[i], parts[i-1])
+		}
+		current = next
+	}
+	return derefStr(current.GetId()), nil
+}
+
+func matchMailFolderName(folders []models.MailFolderable, name string) (models.MailFolderable, error) {
+	if name == "" {
+		return nil, nil
+	}
+	exact := make([]models.MailFolderable, 0, 1)
+	folded := make([]models.MailFolderable, 0, 1)
+	for _, folder := range folders {
+		if folder == nil || folder.GetDisplayName() == nil {
+			continue
+		}
+		displayName := *folder.GetDisplayName()
+		if displayName == name {
+			exact = append(exact, folder)
+		} else if strings.EqualFold(displayName, name) {
+			folded = append(folded, folder)
+		}
+	}
+	matches := exact
+	if len(matches) == 0 {
+		matches = folded
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("folder name %q is ambiguous; use a folder ID", name)
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	return matches[0], nil
+}
+
+func (c *Client) listMailFolderCollection(ctx context.Context, target, parentID string) ([]models.MailFolderable, error) {
+	first := func(ctx context.Context) (mailFolderPage, error) {
+		top := mailFolderPageSize
+		if parentID == "" {
+			response, err := c.targetUser(target).MailFolders().Get(ctx, &users.ItemMailFoldersRequestBuilderGetRequestConfiguration{
+				QueryParameters: &users.ItemMailFoldersRequestBuilderGetQueryParameters{
+					Top:    &top,
+					Select: mailFolderSelectFields,
+				},
+			})
+			return mailFolderPageFrom(response, err)
+		}
+		response, err := c.targetUser(target).MailFolders().ByMailFolderId(parentID).ChildFolders().Get(ctx, &users.ItemMailFoldersItemChildFoldersRequestBuilderGetRequestConfiguration{
+			QueryParameters: &users.ItemMailFoldersItemChildFoldersRequestBuilderGetQueryParameters{
+				Top:    &top,
+				Select: mailFolderSelectFields,
+			},
+		})
+		return mailFolderPageFrom(response, err)
+	}
+
+	next := func(ctx context.Context, nextLink string) (mailFolderPage, error) {
+		collection := "mailFolders"
+		if parentID != "" {
+			collection += "/" + url.PathEscape(parentID) + "/childFolders"
+		}
+		if err := validateGraphContinuation(nextLink, graphContinuationScope{
+			host:           defaultGraphAPIHost,
+			collectionPath: graphUserCollectionPath(target, collection),
+		}); err != nil {
+			return mailFolderPage{}, err
+		}
+		if parentID == "" {
+			response, err := users.NewItemMailFoldersRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
+			return mailFolderPageFrom(response, err)
+		}
+		response, err := users.NewItemMailFoldersItemChildFoldersRequestBuilder(nextLink, c.inner.GetAdapter()).Get(ctx, nil)
+		return mailFolderPageFrom(response, err)
+	}
+
+	page, err := first(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]models.MailFolderable, 0, len(page.values))
+	seenIDs := make(map[string]struct{})
+	seenLinks := make(map[string]struct{})
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if len(page.values) == 0 && page.nextLink != "" {
+			return nil, fmt.Errorf("folder continuation made no progress")
+		}
+		for _, folder := range page.values {
+			if folder == nil || folder.GetId() == nil || *folder.GetId() == "" {
+				return nil, fmt.Errorf("folder collection contains a folder without an ID")
+			}
+			id := *folder.GetId()
+			if _, exists := seenIDs[id]; exists {
+				return nil, fmt.Errorf("folder collection contains duplicate folder ID %q", id)
+			}
+			seenIDs[id] = struct{}{}
+			result = append(result, folder)
+		}
+		if page.nextLink == "" {
+			return result, nil
+		}
+		if _, exists := seenLinks[page.nextLink]; exists {
+			return nil, fmt.Errorf("folder continuation repeated a previous URL")
+		}
+		seenLinks[page.nextLink] = struct{}{}
+		page, err = next(ctx, page.nextLink)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func mailFolderPageFrom(response models.MailFolderCollectionResponseable, err error) (mailFolderPage, error) {
+	if err != nil {
+		return mailFolderPage{}, err
+	}
+	if response == nil {
+		return mailFolderPage{}, errNilMailFolderResponse
+	}
+	return mailFolderPage{
+		values:   response.GetValue(),
+		nextLink: derefStr(response.GetOdataNextLink()),
+	}, nil
+}

--- a/internal/graphapi/mail_folders_test.go
+++ b/internal/graphapi/mail_folders_test.go
@@ -1,0 +1,213 @@
+package graphapi
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestListMailFoldersTraversesVisibleChildren(t *testing.T) {
+	requests := make([]string, 0, 3)
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests = append(requests, req.URL.Path)
+		if got := req.URL.Query().Get("$select"); !strings.Contains(got, "childFolderCount") || !strings.Contains(got, "parentFolderId") {
+			t.Errorf("$select = %q, want traversal fields", got)
+		}
+		switch req.URL.Path {
+		case "/v1.0/users/shared@example.com/mailFolders":
+			return graphJSONResponse(req, `{"value":[
+				{"id":"inbox-id","displayName":"Inbox","childFolderCount":1},
+				{"id":"archive-id","displayName":"Archive","childFolderCount":0}
+			]}`)
+		case "/v1.0/users/shared@example.com/mailFolders/inbox-id/childFolders":
+			return graphJSONResponse(req, `{"value":[
+				{"id":"year-id","displayName":"2026","parentFolderId":"inbox-id","childFolderCount":1}
+			]}`)
+		case "/v1.0/users/shared@example.com/mailFolders/year-id/childFolders":
+			return graphJSONResponse(req, `{"value":[
+				{"id":"receipts-id","displayName":"Receipts","parentFolderId":"year-id","childFolderCount":0}
+			]}`)
+		default:
+			t.Fatalf("unexpected Graph request: %s", req.URL)
+			return nil
+		}
+	})
+
+	folders, err := client.ListMailFolders(context.Background(), "shared@example.com")
+	if err != nil {
+		t.Fatalf("ListMailFolders() error = %v", err)
+	}
+	if got, want := requests, []string{
+		"/v1.0/users/shared@example.com/mailFolders",
+		"/v1.0/users/shared@example.com/mailFolders/inbox-id/childFolders",
+		"/v1.0/users/shared@example.com/mailFolders/year-id/childFolders",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("request paths = %v, want %v", got, want)
+	}
+	if got, want := folderIDs(folders), []string{"inbox-id", "archive-id", "year-id", "receipts-id"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("folder IDs = %v, want breadth-first traversal %v", got, want)
+	}
+	if folders[2].ParentFolderID != "inbox-id" || folders[2].ChildFolderCount != 1 {
+		t.Errorf("converted child folder = %#v, want parent and child count", folders[2])
+	}
+}
+
+func TestListMailFoldersFollowsRootContinuation(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		if requests == 1 {
+			next := "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders?$skiptoken=next"
+			return graphJSONResponse(req, `{"value":[{"id":"one","displayName":"One","childFolderCount":0}],"@odata.nextLink":"`+next+`"}`)
+		}
+		if got := req.URL.Query().Get("$skiptoken"); got != "next" {
+			t.Errorf("continuation skip token = %q, want next", got)
+		}
+		return graphJSONResponse(req, `{"value":[{"id":"two","displayName":"Two","childFolderCount":0}]}`)
+	})
+
+	folders, err := client.ListMailFolders(context.Background(), "shared@example.com")
+	if err != nil {
+		t.Fatalf("ListMailFolders() error = %v", err)
+	}
+	if got, want := folderIDs(folders), []string{"one", "two"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("folder IDs = %v, want %v", got, want)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestResolveMailFolderPathWalksDelegatedMailboxAndChildPages(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		switch requests {
+		case 1:
+			if got := req.URL.Path; got != "/v1.0/users/shared@example.com/mailFolders" {
+				t.Errorf("root path = %q", got)
+			}
+			return graphJSONResponse(req, `{"value":[{"id":"inbox-id","displayName":"Inbox","childFolderCount":2}]}`)
+		case 2:
+			next := "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/inbox-id/childFolders?$skiptoken=next"
+			return graphJSONResponse(req, `{"value":[{"id":"old-id","displayName":"2025","childFolderCount":0}],"@odata.nextLink":"`+next+`"}`)
+		case 3:
+			if got := req.URL.Query().Get("$skiptoken"); got != "next" {
+				t.Errorf("child continuation skip token = %q, want next", got)
+			}
+			return graphJSONResponse(req, `{"value":[{"id":"year-id","displayName":"2026","childFolderCount":0}]}`)
+		default:
+			t.Fatalf("unexpected Graph request: %s", req.URL)
+			return nil
+		}
+	})
+
+	id, err := client.ResolveMailFolderPath(context.Background(), "shared@example.com", "inbox/2026")
+	if err != nil {
+		t.Fatalf("ResolveMailFolderPath() error = %v", err)
+	}
+	if id != "year-id" {
+		t.Fatalf("resolved ID = %q, want year-id", id)
+	}
+	if requests != 3 {
+		t.Fatalf("requests = %d, want 3", requests)
+	}
+}
+
+func TestResolveMailFolderPathPreservesSlashBearingGraphID(t *testing.T) {
+	requests := 0
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		requests++
+		return graphJSONResponse(req, `{"value":[{"id":"inbox-id","displayName":"Inbox","childFolderCount":0}]}`)
+	})
+
+	const graphID = "AAMkAGVm/AAA="
+	got, err := client.ResolveMailFolderPath(context.Background(), "", graphID)
+	if err != nil {
+		t.Fatalf("ResolveMailFolderPath() error = %v", err)
+	}
+	if got != graphID {
+		t.Fatalf("resolved reference = %q, want original Graph ID %q", got, graphID)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want root lookup only", requests)
+	}
+}
+
+func TestResolveMailFolderPathRejectsMissingAndAmbiguousComponents(t *testing.T) {
+	tests := []struct {
+		name     string
+		children string
+		want     string
+	}{
+		{
+			name:     "missing child",
+			children: `{"value":[]}`,
+			want:     `component "2026" not found`,
+		},
+		{
+			name: "ambiguous child",
+			children: `{"value":[
+				{"id":"one","displayName":"2026","childFolderCount":0},
+				{"id":"two","displayName":"2026","childFolderCount":0}
+			]}`,
+			want: `folder name "2026" is ambiguous`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := 0
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				requests++
+				if requests == 1 {
+					return graphJSONResponse(req, `{"value":[{"id":"inbox-id","displayName":"Inbox","childFolderCount":1}]}`)
+				}
+				return graphJSONResponse(req, tc.children)
+			})
+			id, err := client.ResolveMailFolderPath(context.Background(), "", "Inbox/2026")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ResolveMailFolderPath() = (%q, %v), want %q error", id, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateGraphContinuationAllowsMailFolderCollections(t *testing.T) {
+	tests := []struct {
+		name  string
+		url   string
+		scope graphContinuationScope
+	}{
+		{
+			name:  "root folders",
+			url:   "https://graph.microsoft.com/v1.0/me/mailFolders?$skiptoken=next",
+			scope: continuationScope("graph.microsoft.com", "/v1.0/me/mailFolders"),
+		},
+		{
+			name: "delegated child folders",
+			url:  "https://graph.microsoft.com/v1.0/users/shared@example.com/mailFolders/" + url.PathEscape("AAMk/AAA=") + "/childFolders?$skiptoken=next",
+			scope: continuationScope(
+				"graph.microsoft.com",
+				"/v1.0/users/shared@example.com/mailFolders/"+url.PathEscape("AAMk/AAA=")+"/childFolders",
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateGraphContinuation(tc.url, tc.scope); err != nil {
+				t.Fatalf("validateGraphContinuation() error = %v", err)
+			}
+		})
+	}
+}
+
+func folderIDs(folders []MailFolder) []string {
+	ids := make([]string, len(folders))
+	for i := range folders {
+		ids[i] = folders[i].ID
+	}
+	return ids
+}

--- a/internal/graphapi/mail_pages.go
+++ b/internal/graphapi/mail_pages.go
@@ -203,6 +203,7 @@ const (
 	graphMessageDeltaCollection
 	graphCalendarViewDeltaCollection
 	graphContactsDeltaCollection
+	graphMailFolderCollection
 )
 
 type graphCollectionRoute struct {
@@ -250,10 +251,18 @@ func parseGraphCollectionRoute(path string) (graphCollectionRoute, bool) {
 		route.operation = graphMessageCollection
 		return route, true
 	}
+	if len(collection) == 1 && strings.EqualFold(collection[0], "mailfolders") {
+		route.operation = graphMailFolderCollection
+		return route, true
+	}
 
 	if folderID, consumed, ok := graphMailFolderRoute(collection); ok {
 		route.folderID = folderID
 		collection = collection[consumed:]
+		if len(collection) == 1 && strings.EqualFold(collection[0], "childfolders") {
+			route.operation = graphMailFolderCollection
+			return route, true
+		}
 		if len(collection) == 1 && strings.EqualFold(collection[0], "messages") {
 			route.operation = graphMessageCollection
 			return route, true


### PR DESCRIPTION
## Summary

- recursively traverse visible child mail folders, including Graph continuations
- resolve display-name paths such as Inbox/2026 for mail list and delta
- resolve own-mailbox move destinations without changing delegated-write scope
- preserve slash-bearing Graph folder IDs and reject ambiguous or missing path components

## Testing

- go test -race -count=1 ./...
- go vet ./...
- go build ./...
- go mod tidy with no drift
- golangci-lint run --new-from-rev=main (0 new issues)

No live Microsoft Graph mail operations were performed.