### PR TITLE
contrib: add a live smoke test for delegated mailbox writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Thumbs.db
 # olk binaries dropped into per-platform npm packages by the release pipeline
 npm/olk-*/bin/olk
 npm/olk-*/bin/olk.exe
+
+# Live smoke-test configuration and run output (real mailbox addresses)
+contrib/smoke-delegated-mailbox/config.sh
+contrib/smoke-delegated-mailbox/results/

--- a/contrib/smoke-delegated-mailbox/00-preflight.sh
+++ b/contrib/smoke-delegated-mailbox/00-preflight.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Stage 0 — establishes the preconditions and records the starting state.
+# Every call is a read or a --dry-run, with one honest exception: the two guard
+# probes issue a real send and a real draft-create with --no-send and --no-write
+# set, so they write something only if the guard they are testing is broken.
+# Both are addressed to the operator, so the blast radius of that is one
+# self-addressed message.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+section "Stage 0 — preflight (read-only), run ${RUN_ID}"
+
+require_repo_build
+fact "run_id" "${RUN_ID}"
+fact "binary" "$("${OLK}" version 2>&1 | head -1)"
+
+section "Signed-in accounts"
+run "${OLK}" auth list
+
+section "Delegated read access — which mailboxes answer at all"
+# Full Access on the mailbox and Mail.Read.Shared on the token fail differently,
+# but both surface here. A mailbox that cannot be listed cannot be sent as
+# either, so this decides which of the later stages are worth running.
+for mb in "${SHARED_MAILBOX}" "${CONTROL_MAILBOX}"; do
+  for acct in "${SEND_ACCOUNT}" "${RECIPIENT}"; do
+    olk_as "${acct}" "${mb}" mail folders >/dev/null
+    if [[ "${RUN_STATUS}" -eq 0 ]]; then
+      fact "read.${acct}.${mb}" "ok"
+    else
+      fact "read.${acct}.${mb}" "denied: $(printf '%s' "${RUN_OUTPUT}" | head -1)"
+    fi
+  done
+done
+
+section "Dry runs — does the command name the sending mailbox before it sends?"
+# The defect PR 89 fixes is silent by nature: a send from the wrong identity
+# reports success and is visible only in the recipient's inbox. The dry run is
+# the one place the caller can see the sending identity in advance, so check
+# that it names the shared mailbox and not the signed-in account.
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" --dry-run \
+  mail send -t "${RECIPIENT}" -s "[${TAG}] dry-run send" -b "dry run" --cc "${RECIPIENT}"
+fact "dryrun.send.from" "$(printf '%s' "${RUN_OUTPUT}" | sed -n 's/^ *From: *//p')"
+
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" --dry-run \
+  mail drafts create -t "${RECIPIENT}" -s "[${TAG}] dry-run draft" -b "dry run"
+fact "dryrun.draft.in" "$(printf '%s' "${RUN_OUTPUT}" | sed -n 's/^ *In: *//p')"
+
+section "Delegated item read — mail get against a shared-mailbox id"
+# Folder and list reads are covered above; fetching one message by its
+# mailbox-scoped id is a different request builder and worth its own check.
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail list -n 1 --concise --json --results-only >/dev/null
+PROBE_ID="$(printf '%s' "${RUN_OUTPUT}" | jq -r 'if type=="array" then (first | .id // empty) else empty end' 2>/dev/null || true)"
+if [[ -n "${PROBE_ID}" ]]; then
+  olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail get "${PROBE_ID}" --concise --json --results-only >/dev/null
+  fact "read.mail_get.${SHARED_MAILBOX}" "exit=${RUN_STATUS}"
+else
+  fact "read.mail_get.${SHARED_MAILBOX}" "no message available to fetch"
+fi
+
+section "Capability guards still hold on the delegated paths"
+# --no-send and --no-write are enforced in the graphapi client rather than per
+# command, so they should refuse a delegated send exactly as they refuse an
+# ordinary one. A guard that only covers /me would be a hole worth finding.
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" --no-send \
+  mail send -t "${RECIPIENT}" -s "[${TAG}] guarded" -b "should be refused"
+assert_refused "guard.no-send"
+
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" --no-write \
+  mail drafts create -t "${RECIPIENT}" -s "[${TAG}] guarded" -b "should be refused"
+assert_refused "guard.no-write"
+
+section "Baseline — what is in each Sent Items before anything is sent"
+for target in "${SHARED_MAILBOX}" ""; do
+  label="${target:-own}"
+  olk_as "${SEND_ACCOUNT}" "${target}" mail list --folder SentItems -n 3 --concise --plain
+  fact "baseline.sentitems.${label}" "exit=${RUN_STATUS}"
+done
+
+section "Preflight complete"
+log "Facts recorded in ${FACTS}"
+log "Transcript in ${LOG}"
+log ""
+log "Read the two dryrun.* facts before going further. If either names"
+log "${SEND_ACCOUNT} rather than ${SHARED_MAILBOX}, stop: the binary is not the"
+log "one you think it is, and stage 1 would send from the wrong identity."

--- a/contrib/smoke-delegated-mailbox/01-send.sh
+++ b/contrib/smoke-delegated-mailbox/01-send.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Stage 1 — send as the shared mailbox, then read back who it went out as and
+# where the sent copy was filed.
+#
+# This stage sends real mail. Each send is gated behind a confirmation.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_repo_build
+section "Stage 1 — delegated send, run ${RUN_ID}"
+
+send_and_verify() {
+  local mailbox="$1" label="$2"
+  local marker="[${TAG}] send ${label}"
+
+  if ! confirm "Send as ${mailbox} to ${RECIPIENT}?"; then
+    fact "send.${label}" "skipped by operator"
+    return 0
+  fi
+
+  olk_as "${SEND_ACCOUNT}" "${mailbox}" mail send \
+    -t "${RECIPIENT}" -s "${marker}" \
+    -b "Smoke test for delegated send. Run ${RUN_ID}. Safe to delete."
+  fact "send.${label}.exit" "${RUN_STATUS}"
+  fact "send.${label}.output" "$(printf '%s' "${RUN_OUTPUT}" | head -2 | tr '\n' ' ')"
+
+  if [[ "${RUN_STATUS}" -ne 0 ]]; then
+    # A refusal is a result, not a failed test. Graph answers a missing scope
+    # and a missing Exchange delegation almost identically, so what matters is
+    # whether the error names all three grants the caller has to check.
+    fact "send.${label}.result" "refused — record the full message from the transcript"
+    return 0
+  fi
+
+  # The command reporting success proves only that Graph accepted the request.
+  # The sending identity lives in the filed copy, so read that instead.
+  local sent
+  if sent="$(find_by_subject "${SEND_ACCOUNT}" "${mailbox}" SentItems "${marker}")"; then
+    fact "send.${label}.shared_sentitems" "present"
+    fact "send.${label}.from" "$(printf '%s' "${sent}" | jq -r '.from // "<absent>"')"
+  else
+    fact "send.${label}.shared_sentitems" "ABSENT after 60s — see Sent Items placement note"
+  fi
+
+  # The endpoint PR 89 chose, /users/{mailbox}/sendMail, is supposed to file the
+  # copy in the shared mailbox rather than the sender's own. Confirm the second
+  # half of that claim as well: a copy in both places is a different behaviour
+  # from a copy in one, and mailbox configuration can produce it.
+  if find_by_subject "${SEND_ACCOUNT}" "" SentItems "${marker}" >/dev/null; then
+    fact "send.${label}.own_sentitems" "ALSO PRESENT in ${SEND_ACCOUNT} Sent Items"
+  else
+    fact "send.${label}.own_sentitems" "absent, as expected"
+  fi
+
+  # The recipient's copy is the only artefact that shows what a human sees.
+  if sent="$(find_delivered "${RECIPIENT}" "${marker}")"; then
+    fact "send.${label}.recipient_from" "$(printf '%s' "${sent}" | jq -r '.from // "<absent>"')"
+    fact "send.${label}.recipient_id" "$(printf '%s' "${sent}" | jq -r '.id')"
+  else
+    fact "send.${label}.recipient_from" "not delivered within 60s"
+  fi
+}
+
+send_and_verify "${SHARED_MAILBOX}" "primary"
+
+# The control mailbox has an independently granted delegation. Running both is
+# the only way to notice that one is Send As and the other Send on Behalf Of,
+# since olk prints the same From line for either.
+if [[ -n "${CONTROL_MAILBOX}" ]] &&
+  confirm "Also run the same send against the control mailbox ${CONTROL_MAILBOX}?"; then
+  send_and_verify "${CONTROL_MAILBOX}" "control"
+fi
+
+section "Stage 1 complete — facts in ${FACTS}"

--- a/contrib/smoke-delegated-mailbox/02-drafts.sh
+++ b/contrib/smoke-delegated-mailbox/02-drafts.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Stage 2 — draft create, list, send and delete against the shared mailbox.
+#
+# Drafting is the lower-privilege half of PR 89 and is worth testing on its own:
+# creating a draft in a shared mailbox needs Mail.ReadWrite.Shared and Full
+# Access but not Send As, so a tenant can perfectly well allow this stage and
+# refuse stage 1. Sending the draft is the step that consumes the send grant.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_repo_build
+section "Stage 2 — delegated drafts, run ${RUN_ID}"
+
+MARKER="[${TAG}] draft"
+
+section "Create the draft in ${SHARED_MAILBOX}"
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts create \
+  -t "${RECIPIENT}" -s "${MARKER}" \
+  -b "Smoke test for delegated drafts. Run ${RUN_ID}. Safe to delete."
+fact "draft.create.exit" "${RUN_STATUS}"
+fact "draft.create.output" "$(printf '%s' "${RUN_OUTPUT}" | head -1)"
+
+if [[ "${RUN_STATUS}" -ne 0 ]]; then
+  # Mail.ReadWrite.Shared is not in any default scope set and is not proven by
+  # a working delegated read, so this is the likeliest place for the token to
+  # come up short. Record the message rather than guessing which grant is missing.
+  fact "draft.create.result" "refused — likely Mail.ReadWrite.Shared or Full Access"
+  section "Stage 2 stopped: no draft to send"
+  exit 0
+fi
+
+# `drafts create` prints the id in prose and ignores --json, so read the id back
+# from a listing instead of parsing the success line.
+section "Is the draft in the shared mailbox's Drafts, and not in the sender's?"
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts list -n 25 --json --results-only >/dev/null
+DRAFTS_JSON="${RUN_OUTPUT}"
+DRAFT_ID="$(printf '%s' "${DRAFTS_JSON}" | jq -r --arg m "${MARKER}" \
+  'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | first | .id // empty) else empty end')"
+fact "draft.in_shared_drafts" "${DRAFT_ID:-ABSENT}"
+
+olk_as "${SEND_ACCOUNT}" "" mail drafts list -n 25 --json --results-only >/dev/null
+OWN_HIT="$(printf '%s' "${RUN_OUTPUT}" | jq -r --arg m "${MARKER}" \
+  'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | length) else 0 end' 2>/dev/null || echo "?")"
+fact "draft.in_own_drafts" "${OWN_HIT} match(es) — expect 0"
+
+if [[ -z "${DRAFT_ID}" ]]; then
+  section "Stage 2 stopped: draft id not found in ${SHARED_MAILBOX}"
+  exit 0
+fi
+
+section "Send the draft"
+if confirm "Send the draft from ${SHARED_MAILBOX} to ${RECIPIENT}?"; then
+  olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts send "${DRAFT_ID}"
+  fact "draft.send.exit" "${RUN_STATUS}"
+  fact "draft.send.output" "$(printf '%s' "${RUN_OUTPUT}" | head -2 | tr '\n' ' ')"
+
+  if [[ "${RUN_STATUS}" -eq 0 ]]; then
+    if SENT="$(find_by_subject "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" SentItems "${MARKER}")"; then
+      fact "draft.send.from" "$(printf '%s' "${SENT}" | jq -r '.from // "<absent>"')"
+    else
+      fact "draft.send.from" "sent copy not filed in ${SHARED_MAILBOX} within 60s"
+    fi
+
+    # The same postconditions stage 1 checks, so that a difference between
+    # sending directly and sending a draft would show up rather than hide in a
+    # gap between the two stages.
+    if find_by_subject "${SEND_ACCOUNT}" "" SentItems "${MARKER}" >/dev/null; then
+      fact "draft.send.own_sentitems" "ALSO PRESENT in ${SEND_ACCOUNT} Sent Items"
+    else
+      fact "draft.send.own_sentitems" "absent, as expected"
+    fi
+
+    if RCV="$(find_delivered "${RECIPIENT}" "${MARKER}")"; then
+      fact "draft.send.recipient_from" "$(printf '%s' "${RCV}" | jq -r '.from // "<absent>"')"
+    else
+      fact "draft.send.recipient_from" "not delivered within 60s"
+    fi
+
+    # Sending a draft should consume it: a copy left behind in Drafts would mean
+    # the team sees an unsent message that has in fact gone out.
+    olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts list -n 25 --json --results-only >/dev/null
+    STILL="$(printf '%s' "${RUN_OUTPUT}" | jq -r --arg m "${MARKER}" \
+      'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | length) else 0 end' 2>/dev/null || echo "?")"
+    fact "draft.send.removed_from_drafts" "${STILL} left in Drafts — expect 0"
+  fi
+else
+  # An unsent draft is the honest fallback the docs describe, so leaving it in
+  # place is a valid outcome — but say where it is rather than abandoning it.
+  fact "draft.send" "declined; draft ${DRAFT_ID} left in ${SHARED_MAILBOX}"
+  if confirm "Delete the unsent draft ${DRAFT_ID} from ${SHARED_MAILBOX}?"; then
+    olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts delete "${DRAFT_ID}" --force
+    fact "draft.delete.exit" "${RUN_STATUS}"
+  fi
+fi
+
+section "Stage 2 complete — facts in ${FACTS}"

--- a/contrib/smoke-delegated-mailbox/03-reply-forward.sh
+++ b/contrib/smoke-delegated-mailbox/03-reply-forward.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Stage 3 — reply, reply-all and forward as the shared mailbox.
+#
+# These three read the original from the target mailbox before sending as it, so
+# they need read access on top of the send grants. Message ids are scoped to the
+# mailbox that listed them, which is why the thread is seeded into the shared
+# mailbox first rather than reusing an id from anywhere else.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_repo_build
+section "Stage 3 — delegated reply and forward, run ${RUN_ID}"
+
+SEED_MARKER="[${TAG}] seed"
+
+section "Seed a thread into ${SHARED_MAILBOX}"
+# The seed carries a second recipient so that reply-all has somebody to widen
+# to. Without one it addresses exactly the same people as a plain reply and
+# demonstrates nothing. The sending account is used, because it is an automation
+# account under the operator's control rather than a colleague.
+if ! confirm "Send a seed message from ${RECIPIENT} to ${SHARED_MAILBOX}, cc ${SEND_ACCOUNT}?"; then
+  log "Nothing to reply to. Stopping."
+  exit 0
+fi
+olk_as "${RECIPIENT}" "" mail send \
+  -t "${SHARED_MAILBOX}" --cc "${SEND_ACCOUNT}" -s "${SEED_MARKER}" \
+  -b "Seed message for the delegated reply and forward smoke test. Run ${RUN_ID}."
+assert_ok "seed.send"
+
+section "Find the seed by its mailbox-scoped id"
+if ! SEED="$(find_by_subject "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" Inbox "${SEED_MARKER}")"; then
+  fact "seed.delivered" "not visible in ${SHARED_MAILBOX} Inbox within 60s"
+  log "Check whether an inbox rule filed it elsewhere before treating this as a failure."
+  exit 0
+fi
+SEED_ID="$(printf '%s' "${SEED}" | jq -r '.id')"
+SEED_CONV="$(printf '%s' "${SEED}" | jq -r '.conversationId // ""')"
+fact "seed.id" "${SEED_ID:0:40}..."
+fact "seed.conversationId" "${SEED_CONV:0:40}..."
+
+section "Reply as the mailbox"
+if confirm "Reply as ${SHARED_MAILBOX} to the seed?"; then
+  olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail reply "${SEED_ID}" \
+    -b "Delegated reply. Run ${RUN_ID}."
+  fact "reply.exit" "${RUN_STATUS}"
+  fact "reply.output" "$(printf '%s' "${RUN_OUTPUT}" | head -2 | tr '\n' ' ')"
+  if [[ "${RUN_STATUS}" -eq 0 ]]; then
+    if SENT="$(find_by_subject "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" SentItems "${SEED_MARKER}")"; then
+      fact "reply.from" "$(printf '%s' "${SENT}" | jq -r '.from // "<absent>"')"
+      # Threading is a comparison, not a value: the reply belongs to the seed's
+      # conversation or it started a new one, and only the two together say which.
+      REPLY_CONV="$(printf '%s' "${SENT}" | jq -r '.conversationId // ""')"
+      if [[ -n "${SEED_CONV}" && "${REPLY_CONV}" == "${SEED_CONV}" ]]; then
+        fact "reply.threaded" "yes — same conversationId as the seed"
+      else
+        fact "reply.threaded" "NO — reply ${REPLY_CONV:0:24} vs seed ${SEED_CONV:0:24}"
+      fi
+    else
+      fact "reply.from" "sent copy not filed in ${SHARED_MAILBOX} within 60s"
+    fi
+    # The same two-sided placement check stage 1 makes: a copy in the delegate's
+    # own Sent Items as well would be a different behaviour worth knowing about.
+    if find_by_subject "${SEND_ACCOUNT}" "" SentItems "${SEED_MARKER}" >/dev/null; then
+      fact "reply.own_sentitems" "ALSO PRESENT in ${SEND_ACCOUNT} Sent Items"
+    else
+      fact "reply.own_sentitems" "absent, as expected"
+    fi
+    if RCV="$(find_delivered "${RECIPIENT}" "RE: ${SEED_MARKER}" "${SEED_MARKER}")"; then
+      fact "reply.recipient_from" "$(printf '%s' "${RCV}" | jq -r '.from // "<absent>"')"
+    fi
+  fi
+fi
+
+# Read the current number of filed "RE:" copies rather than assuming the reply
+# above ran, so that skipping it does not make the reply-all check unfalsifiable.
+REPLY_SENT_COUNT="$(count_by_subject "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" SentItems "RE: ${SEED_MARKER}")"
+
+section "Reply-all as the mailbox"
+# Reply-all takes a different Graph endpoint from reply, so a delegation that
+# works for one is not evidence for the other. What distinguishes it here is the
+# recipient list: it should reach the cc'd address as well as the sender.
+if confirm "Reply-all as ${SHARED_MAILBOX} to the seed (reaches ${RECIPIENT} and ${SEND_ACCOUNT})?"; then
+  olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail reply "${SEED_ID}" --reply-all \
+    -b "Delegated reply-all. Run ${RUN_ID}."
+  fact "replyall.exit" "${RUN_STATUS}"
+  fact "replyall.output" "$(printf '%s' "${RUN_OUTPUT}" | head -2 | tr '\n' ' ')"
+  if [[ "${RUN_STATUS}" -eq 0 ]]; then
+    # A reply and a reply-all file copies with byte-identical subjects, so the
+    # presence of a "RE:" copy proves nothing about which of the two produced
+    # it. The count is what distinguishes them, which is why the plain reply
+    # above recorded one before this step ran.
+    if wait_for_count "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" SentItems \
+      "RE: ${SEED_MARKER}" "$((REPLY_SENT_COUNT + 1))" >/dev/null; then
+      fact "replyall.shared_sentitems" "a second RE: copy filed in ${SHARED_MAILBOX}"
+    else
+      fact "replyall.shared_sentitems" "NO second RE: copy filed within 60s"
+    fi
+    # The widening is the point: the cc'd account should have received it, and
+    # it holds no earlier "RE:" copy because a plain reply goes only to the
+    # original sender.
+    if wait_for_count "${SEND_ACCOUNT}" "" Inbox "RE: ${SEED_MARKER}" 1 >/dev/null; then
+      fact "replyall.reached_cc" "yes — the cc'd address received it"
+    else
+      fact "replyall.reached_cc" "NO — the cc'd address did not receive it"
+    fi
+  fi
+fi
+
+section "Forward as the mailbox"
+if confirm "Forward the seed from ${SHARED_MAILBOX} to ${RECIPIENT}?"; then
+  olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail forward "${SEED_ID}" \
+    -t "${RECIPIENT}" -c "Delegated forward. Run ${RUN_ID}."
+  fact "forward.exit" "${RUN_STATUS}"
+  fact "forward.output" "$(printf '%s' "${RUN_OUTPUT}" | head -2 | tr '\n' ' ')"
+  if [[ "${RUN_STATUS}" -eq 0 ]]; then
+    if RCV="$(find_delivered "${RECIPIENT}" "FW: ${SEED_MARKER}" "${SEED_MARKER}")"; then
+      fact "forward.recipient_from" "$(printf '%s' "${RCV}" | jq -r '.from // "<absent>"')"
+    else
+      fact "forward.recipient_from" "not delivered within 60s"
+    fi
+    if find_by_subject "${SEND_ACCOUNT}" "" SentItems "FW: ${SEED_MARKER}" >/dev/null; then
+      fact "forward.own_sentitems" "ALSO PRESENT in ${SEND_ACCOUNT} Sent Items"
+    else
+      fact "forward.own_sentitems" "absent, as expected"
+    fi
+  fi
+fi
+
+section "Negative case — an id from the wrong mailbox"
+# Ids are mailbox-scoped, so one taken from the caller's own mailbox should not
+# resolve against the shared one. This cannot be run with --dry-run: reply
+# returns before it reaches Graph in dry-run mode, so the check would pass
+# whether or not the id resolved. It therefore runs for real, and is gated: if
+# the id does resolve, a reply goes to whoever sent the caller that message.
+if confirm "Run the id-scoping check for real? It sends nothing if the id is correctly rejected, and one reply if olk has the bug."; then
+  olk_as "${SEND_ACCOUNT}" "" mail list -n 1 --concise --json --results-only >/dev/null
+  OWN_ID="$(printf '%s' "${RUN_OUTPUT}" | jq -r 'if type=="array" then (first | .id // empty) else empty end')"
+  if [[ -n "${OWN_ID}" ]]; then
+    # A reply carries the original's subject, so the probe cannot be recognised
+    # by one. Note what sits at the top of Sent Items before it runs instead, so
+    # that a timeout can still be settled by looking at what changed.
+    SENT_TOP_BEFORE="$(newest_id "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" SentItems)"
+    olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail reply "${OWN_ID}" \
+      -b "Smoke test ${RUN_ID}: this should never have been sent. Please ignore."
+    if [[ "${RUN_STATUS}" -eq 0 ]]; then
+      fact "wrong_mailbox_id" "ACCEPTED — an own-mailbox id resolved against ${SHARED_MAILBOX}"
+    elif printf '%s' "${RUN_OUTPUT}" | grep -q 'context deadline exceeded'; then
+      # A client-side timeout is not a refusal. The request reached Graph and its
+      # fate is unknown, so the only honest answer comes from looking at what the
+      # mailbox now holds rather than from the exit status.
+      sleep 20
+      SENT_TOP_AFTER="$(newest_id "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" SentItems)"
+      if [[ -n "${SENT_TOP_AFTER}" && "${SENT_TOP_AFTER}" != "${SENT_TOP_BEFORE}" ]]; then
+        fact "wrong_mailbox_id" "TIMED OUT AND SENT — a new message is at the top of ${SHARED_MAILBOX} Sent Items"
+      else
+        fact "wrong_mailbox_id" "timed out with nothing sent: the request exceeded the client timeout and Sent Items is unchanged"
+      fi
+    else
+      fact "wrong_mailbox_id" "rejected: $(printf '%s' "${RUN_OUTPUT}" | head -1)"
+    fi
+  fi
+fi
+
+section "Stage 3 complete — facts in ${FACTS}"

--- a/contrib/smoke-delegated-mailbox/04-delegation-type.sh
+++ b/contrib/smoke-delegated-mailbox/04-delegation-type.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Stage 4 — decide, for each mailbox, whether the send used Send As or Send on
+# Behalf Of.
+#
+# olk cannot answer this on its own. Both delegations put the shared mailbox in
+# the message's `from` property; the only thing that separates them is `sender`,
+# which carries the delegate under Send on Behalf Of and the mailbox itself
+# under Send As. `sender` is already accepted in the CLI's $select allowlist but
+# is never read into MailMessage or printed, so every olk output looks identical
+# either way. This stage therefore prints what a human has to look at, and
+# records the answer they come back with.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+section "Stage 4 — Send As or Send on Behalf Of, run ${RUN_ID}"
+
+cat <<TEXT | tee -a "${LOG}"
+
+For each message this run produced, open the recipient's copy in Outlook on the
+web as ${RECIPIENT} and read the sender line.
+
+  Send As              the message reads simply as the mailbox:
+                       "Information Security"
+
+  Send on Behalf Of    Outlook renders the delegate too:
+                       "Ben Collier on behalf of Information Security"
+
+If the rendering is ambiguous, take the raw headers, which are not:
+
+  1. Open the message, then the ... menu, then View, then View message source.
+  2. Compare the two headers.
+       From: ...        the mailbox under either delegation
+       Sender: ...      absent or equal to From under Send As;
+                        the delegate's address under Send on Behalf Of.
+
+Search the mailbox for ${TAG} to find every message this run produced.
+
+TEXT
+
+# Only ask about a mailbox this run actually sent as. Recording an answer for a
+# send that was skipped or refused would put an unsupported claim in the report
+# alongside the measured ones, and nothing downstream would tell them apart.
+sent_as() {
+  local mailbox="$1"
+  [[ -f "${FACTS}" ]] || return 1
+  grep -qE "^(send\.[a-z]+|draft|reply|forward)\..*${mailbox}" "${FACTS}" ||
+    grep -qE "^send\.(primary|control)\.from\t.*${mailbox}" "${FACTS}"
+}
+
+record() {
+  local label="$1" reply=""
+  if ! sent_as "${label}"; then
+    fact "delegation.${label}" "not applicable — no successful send as this mailbox in run ${RUN_ID}"
+    return 0
+  fi
+  printf '\n>>> %s — [a]s / [o]n behalf / [u]nknown: ' "${label}" >&2
+  read -r reply
+  case "${reply}" in
+  a | A) fact "delegation.${label}" "observed Send As on this message" ;;
+  o | O) fact "delegation.${label}" "observed Send on Behalf Of on this message" ;;
+  *) fact "delegation.${label}" "not determined" ;;
+  esac
+}
+
+record "${SHARED_MAILBOX}"
+if [[ -n "${CONTROL_MAILBOX}" ]]; then
+  record "${CONTROL_MAILBOX}"
+fi
+
+cat <<'TEXT' | tee -a "${LOG}"
+
+What this establishes, and what it does not.
+
+It establishes which delegation *this message* went out under. It does not
+inventory which grants the mailbox holds, and the difference matters: Exchange
+resolves Send As ahead of Send on Behalf Of when a delegate has both, so
+observing Send As is equally consistent with "only Send As is granted" and with
+"both are granted". Observing Send As therefore never proves Send on Behalf Of
+is absent.
+
+The authoritative inventory is Exchange-side, and needs Exchange Online
+PowerShell rather than Graph, which does not expose mailbox permissions at all:
+
+  Get-RecipientPermission <mailbox>            # Send As
+  Get-Mailbox <mailbox> | fl GrantSendOnBehalfTo   # Send on Behalf Of
+  Get-MailboxPermission <mailbox>              # Full Access
+
+pwsh is not installed on this machine, so that has to be run by somebody who has
+it, or read from the Exchange admin centre. Report the observed behaviour and the
+granted permissions as two separate findings; presenting either as the other is
+the mistake this section exists to prevent.
+
+TEXT
+
+section "Stage 4 complete — facts in ${FACTS}"

--- a/contrib/smoke-delegated-mailbox/05-negative.sh
+++ b/contrib/smoke-delegated-mailbox/05-negative.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Stage 5 — the refusals.
+#
+# PR 89 rewrote these messages precisely because Graph's own answer names none of
+# the three grants a reader has to check: a bare "Access is denied", or an
+# ErrorSendAsDenied that speaks only to the Exchange delegation and says nothing
+# about the token scope. The rewritten text is the artifact under test, and it
+# only reaches a reader in a live refusal, so the wording is recorded verbatim.
+#
+# These probes are real sends and real draft-creates. They write nothing only so
+# long as the refusal fires, which is the thing being tested — so the stage
+# re-establishes that the mailbox is unreachable immediately before each probe
+# rather than trusting a note written earlier, and it never aims at a mailbox
+# whose contents anyone is obliged to keep clean.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_repo_build
+section "Stage 5 — refusal messages, run ${RUN_ID}"
+
+# Pick a mailbox the signed-in account genuinely holds nothing on, and never a
+# compliance, incident or payments queue: this stage sends as it on purpose, so
+# if a probe unexpectedly succeeds the residue should be a stray test message
+# rather than something that lands in an audit.
+NO_ACCESS_MAILBOX="${NO_ACCESS_MAILBOX:-}"
+if [[ -z "${NO_ACCESS_MAILBOX}" ]]; then
+  log "NO_ACCESS_MAILBOX is unset, so the refusal messages are not exercised."
+  log "Set it to a mailbox this account has no permission on to run this stage."
+  exit 0
+fi
+fact "negative.mailbox" "${NO_ACCESS_MAILBOX}"
+
+section "Confirm the premise before relying on it"
+# Everything below assumes this mailbox is unreachable. Access changes, and a
+# stale assumption here is what turns a negative test into an unintended write.
+olk_as "${SEND_ACCOUNT}" "${NO_ACCESS_MAILBOX}" mail folders >/dev/null
+if [[ "${RUN_STATUS}" -eq 0 ]]; then
+  fact "negative.premise" "BROKEN — ${SEND_ACCOUNT} can now read ${NO_ACCESS_MAILBOX}"
+  log "FATAL: this stage sends as a mailbox it expects to be refused, and that"
+  log "       mailbox is now reachable. Set NO_ACCESS_MAILBOX to one this"
+  log "       account genuinely holds nothing on, and do not point it at a"
+  log "       compliance or incident queue."
+  exit 1
+fi
+fact "negative.premise" "confirmed unreachable: $(printf '%s' "${RUN_OUTPUT}" | head -1)"
+fact "negative.read.error" "$(printf '%s' "${RUN_OUTPUT}" | head -1)"
+
+if ! confirm "Run the refusal probes against ${NO_ACCESS_MAILBOX}? Each is a real request that writes only if the refusal fails to fire."; then
+  log "Skipped."
+  exit 0
+fi
+
+section "Send as a mailbox with no delegation"
+# This is the case the hint text was written for. It should name all three
+# grants — Mail.Send.Shared, Send As or Send on Behalf Of, and Full Access —
+# because holding one tells the reader nothing about the other two.
+olk_as "${SEND_ACCOUNT}" "${NO_ACCESS_MAILBOX}" mail send \
+  -t "${RECIPIENT}" -s "[${TAG}] should be refused" \
+  -b "If this arrives, the refusal did not happen and that is the finding."
+if [[ "${RUN_STATUS}" -eq 0 ]]; then
+  fact "negative.send" "NOT REFUSED — a message went out as ${NO_ACCESS_MAILBOX}; clean it up"
+else
+  fact "negative.send.error" "$(printf '%s' "${RUN_OUTPUT}" | tr '\n' ' ')"
+fi
+
+section "Create a draft in a mailbox with no delegation"
+# The draft path needs a different pair of grants from the send path, so its
+# refusal should read differently. If both produce the same text, one of them is
+# misleading.
+olk_as "${SEND_ACCOUNT}" "${NO_ACCESS_MAILBOX}" mail drafts create \
+  -t "${RECIPIENT}" -s "[${TAG}] should be refused" -b "should be refused"
+if [[ "${RUN_STATUS}" -eq 0 ]]; then
+  fact "negative.draft" "NOT REFUSED — a draft was left in ${NO_ACCESS_MAILBOX}; delete it"
+else
+  fact "negative.draft.error" "$(printf '%s' "${RUN_OUTPUT}" | tr '\n' ' ')"
+fi
+
+section "A malformed mailbox value"
+# Validation happens before anything reaches Graph, so this one is safe to run
+# unconditionally and --dry-run does not weaken it.
+olk_as "${SEND_ACCOUNT}" "not-an-address" --dry-run \
+  mail send -t "${RECIPIENT}" -s "[${TAG}] malformed" -b "x"
+assert_refused "negative.malformed_mailbox"
+
+section "Stage 5 complete — quote these messages verbatim in the report"

--- a/contrib/smoke-delegated-mailbox/06-cleanup-and-report.sh
+++ b/contrib/smoke-delegated-mailbox/06-cleanup-and-report.sh
@@ -13,7 +13,7 @@ section "Stage 6 — cleanup, run ${RUN_ID}"
 # be tidied by olk at all, and have to be removed by hand in Outlook. Drafts are
 # the exception, because the draft commands do honour --mailbox.
 section "Drafts left behind in ${SHARED_MAILBOX}"
-olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts list -n 25 --json --results-only >/dev/null
+olk_as_private "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts list -n 25 --json --results-only
 
 # Collect before prompting: a `while read` fed from a pipe would take the
 # operator's keystrokes for each confirmation out of the same stream as the list.

--- a/contrib/smoke-delegated-mailbox/06-cleanup-and-report.sh
+++ b/contrib/smoke-delegated-mailbox/06-cleanup-and-report.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Stage 5 — remove what can be removed, name what cannot, and assemble the
+# report from the recorded facts.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+section "Stage 6 — cleanup, run ${RUN_ID}"
+
+# `mail delete` and `mail move` do not read --mailbox: they are scoped to the
+# signed-in user. So the sent copies this run left in the shared mailbox cannot
+# be tidied by olk at all, and have to be removed by hand in Outlook. Drafts are
+# the exception, because the draft commands do honour --mailbox.
+section "Drafts left behind in ${SHARED_MAILBOX}"
+olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts list -n 25 --json --results-only >/dev/null
+
+# Collect before prompting: a `while read` fed from a pipe would take the
+# operator's keystrokes for each confirmation out of the same stream as the list.
+DRAFT_ROWS=()
+while IFS= read -r row; do
+  [[ -n "${row}" ]] && DRAFT_ROWS+=("${row}")
+done < <(printf '%s' "${RUN_OUTPUT}" | jq -r --arg m "${TAG}" \
+  'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | .[] | "\(.id)\t\(.subject)") else empty end' 2>/dev/null || true)
+
+log "drafts matching ${TAG}: ${#DRAFT_ROWS[@]}"
+for row in ${DRAFT_ROWS[@]+"${DRAFT_ROWS[@]}"}; do
+  id="${row%%$'\t'*}"
+  subject="${row#*$'\t'}"
+  log "draft: ${subject}"
+  if confirm "Delete draft ${id:0:30}... from ${SHARED_MAILBOX}?"; then
+    olk_as "${SEND_ACCOUNT}" "${SHARED_MAILBOX}" mail drafts delete "${id}" --force
+  fi
+done
+
+section "Residue that olk cannot remove"
+cat <<TEXT | tee -a "${LOG}"
+
+Delete these by hand in Outlook on the web, searching for ${TAG}:
+
+  ${SHARED_MAILBOX}   Sent Items, and the seed in Inbox
+  ${CONTROL_MAILBOX:-(no control mailbox set)}  Sent Items, if the control send ran
+  ${RECIPIENT}        Inbox, the delivered copies
+
+mail delete and mail move are scoped to the signed-in user and ignore --mailbox,
+so there is no command-line path to the first two.
+
+TEXT
+
+section "Recorded facts"
+if [[ -f "${FACTS}" ]]; then
+  column -t -s $'\t' "${FACTS}" | tee -a "${LOG}"
+else
+  log "No facts file at ${FACTS} — were the earlier stages run with this RUN_ID?"
+fi
+
+section "Report"
+log "Transcript: ${LOG}"
+log "Facts:      ${FACTS}"
+log ""
+log "Every stage has to be run with the same RUN_ID to share one results"
+log "directory. Export it once and run the stages in order:"
+log ""
+log "  export RUN_ID=${RUN_ID}"

--- a/contrib/smoke-delegated-mailbox/07-mcp-mailbox-scope.sh
+++ b/contrib/smoke-delegated-mailbox/07-mcp-mailbox-scope.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Stage 7 — the agent-facing half of PR 89.
+#
+# The pull request did two things: it made the four write paths honour
+# --mailbox, and it gave the MCP server a mailbox policy — a launch-time
+# --mailbox that every tool call inherits, and an --allow-mailbox list naming
+# the mailboxes a caller may redirect to. Stages 1 to 5 cover the first half.
+# This stage covers the second, which is the surface an agent actually reaches.
+#
+# Nothing here sends: every probe is a tools/list, or a call with --no-send set,
+# so the server refuses before anything leaves the building.
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_repo_build
+section "Stage 7 — MCP mailbox scoping, run ${RUN_ID}"
+
+# One JSON-RPC exchange over stdio. The server speaks the protocol on stdin and
+# stdout, so the request goes in on a pipe and the framed reply comes back out.
+mcp_call() {
+  local body="$1"
+  shift
+  # The pause matters: the server shuts down on stdin EOF, and without it the
+  # pipe closes before the reply is written — which reads as an empty tool list
+  # rather than as the timing problem it is.
+  {
+    printf '%s\n' \
+      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+      '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+      "${body}"
+    sleep "${MCP_SETTLE:-5}"
+  } | "${OLK}" --account "${SEND_ACCOUNT}" --no-input mcp "$@" 2>/dev/null || true
+}
+
+# assert_tools_listed catches the failure mode above: every probe in this stage
+# reads a tool list, and an empty one looks identical to a correct refusal.
+assert_tools_listed() {
+  local count="$1"
+  if [[ "${count}" -eq 0 ]]; then
+    log "FATAL: the server returned no tools at all, so nothing below can be"
+    log "       distinguished from a refusal. Raise MCP_SETTLE and rerun."
+    exit 1
+  fi
+}
+
+section "Which mail tools does a default launch expose?"
+# Read-only by default: the send tier should be absent until it is asked for.
+OUT="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')"
+TOOLS="$(printf '%s' "${OUT}" | jq -rs '[.[] | select(.id==2) | .result.tools[]?.name] | sort | join(",")' 2>/dev/null || true)"
+DEFAULT_COUNT="$(printf '%s' "${TOOLS}" | tr ',' '\n' | grep -c . || true)"
+assert_tools_listed "${DEFAULT_COUNT}"
+fact "mcp.default.tool_count" "${DEFAULT_COUNT}"
+fact "mcp.default.mail_send_exposed" "$(printf '%s' "${TOOLS}" | grep -q 'mail_send' && echo 'EXPOSED — should be off by default' || echo 'no, as expected')"
+
+section "Does --allow-send expose the send tier?"
+OUT="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' --allow-send mail_send)"
+TOOLS="$(printf '%s' "${OUT}" | jq -rs '[.[] | select(.id==2) | .result.tools[]?.name] | sort | join(",")' 2>/dev/null || true)"
+assert_tools_listed "$(printf '%s' "${TOOLS}" | tr ',' '\n' | grep -c . || true)"
+fact "mcp.allow_send.mail_send_exposed" "$(printf '%s' "${TOOLS}" | grep -q 'mail_send' && echo 'yes, as expected' || echo 'NO — --allow-send did not expose it')"
+
+section "Does --no-send outrank --allow-send?"
+# The capability guards are enforced in the graphapi client, so they should hold
+# regardless of what the server was told to expose.
+OUT="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' --allow-send mail_send --no-send)"
+TOOLS="$(printf '%s' "${OUT}" | jq -rs '[.[] | select(.id==2) | .result.tools[]?.name] | sort | join(",")' 2>/dev/null || true)"
+assert_tools_listed "$(printf '%s' "${TOOLS}" | tr ',' '\n' | grep -c . || true)"
+fact "mcp.no_send_beats_allow_send" "$(printf '%s' "${TOOLS}" | grep -q 'mail_send' && echo 'EXPOSED — guard did not apply' || echo 'not exposed, as expected')"
+
+section "A malformed --allow-mailbox is refused at launch"
+# Refused outright rather than dropped with a warning: a mistyped mailbox would
+# otherwise leave agents believing a mailbox is reachable when no call can name it.
+# Validation happens in Run, so the server has to be started for real; --help
+# would short-circuit before the flag is ever parsed and prove nothing.
+OUT="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' --allow-mailbox "not-an-address")"
+if printf '%s' "${OUT}" | jq -rs '[.[] | select(.id==2) | .result.tools[]?.name] | length' 2>/dev/null | grep -qv '^0$'; then
+  fact "mcp.malformed_allow_mailbox" "STARTED ANYWAY — a mistyped mailbox was accepted"
+else
+  fact "mcp.malformed_allow_mailbox" "refused to start, as expected"
+fi
+
+section "Launch-time --mailbox reaches a tool call"
+# With a launch mailbox set and no --allow-mailbox, every call should act on
+# that mailbox. mail_list is read-only, so this is safe to run for real.
+# The tool takes `top`, not the CLI's `-n`: MCP argument names follow the long
+# flags. A wrong name comes back as invalid_input rather than as an empty
+# result, so the reply is checked for an error before anything is concluded.
+mcp_mail_list() {
+  local out
+  out="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"mail_list","arguments":{"top":3,"concise":true}}}' "$@")"
+  printf '%s' "${out}" | jq -rs '[.[] | select(.id==2)] | first | (.result.content[0].text // .error.message // "no reply")' 2>/dev/null || echo "unparseable"
+}
+
+SCOPED="$(mcp_mail_list --mailbox "${SHARED_MAILBOX}")"
+UNSCOPED="$(mcp_mail_list)"
+printf 'scoped:\n%s\nunscoped:\n%s\n' "${SCOPED:0:800}" "${UNSCOPED:0:800}" >>"${LOG}"
+
+if printf '%s' "${SCOPED}" | grep -q '"code"'; then
+  fact "mcp.launch_mailbox_applied" "tool call errored: $(printf '%s' "${SCOPED}" | head -c 120)"
+else
+  # Two listings of two different mailboxes should not return the same message
+  # ids. Identical ids would mean the launch mailbox was accepted and ignored —
+  # the same silent failure on the agent surface that PR 89 fixed on the CLI.
+  SCOPED_IDS="$(printf '%s' "${SCOPED}" | jq -rc '[.. | objects | .id? // empty] | sort' 2>/dev/null || echo '[]')"
+  UNSCOPED_IDS="$(printf '%s' "${UNSCOPED}" | jq -rc '[.. | objects | .id? // empty] | sort' 2>/dev/null || echo '[]')"
+  fact "mcp.scoped_senders" "$(printf '%s' "${SCOPED}" | jq -rc '[.. | objects | .from? // empty] | unique' 2>/dev/null || echo '?')"
+  fact "mcp.unscoped_senders" "$(printf '%s' "${UNSCOPED}" | jq -rc '[.. | objects | .from? // empty] | unique' 2>/dev/null || echo '?')"
+  if [[ "${SCOPED_IDS}" == "[]" ]]; then
+    fact "mcp.launch_mailbox_applied" "inconclusive — no message ids parsed from the reply"
+  elif [[ "${SCOPED_IDS}" == "${UNSCOPED_IDS}" ]]; then
+    fact "mcp.launch_mailbox_applied" "NO — --mailbox at launch returned the caller's own mail"
+  else
+    fact "mcp.launch_mailbox_applied" "yes — the scoped listing differs from the unscoped one"
+  fi
+fi
+
+section "Stage 7 complete — facts in ${FACTS}"

--- a/contrib/smoke-delegated-mailbox/README.md
+++ b/contrib/smoke-delegated-mailbox/README.md
@@ -1,0 +1,108 @@
+# Delegated-mailbox smoke test
+
+A live-tenant harness for the `--mailbox` write paths: send, draft create and
+send, reply, reply-all and forward as a shared mailbox.
+
+None of this can be covered by unit tests. Whether a delegated send succeeds is
+decided by Exchange permissions and token scopes rather than by anything in this
+repository, and where the sent copy is filed is decided by a mailbox setting on
+the tenant. The only way to know is to send a message and look.
+
+**These stages send real mail from a real identity to real people, and it cannot
+be recalled.** Every send asks first. `SMOKE_ASSUME_YES=1` removes that gate and
+is deliberately not the default.
+
+## Setup
+
+```bash
+make build                       # the harness refuses any other binary
+cd contrib/smoke-delegated-mailbox
+cp config.example.sh config.sh
+$EDITOR config.sh
+source ./config.sh
+./00-preflight.sh                # read-only; start here
+```
+
+`00-preflight.sh` sends nothing. It confirms the binary, proves which mailboxes
+answer, and checks that `--dry-run` names the shared mailbox rather than the
+signed-in account. If a dry run names the wrong identity, stop: the binary is
+not the one you think it is, and the sending stages would send as the wrong
+sender.
+
+Then either walk the stages individually or run the lot:
+
+```bash
+./run-all.sh
+```
+
+Each run gets an identifier, every subject carries it as `OLK-SMOKE-<id>`, and
+results land in `results/<id>/` as a transcript and a table of recorded facts.
+
+## What each stage does
+
+| Stage | Sends? | Covers |
+|---|---|---|
+| `00-preflight` | no | binary identity, delegated reads, dry runs, `--no-write` and `--no-send`, Sent Items baseline |
+| `07-mcp-mailbox-scope` | no | tool exposure by tier, `--allow-send`, `--no-send` precedence, launch-time `--mailbox` |
+| `01-send` | yes | `mail send` as the mailbox; `from`, Sent Items placement, delivery |
+| `02-drafts` | yes | draft created in the mailbox's Drafts, sent from it, removed after |
+| `03-reply-forward` | yes | reply, reply-all, forward; threading; identifier scoping |
+| `05-negative` | attempts | what a refusal looks like on a mailbox with no delegation |
+| `04-delegation-type` | no | guided reading of the received headers, by a human |
+| `06-cleanup-and-report` | no | removes what it can, names what it cannot, prints the facts |
+
+## The three grants
+
+A delegated send needs all of the following, and holding one implies nothing
+about the others:
+
+1. **`Mail.Send.Shared`** in the token. It is not in the default scope set;
+   request it at login with `--scope Mail.Send.Shared`.
+2. **Send As** or **Send on Behalf Of** on the mailbox, granted in Exchange.
+3. **Full Access** on the mailbox. Microsoft requires it for
+   `/users/{mailbox}/sendMail` even though the name suggests otherwise.
+
+A missing Full Access grant does not say so. It surfaces as:
+
+```
+ErrorItemNotFound: The specified object was not found in the store.
+```
+
+## Send As versus Send on Behalf Of
+
+Stage 4 has a human read the received headers, because olk cannot answer this:
+the `sender` field is not an available selector, there is no raw message output,
+and Graph exposes no mailbox permissions at all.
+
+It also cannot be answered by inference. **Exchange resolves Send As ahead of
+Send on Behalf Of when a delegate holds both**, so observing Send As is equally
+consistent with "only Send As is granted" and with "both are granted".
+Observing Send As never proves Send on Behalf Of is absent.
+
+Report what a message did and what a mailbox was granted as two separate
+findings. The grants are Exchange-side:
+
+```powershell
+Get-RecipientPermission <mailbox>                  # Send As
+Get-Mailbox <mailbox> | fl GrantSendOnBehalfTo     # Send on Behalf Of
+Get-MailboxPermission <mailbox>                    # Full Access
+```
+
+## Reading the results
+
+Three outcomes look alike in an exit status and are not alike at all:
+
+- **Refused.** olk or Graph rejected the request; nothing was sent.
+- **Timed out.** The request reached Graph and the client gave up waiting. What
+  the server did is unknown, and only the mailbox can settle it. The harness
+  detects this and re-reads Sent Items rather than calling it a refusal.
+- **Not found where expected.** A message can be delivered and filed out of the
+  Inbox by a rule within seconds. An Inbox-only check reports that as a
+  non-delivery, so the delivery checks fall back to a mailbox-wide search.
+
+## Cleanup
+
+`06-cleanup-and-report` deletes the drafts it can reach and then names what it
+cannot. `mail delete` and `mail move` are scoped to the signed-in user and
+ignore `--mailbox`, so anything filed in a shared mailbox has to be removed by
+hand. Search for the run identifier, which every subject carries.

--- a/contrib/smoke-delegated-mailbox/config.example.sh
+++ b/contrib/smoke-delegated-mailbox/config.example.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copy to config.sh, fill in, and source before running any stage:
+#
+#   cp config.example.sh config.sh
+#   $EDITOR config.sh
+#   source ./config.sh && ./run-all.sh
+#
+# config.sh is ignored by git. Nothing here is secret, but mailbox addresses
+# name real people and belong in nobody's commit history but your own.
+
+# Required. The signed-in account that holds the delegation. It must already be
+# authenticated: `olk auth login --enterprise --scope Mail.Send.Shared`.
+export SEND_ACCOUNT="delegate@example.com"
+
+# Required. The shared mailbox to act as. The signed-in account needs all three
+# of Mail.Send.Shared in the token, Send As or Send on Behalf Of in Exchange,
+# and Full Access on the mailbox. Holding one implies nothing about the others,
+# and Graph reports a missing Full Access grant as an unrelated-looking
+# "ErrorItemNotFound".
+export SHARED_MAILBOX="shared-mailbox@example.com"
+
+# Required. Where the test messages are sent. Use an account you can read, since
+# several checks confirm what actually arrived.
+export RECIPIENT="recipient@example.com"
+
+# Optional. A second shared mailbox whose delegation was granted separately.
+# Worth setting if the two mailboxes differ in how they were delegated, because
+# olk prints the same From line for Send As and Send on Behalf Of and only the
+# received headers tell them apart. Stages skip it when unset.
+# export CONTROL_MAILBOX="second-mailbox@example.com"
+
+# Optional. A mailbox the signed-in account has no permission on at all, used to
+# record what a refusal looks like. Stage 5 sends as it deliberately, so pick
+# something inert: never a compliance, incident, payments or legal queue. The
+# stage re-checks that the mailbox is genuinely unreachable before probing, and
+# skips itself when unset.
+# export NO_ACCESS_MAILBOX="no-access-mailbox@example.com"
+
+# Optional. Defaults to bin/olk in the checkout. Point it elsewhere only if you
+# know the binary was built from the commit you are testing.
+# export OLK="/path/to/olk"
+
+# Optional. Defaults to the checkout's HEAD. Set it when testing a binary built
+# from a different commit; the preflight refuses to run against a mismatch.
+# export EXPECTED_COMMIT="abc1234"
+
+# Optional. Answers every send confirmation with yes. Think twice: the stages
+# send real mail from a live identity to real people, and it cannot be recalled.
+# export SMOKE_ASSUME_YES=1

--- a/contrib/smoke-delegated-mailbox/lib.sh
+++ b/contrib/smoke-delegated-mailbox/lib.sh
@@ -86,6 +86,37 @@ run() {
   return 0
 }
 
+# run_private is run for commands whose output must not be archived. The
+# transcript is the point of this harness, but a full listing of a shared
+# mailbox is not this run's residue: it is other people's mail, and writing it
+# to disk outlives the test by as long as nobody remembers to delete it.
+# Callers still get RUN_OUTPUT to parse; the log gets a note instead.
+#
+# Projecting the payload down at the source would be better, but --concise and
+# --select are both ignored by `mail drafts list`, so the caller cannot ask for
+# less than the whole draft. Withholding it here is the remaining lever.
+run_private() {
+  log "\$ $*"
+  local out status=0
+  out="$("$@" 2>&1)" || status=$?
+  log "[output withheld from transcript: $(printf '%s' "${out}" | wc -c | tr -d ' ') bytes]"
+  # shellcheck disable=SC2034  # both are read by the sourcing stage scripts.
+  RUN_OUTPUT="${out}"
+  # shellcheck disable=SC2034
+  RUN_STATUS="${status}"
+  return 0
+}
+
+olk_as_private() {
+  local account="$1" mailbox="$2"
+  shift 2
+  if [[ -n "${mailbox}" ]]; then
+    run_private "${OLK}" --account "${account}" --mailbox "${mailbox}" "${OLK_COMMON[@]}" "$@"
+  else
+    run_private "${OLK}" --account "${account}" "${OLK_COMMON[@]}" "$@"
+  fi
+}
+
 olk_as() {
   local account="$1" mailbox="$2"
   shift 2

--- a/contrib/smoke-delegated-mailbox/lib.sh
+++ b/contrib/smoke-delegated-mailbox/lib.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Shared configuration and helpers for the olk delegated-mailbox smoke test.
+# Sourced by every numbered stage; not runnable on its own.
+
+set -euo pipefail
+
+SMOKE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SMOKE_DIR}/../.." && pwd)"
+
+# Pin the repository build by full path. A binary found on PATH is most likely
+# the released one, and any build predating the delegated-write work accepts
+# --mailbox on a send and ignores it, which turns every assertion here into a
+# false pass. The expected commit follows the checkout rather than being frozen,
+# so the guard keeps working as the repository moves.
+OLK="${OLK:-${REPO_DIR}/bin/olk}"
+EXPECTED_COMMIT="${EXPECTED_COMMIT:-$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || true)}"
+
+# require_env fails by name rather than falling back to somebody else's mailbox.
+# These addresses decide who receives real mail, so a forgotten variable has to
+# stop the run, not pick a default.
+require_env() {
+  local name="$1" purpose="$2"
+  if [[ -z "${!name:-}" ]]; then
+    printf 'FATAL: %s is not set (%s).\n' "${name}" "${purpose}" >&2
+    printf '       Copy config.example.sh, fill it in, and source it first.\n' >&2
+    exit 1
+  fi
+}
+
+# Who signs in, which mailbox is targeted, and who receives the test mail.
+require_env SEND_ACCOUNT "the signed-in account that holds the delegation"
+require_env SHARED_MAILBOX "the shared mailbox to send as"
+require_env RECIPIENT "the address the test messages are sent to"
+
+# Optional. A second mailbox whose delegation was granted independently: sending
+# as both is the only way to notice that one is Send As and the other Send on
+# Behalf Of. Stages that need it skip themselves when it is unset.
+CONTROL_MAILBOX="${CONTROL_MAILBOX:-}"
+
+# Every subject carries the run identifier so that verification can match on it
+# and a human reading the mailbox knows at a glance what the message is.
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+# shellcheck disable=SC2034  # read by the sourcing stage scripts, not here.
+TAG="OLK-SMOKE-${RUN_ID}"
+
+RESULTS_DIR="${SMOKE_DIR}/results/${RUN_ID}"
+mkdir -p "${RESULTS_DIR}"
+
+LOG="${RESULTS_DIR}/transcript.log"
+FACTS="${RESULTS_DIR}/facts.tsv"
+
+# Guards that belong on every call. --no-input turns a prompt into a failure
+# rather than a hang; the send guards are lifted per-command, deliberately.
+OLK_COMMON=(--no-input)
+
+log() {
+  printf '%s\n' "$*" | tee -a "${LOG}"
+}
+
+section() {
+  log ""
+  log "=============================================================="
+  log "$*"
+  log "=============================================================="
+}
+
+# fact records one observation as a tab-separated row, so the final report is
+# assembled from recorded results rather than from memory.
+fact() {
+  local key="$1" value="$2"
+  printf '%s\t%s\n' "${key}" "${value}" >>"${FACTS}"
+  log "  [fact] ${key} = ${value}"
+}
+
+# run echoes a command before running it and captures both streams, so the
+# transcript shows exactly what was issued even when a call fails.
+run() {
+  log "\$ $*"
+  local out status=0
+  out="$("$@" 2>&1)" || status=$?
+  printf '%s\n' "${out}" | tee -a "${LOG}"
+  # shellcheck disable=SC2034  # both are read by the sourcing stage scripts.
+  RUN_OUTPUT="${out}"
+  # shellcheck disable=SC2034
+  RUN_STATUS="${status}"
+  return 0
+}
+
+olk_as() {
+  local account="$1" mailbox="$2"
+  shift 2
+  if [[ -n "${mailbox}" ]]; then
+    run "${OLK}" --account "${account}" --mailbox "${mailbox}" "${OLK_COMMON[@]}" "$@"
+  else
+    run "${OLK}" --account "${account}" "${OLK_COMMON[@]}" "$@"
+  fi
+}
+
+# confirm is the gate in front of anything that puts mail in front of a real
+# person. Outbound mail cannot be recalled, so each send is agreed separately.
+confirm() {
+  local prompt="$1"
+  if [[ "${SMOKE_ASSUME_YES:-}" == "1" ]]; then
+    log "[confirm] ${prompt} -> auto-yes (SMOKE_ASSUME_YES=1)"
+    return 0
+  fi
+  local reply=""
+  printf '\n>>> %s [y/N] ' "${prompt}" >&2
+  read -r reply
+  case "${reply}" in
+  y | Y | yes | YES)
+    log "[confirm] ${prompt} -> yes"
+    return 0
+    ;;
+  *)
+    log "[confirm] ${prompt} -> declined, skipping"
+    return 1
+    ;;
+  esac
+}
+
+# find_by_subject polls a folder for a message whose subject carries a marker.
+# Exchange files a sent copy asynchronously, so a single immediate read reports
+# a false absence; poll rather than sleep once and guess.
+find_by_subject() {
+  local account="$1" mailbox="$2" folder="$3" marker="$4"
+  local attempt json err
+  err="$(mktemp)"
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    if [[ -n "${mailbox}" ]]; then
+      json="$("${OLK}" --account "${account}" --mailbox "${mailbox}" --no-input \
+        mail list --folder "${folder}" -n 25 --concise --json --results-only 2>"${err}" || true)"
+    else
+      json="$("${OLK}" --account "${account}" --no-input \
+        mail list --folder "${folder}" -n 25 --concise --json --results-only 2>"${err}" || true)"
+    fi
+    # A listing that failed outright is not the same as a message that has not
+    # arrived, and silently retrying past an authentication or permission error
+    # would report it as a false absence.
+    if [[ -s "${err}" ]]; then
+      log "  ! listing ${folder} in ${mailbox:-own mailbox} failed: $(head -1 "${err}")" >&2
+    fi
+    if [[ -n "${json}" ]]; then
+      local hit
+      hit="$(printf '%s' "${json}" | jq -c --arg m "${marker}" \
+        'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | first) else empty end' 2>/dev/null || true)"
+      if [[ -n "${hit}" && "${hit}" != "null" ]]; then
+        rm -f "${err}"
+        printf '%s' "${hit}"
+        return 0
+      fi
+    fi
+    # Progress goes to stderr: this function's stdout is the JSON its callers
+    # capture, and a retry line printed there would corrupt it.
+    log "  ... not filed yet (attempt ${attempt}/10), waiting 6s" >&2
+    sleep 6
+  done
+  rm -f "${err}"
+  return 1
+}
+
+# assert_refused turns "the guard did not fire" into a loud failure rather than
+# a recorded zero. A guard that silently stopped working would otherwise let the
+# stage carry on having sent the message it was meant to prevent.
+assert_refused() {
+  local label="$1"
+  if [[ "${RUN_STATUS}" -eq 0 ]]; then
+    fact "${label}" "DID NOT REFUSE — the guard is broken and the operation went through"
+    log "FATAL: ${label} was expected to be refused and was not. Stopping before"
+    log "       any further stage compounds it."
+    exit 1
+  fi
+  fact "${label}" "refused (exit ${RUN_STATUS}): $(printf '%s' "${RUN_OUTPUT}" | head -1)"
+}
+
+# assert_ok stops the stage when a step every later step depends on has failed,
+# which `run` alone will not do: it captures the status rather than raising it.
+assert_ok() {
+  local label="$1"
+  if [[ "${RUN_STATUS}" -ne 0 ]]; then
+    fact "${label}" "FAILED (exit ${RUN_STATUS}): $(printf '%s' "${RUN_OUTPUT}" | head -2 | tr '\n' ' ')"
+    log "FATAL: ${label} failed; the rest of this stage depends on it."
+    exit 1
+  fi
+  fact "${label}" "ok"
+}
+
+require_repo_build() {
+  if [[ ! -x "${OLK}" ]]; then
+    log "FATAL: ${OLK} is missing. Build it with 'make build' in ${REPO_DIR}."
+    log "       A fresh build is a new code-signing identity, so macOS will raise"
+    log "       a Keychain prompt that a human has to answer with Always Allow."
+    exit 1
+  fi
+  local version
+  version="$("${OLK}" version 2>&1)"
+  log "binary: ${OLK}"
+  log "version: ${version}"
+  if [[ -z "${EXPECTED_COMMIT}" ]]; then
+    log "FATAL: could not read the checkout's commit, and EXPECTED_COMMIT is unset."
+    log "       Set it to the commit the binary was built from, or run this from a"
+    log "       git checkout so that it can be derived."
+    exit 1
+  fi
+  if [[ "${version}" != *"${EXPECTED_COMMIT}"* ]]; then
+    log "FATAL: expected a build at commit ${EXPECTED_COMMIT}; got the line above."
+    log "       Run 'make build', or set EXPECTED_COMMIT if you are deliberately"
+    log "       testing another build. A binary older than the delegated-write"
+    log "       work accepts --mailbox on a send and ignores it, which makes"
+    log "       every assertion here pass for the wrong reason."
+    exit 1
+  fi
+}
+
+# find_delivered answers "did the recipient get it", which is not the same
+# question as "is it in the Inbox". A server-side rule can file a message the
+# moment it lands, and the 24 August run recorded a false absence for exactly
+# that reason: the message arrived, a rule moved it to Archive, and a poll of
+# the Inbox alone never saw it. Poll the Inbox first, because that is the common
+# case and the listing is cheap, then fall back to a mailbox-wide search.
+find_delivered() {
+  local account="$1" marker="$2" query="${3:-$2}"
+  local hit json
+  if hit="$(find_by_subject "${account}" "" Inbox "${marker}")"; then
+    printf '%s' "${hit}"
+    return 0
+  fi
+  log "  ... not in the Inbox; searching the whole mailbox" >&2
+  json="$("${OLK}" --account "${account}" --no-input \
+    mail search "${query}" -n 25 --concise --json --results-only 2>/dev/null || true)"
+  hit="$(printf '%s' "${json}" | jq -c --arg m "${marker}" \
+    'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | first) else empty end' 2>/dev/null || true)"
+  if [[ -n "${hit}" && "${hit}" != "null" ]]; then
+    printf '%s' "${hit}"
+    return 0
+  fi
+  return 1
+}
+
+# count_by_subject reports how many messages in a folder carry a marker. Reply
+# and reply-all produce copies with byte-identical subjects, so "a matching
+# message exists" cannot tell the two apart; only the change in the count can.
+count_by_subject() {
+  local account="$1" mailbox="$2" folder="$3" marker="$4"
+  local json
+  if [[ -n "${mailbox}" ]]; then
+    json="$("${OLK}" --account "${account}" --mailbox "${mailbox}" --no-input \
+      mail list --folder "${folder}" -n 25 --concise --json --results-only 2>/dev/null || true)"
+  else
+    json="$("${OLK}" --account "${account}" --no-input \
+      mail list --folder "${folder}" -n 25 --concise --json --results-only 2>/dev/null || true)"
+  fi
+  printf '%s' "${json}" | jq --arg m "${marker}" \
+    'if type=="array" then (map(select(.subject != null and (.subject | contains($m)))) | length) else 0 end' \
+    2>/dev/null || printf '0'
+}
+
+# wait_for_count polls until the count reaches a target, and returns non-zero if
+# it never does. Exchange files sent copies asynchronously, so the answer taken
+# immediately after a send is not the answer.
+wait_for_count() {
+  local account="$1" mailbox="$2" folder="$3" marker="$4" target="$5"
+  local attempt now
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    now="$(count_by_subject "${account}" "${mailbox}" "${folder}" "${marker}")"
+    if [[ "${now}" -ge "${target}" ]]; then
+      printf '%s' "${now}"
+      return 0
+    fi
+    log "  ... ${now}/${target} matching '${marker}' in ${folder} (attempt ${attempt}/10), waiting 6s" >&2
+    sleep 6
+  done
+  printf '%s' "${now}"
+  return 1
+}
+
+# newest_id reports the identifier of the most recent message in a folder. It
+# answers "did anything new arrive here" without depending on a subject, which
+# matters for a reply: a reply inherits the original's subject and so cannot be
+# recognised by one. It is also indifferent to how full the folder is, unlike a
+# count taken from a listing capped at a page.
+newest_id() {
+  local account="$1" mailbox="$2" folder="$3"
+  local json
+  if [[ -n "${mailbox}" ]]; then
+    json="$("${OLK}" --account "${account}" --mailbox "${mailbox}" --no-input \
+      mail list --folder "${folder}" -n 1 --concise --json --results-only 2>/dev/null || true)"
+  else
+    json="$("${OLK}" --account "${account}" --no-input \
+      mail list --folder "${folder}" -n 1 --concise --json --results-only 2>/dev/null || true)"
+  fi
+  printf '%s' "${json}" | jq -r 'if type=="array" then (first | .id // "") else "" end' 2>/dev/null || true
+}

--- a/contrib/smoke-delegated-mailbox/run-all.sh
+++ b/contrib/smoke-delegated-mailbox/run-all.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run the stages in order under one run identifier, so every result lands in one
+# directory. Each stage that sends asks first; SMOKE_ASSUME_YES=1 answers yes in
+# advance, which is worth thinking twice about — these send from a live team
+# identity to real people.
+#
+#   source ./config.sh && ./run-all.sh
+#
+# Stage 0 is read-only, is safe to run on its own, and is the right first move.
+# See README.md for the variables and the Exchange permissions they assume.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+export RUN_ID
+
+# 07 is read-only and independent of the mail stages, so it runs early: a
+# failure there is worth knowing before anything sends.
+STAGES=(00-preflight 07-mcp-mailbox-scope 01-send 02-drafts 03-reply-forward 05-negative 04-delegation-type 06-cleanup-and-report)
+
+for stage in "${STAGES[@]}"; do
+  printf '\n################ %s\n' "${stage}"
+  if ! "${HERE}/${stage}.sh"; then
+    printf '\n%s failed; stopping. Tidy up with:\n  RUN_ID=%s %s/06-cleanup-and-report.sh\n' \
+      "${stage}" "${RUN_ID}" "${HERE}" >&2
+    exit 1
+  fi
+done
+
+printf '\n################ done\n'
+printf 'results: %s/results/%s/\n' "${HERE}" "${RUN_ID}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,6 +22,16 @@ go mod verify
 New tests should pass `go test -race -count=1 ./...`. Graph-wrapper changes
 should include fixture tests for request projections and converted output.
 
+### Delegated-mailbox changes
+
+Whether a delegated send succeeds is decided by Exchange permissions and token
+scopes rather than by anything in this repository, and where the sent copy is
+filed is decided by a mailbox setting on the tenant, so the `--mailbox` write
+paths cannot be covered by unit tests. `contrib/smoke-delegated-mailbox/` is a
+live-tenant harness for them. It needs an enterprise account with a shared
+mailbox delegated to it, and it sends real mail, so every send asks first. Its
+read-only preflight is worth running on its own.
+
 ## CI
 
 Pull requests run module tidy checks, vet, build, race tests, and


### PR DESCRIPTION
Follow-up to the live testing you asked for on #89. The results are in [that thread](https://github.com/rlrghb/olkcli/pull/89#issuecomment-5401353655); this is the harness that produced them, generalized so it runs against any tenant.

The gap it fills: whether a delegated send succeeds is decided by Exchange permissions and token scopes rather than by anything in this repository, and where the sent copy is filed is decided by a mailbox setting on the tenant. Neither is reachable from a unit test, so the `--mailbox` write paths have had no coverage beyond request projection.

`contrib/smoke-delegated-mailbox/` covers send, draft create and send, reply, reply-all and forward as a shared mailbox, recording for each what the `From` line said, which Sent Items the copy landed in, and what the recipient actually received. Two read-only stages run first — a preflight, and one that drives the Model Context Protocol server over stdio to check tool exposure and launch-time mailbox scoping. Start with `./00-preflight.sh`, which sends nothing.

Three safety properties, since this sends real mail:

- Every send asks first. `SMOKE_ASSUME_YES=1` exists and is deliberately not the default.
- Mailbox addresses are required variables with no defaults. A forgotten one stops the run rather than sending to whatever was left in the file.
- The binary is pinned to a build from the checkout. A release predating the delegated-write work accepts `--mailbox` on a send and ignores it, so testing the wrong binary would make every assertion pass for the wrong reason. The preflight's dry runs are the cheap confirmation.

Three outcomes that share an exit status are distinguished on purpose, each because it produced a wrong answer during the live run:

- A client timeout is not a refusal. The request reached Graph and its fate is unknown, so the harness re-reads Sent Items instead of assuming nothing was sent.
- A delivered message can be filed out of the Inbox by a rule within seconds, which an Inbox-only check reports as a non-delivery. Delivery checks fall back to a mailbox-wide search.
- Exchange resolves Send As ahead of Send on Behalf Of when a delegate holds both, so observing Send As never proves Send on Behalf Of is absent. The stage that reads the received headers records what a message did without claiming to know what the mailbox was granted.

Happy to move it, rename it, or drop it if you would rather not carry live-tenant scripts in the repository. The README is written for someone who was not present for the original run.
