### PR TITLE
fix(mail): honor delegated mailbox for attachments

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -339,6 +339,7 @@ olk mail list --mailbox boss@example.com
 olk mail get <ID> --mailbox boss@example.com
 olk mail search "from:partner@example.com" --mailbox boss@example.com
 olk mail folders --mailbox boss@example.com
+olk mail attachments <ID> --mailbox boss@example.com   # list; also --save / --attachment-id to download
 
 # Send as a shared mailbox (needs Mail.Send.Shared + Send As + Full Access)
 olk mail send --mailbox team@example.com --to person@example.com --subject "..." --body "..."

--- a/internal/cmd/mail_attachments.go
+++ b/internal/cmd/mail_attachments.go
@@ -102,10 +102,14 @@ func (c *MailAttachmentsCmd) Run(ctx *RunContext) error {
 	if err != nil {
 		return err
 	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
 
 	// Download a specific attachment by ID
 	if c.AttachmentID != "" {
-		att, err := client.DownloadAttachment(ctx.Ctx, c.ID, c.AttachmentID)
+		att, err := client.DownloadAttachment(ctx.Ctx, target, c.ID, c.AttachmentID)
 		if err != nil {
 			return err
 		}
@@ -126,7 +130,7 @@ func (c *MailAttachmentsCmd) Run(ctx *RunContext) error {
 		return nil
 	}
 
-	attachments, err := client.GetAttachments(ctx.Ctx, c.ID)
+	attachments, err := client.GetAttachments(ctx.Ctx, target, c.ID)
 	if err != nil {
 		return err
 	}
@@ -147,7 +151,7 @@ func (c *MailAttachmentsCmd) Run(ctx *RunContext) error {
 			if a.Size > maxDownloadSize {
 				return fmt.Errorf("attachment %q is %d bytes, exceeds 50MB download limit", a.Name, a.Size)
 			}
-			att, err := client.DownloadAttachment(ctx.Ctx, c.ID, a.ID)
+			att, err := client.DownloadAttachment(ctx.Ctx, target, c.ID, a.ID)
 			if err != nil {
 				return fmt.Errorf("downloading %q: %w", a.Name, err)
 			}

--- a/internal/cmd/mail_attachments_target_test.go
+++ b/internal/cmd/mail_attachments_target_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMailAttachmentsCommandPreservesDelegatedTarget(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      func(string) []string
+		wantPaths []string
+		wantFile  bool
+	}{
+		{
+			name: "list",
+			args: func(_ string) []string {
+				return []string{"message-id", "--mailbox", "shared@example.com", "--json"}
+			},
+			wantPaths: []string{"/v1.0/users/shared@example.com/messages/message-id/attachments"},
+		},
+		{
+			name: "download all",
+			args: func(out string) []string {
+				return []string{"message-id", "--mailbox", "shared@example.com", "--save", "--out", out}
+			},
+			wantPaths: []string{
+				"/v1.0/users/shared@example.com/messages/message-id/attachments",
+				"/v1.0/users/shared@example.com/messages/message-id/attachments/attachment-id",
+			},
+			wantFile: true,
+		},
+		{
+			name: "download one",
+			args: func(out string) []string {
+				return []string{"message-id", "--mailbox", "shared@example.com", "--attachment-id", "attachment-id", "--out", out}
+			},
+			wantPaths: []string{"/v1.0/users/shared@example.com/messages/message-id/attachments/attachment-id"},
+			wantFile:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			var paths []string
+			output, calls, err := runMailCommand(t, []string{"mail", "attachments"}, tc.args(outDir), func(req *http.Request) *http.Response {
+				paths = append(paths, req.URL.Path)
+				if strings.HasSuffix(req.URL.Path, "/attachment-id") {
+					return graphJSONResponse(req, `{
+						"@odata.type":"#microsoft.graph.fileAttachment",
+						"id":"attachment-id",
+						"name":"file.txt",
+						"contentType":"text/plain",
+						"size":4,
+						"contentBytes":"dGVzdA=="
+					}`)
+				}
+				return graphJSONResponse(req, `{"value":[{
+					"@odata.type":"#microsoft.graph.fileAttachment",
+					"id":"attachment-id",
+					"name":"file.txt",
+					"contentType":"text/plain",
+					"size":4
+				}]}`)
+			})
+			if err != nil {
+				t.Fatalf("mail attachments: %v", err)
+			}
+			if calls != len(tc.wantPaths) {
+				t.Fatalf("Graph requests = %d, want %d", calls, len(tc.wantPaths))
+			}
+			if strings.Join(paths, "\n") != strings.Join(tc.wantPaths, "\n") {
+				t.Fatalf("request paths = %v, want %v", paths, tc.wantPaths)
+			}
+			if tc.wantFile {
+				content, err := os.ReadFile(filepath.Join(outDir, "file.txt"))
+				if err != nil {
+					t.Fatalf("read downloaded file: %v", err)
+				}
+				if string(content) != "test" {
+					t.Errorf("downloaded content = %q, want test", content)
+				}
+				if !strings.Contains(output, "Saved:") {
+					t.Errorf("output = %q, want Saved confirmation", output)
+				}
+			}
+		})
+	}
+}
+
+func TestMailAttachmentsCommandRejectsInvalidMailboxBeforeGraph(t *testing.T) {
+	_, calls, err := runMailCommand(
+		t,
+		[]string{"mail", "attachments"},
+		[]string{"message-id", "--mailbox", "not-an-address"},
+		func(req *http.Request) *http.Response {
+			t.Errorf("unexpected Graph request: %s %s", req.Method, req.URL.Path)
+			return graphJSONResponse(req, `{}`)
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid --mailbox") {
+		t.Fatalf("error = %v, want invalid --mailbox", err)
+	}
+	if calls != 0 {
+		t.Fatalf("Graph requests = %d, want 0", calls)
+	}
+}

--- a/internal/cmd/mcp_mailbox_scope_test.go
+++ b/internal/cmd/mcp_mailbox_scope_test.go
@@ -16,8 +16,8 @@ import (
 // Every one of these reads or writes mailbox-scoped data while ignoring
 // --mailbox, which is why a launch mailbox withholds them.
 var mailboxScopedUnawareTools = map[string]bool{
-	"mail_attachments": true, "mail_categories_list": true, "mail_rules_list": true,
-	"mail_ooo_get": true, "mail_flag": true, "mail_categorize": true,
+	"mail_categories_list": true, "mail_rules_list": true, "mail_ooo_get": true,
+	"mail_flag": true, "mail_categorize": true,
 	"mail_mark": true, "mail_move": true, "mail_folders_create": true,
 	"mail_folders_rename": true, "mail_delete": true,
 	"calendar_availability": true, "calendar_find_times": true,

--- a/internal/cmd/mcp_server.go
+++ b/internal/cmd/mcp_server.go
@@ -230,7 +230,7 @@ const mailboxArg = "mailbox"
 // exposed at all.
 var mailboxAwareTools = map[string]bool{
 	"mail_list": true, "mail_get": true, "mail_batch": true, "mail_thread": true,
-	"mail_search": true, "mail_folders_list": true, "mail_delta": true,
+	"mail_search": true, "mail_folders_list": true, "mail_attachments": true, "mail_delta": true,
 	"mail_drafts_create": true, "mail_drafts_send": true,
 	"mail_send": true, "mail_reply": true, "mail_forward": true,
 	"calendar_events": true, "calendar_view": true, "calendar_get": true,

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -751,14 +751,16 @@ type AttachmentInput struct {
 	Content     []byte
 }
 
-func (c *Client) DownloadAttachment(ctx context.Context, messageID, attachmentID string) (*Attachment, error) {
+// DownloadAttachment fetches one file attachment from the target mailbox, or
+// from the signed-in user's mailbox when target is empty.
+func (c *Client) DownloadAttachment(ctx context.Context, target, messageID, attachmentID string) (*Attachment, error) {
 	if err := validateID(messageID, "message ID"); err != nil {
 		return nil, err
 	}
 	if err := validateID(attachmentID, "attachment ID"); err != nil {
 		return nil, err
 	}
-	resp, err := c.inner.Me().Messages().ByMessageId(messageID).Attachments().ByAttachmentId(attachmentID).Get(ctx, nil)
+	resp, err := c.targetUser(target).Messages().ByMessageId(messageID).Attachments().ByAttachmentId(attachmentID).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("downloading attachment: %w", err)
 	}
@@ -788,11 +790,13 @@ func (c *Client) DownloadAttachment(ctx context.Context, messageID, attachmentID
 	return att, nil
 }
 
-func (c *Client) GetAttachments(ctx context.Context, messageID string) ([]Attachment, error) {
+// GetAttachments lists attachments on a message in the target mailbox, or in
+// the signed-in user's mailbox when target is empty.
+func (c *Client) GetAttachments(ctx context.Context, target, messageID string) ([]Attachment, error) {
 	if err := validateID(messageID, "message ID"); err != nil {
 		return nil, err
 	}
-	resp, err := c.inner.Me().Messages().ByMessageId(messageID).Attachments().Get(ctx, nil)
+	resp, err := c.targetUser(target).Messages().ByMessageId(messageID).Attachments().Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting attachments: %w", err)
 	}

--- a/internal/graphapi/mail_attachments_routing_test.go
+++ b/internal/graphapi/mail_attachments_routing_test.go
@@ -1,0 +1,86 @@
+package graphapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestMailAttachmentsAddressTheTargetMailbox(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+		call   func(*Client, context.Context, string) error
+	}{
+		{
+			name:   "list from the caller's own mailbox",
+			target: "",
+			want:   meBuilderPath + "/messages/message-id/attachments",
+			call: func(c *Client, ctx context.Context, target string) error {
+				_, err := c.GetAttachments(ctx, target, "message-id")
+				return err
+			},
+		},
+		{
+			name:   "list from a delegated mailbox",
+			target: "shared@example.com",
+			want:   "/v1.0/users/shared@example.com/messages/message-id/attachments",
+			call: func(c *Client, ctx context.Context, target string) error {
+				_, err := c.GetAttachments(ctx, target, "message-id")
+				return err
+			},
+		},
+		{
+			name:   "download from the caller's own mailbox",
+			target: "",
+			want:   meBuilderPath + "/messages/message-id/attachments/attachment-id",
+			call: func(c *Client, ctx context.Context, target string) error {
+				_, err := c.DownloadAttachment(ctx, target, "message-id", "attachment-id")
+				return err
+			},
+		},
+		{
+			name:   "download from a delegated mailbox",
+			target: "shared@example.com",
+			want:   "/v1.0/users/shared@example.com/messages/message-id/attachments/attachment-id",
+			call: func(c *Client, ctx context.Context, target string) error {
+				_, err := c.DownloadAttachment(ctx, target, "message-id", "attachment-id")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			calls := 0
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				calls++
+				got = req.URL.Path
+				if strings.HasSuffix(req.URL.Path, "/attachment-id") {
+					return graphJSONResponse(req, `{
+						"@odata.type":"#microsoft.graph.fileAttachment",
+						"id":"attachment-id",
+						"name":"file.txt",
+						"contentType":"text/plain",
+						"size":4,
+						"contentBytes":"dGVzdA=="
+					}`)
+				}
+				return graphJSONResponse(req, `{"value":[]}`)
+			})
+
+			if err := tc.call(client, context.Background(), tc.target); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+			if calls != 1 {
+				t.Fatalf("Graph requests = %d, want 1", calls)
+			}
+			if got != tc.want {
+				t.Errorf("request path = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- route attachment listing and downloads through the resolved delegated mailbox target
- preserve the target for list, save-all, and single-attachment download paths
- expose mail_attachments as mailbox-aware under MCP instead of withholding it from delegated servers
- add command-boundary and Graph request-projection regressions for own and delegated mailboxes

## Codebase audit

Audited command Graph calls and direct /me request builders across the repository. All reads in the documented delegated mail/calendar/contact surface now resolve and pass the mailbox target. The remaining direct /me routes are the explicitly classified own-mailbox operations or mailbox-irrelevant services already protected by the MCP mailbox-scoping matrix.

## Validation

- go test -race -count=1 ./...
- go vet ./...
- go mod tidy (no go.mod/go.sum drift)
- make build
- golangci-lint run --new-from-rev=origin/main (0 issues; local v2.12.2)
- synthesized PR #92 -> #93 -> #94 -> this commit: race suite, vet, tidy, build, and diff lint all pass; this commit applies without conflict

Fixes #95