### PR TITLE
feat(mail): expose inline attachment identity

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -108,6 +108,10 @@ unique, files must be images, and each must be under 3 MB. This works on
 `mail reply --html --draft` and `mail drafts create --html`; it is not available
 on immediate replies, sends, or forwards.
 
+Attachment JSON includes `isInline` and `contentId` for matching inline images
+to HTML `cid:` references. Query attachments directly when inspecting inline
+images, even when `hasAttachments` is false.
+
 For a bounded mail inventory, use:
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,7 +49,7 @@ olk mail forward <ID> --to EMAIL [--comment COMMENT] [--html]
 olk mail mark <ID> read|unread
 olk mail move <ID> ID_OR_PATH
 olk mail delete <ID> --force
-olk mail attachments <ID> --attachment-id ID
+olk mail attachments <ID> [--save] [--out DIR] [--attachment-id ID]
 olk mail folders list|create|rename|delete  # list traverses visible child folders
 olk mail drafts list|create|send|delete
 olk mail drafts create --to EMAIL --subject SUBJECT --body '<img src="cid:logo">' --html --inline logo=logo.png
@@ -70,6 +70,11 @@ their immediate-send behavior.
 `mail drafts create --html`. Reference every supplied CID in the HTML as
 `cid:CID`; CIDs must be unique, files must be images, and each file must be
 under 3 MB. Immediate replies, sends, and forwards do not accept `--inline`.
+
+`mail attachments --json` includes `isInline` and `contentId`. Use the content ID
+to match an attachment to a `cid:` reference in the HTML body; attachment names
+can repeat. Missing content IDs are empty strings. Query attachments directly
+when inspecting inline images, even if the message reports `hasAttachments: false`.
 
 ## Calendar
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -31,6 +31,7 @@ var advertisedCapabilities = []string{
 	"mail.move.structured-receipt-v1",
 	"mail.provider-body-format-v1",
 	"mail.thread.complete-v1",
+	"mail.attachments.inline-identity-v1",
 	"mail.shared-mailbox-send-v1",
 	"mcp.delegated-mailbox-v1",
 }

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -40,6 +40,7 @@ func TestVersionJSONAdvertisesStructuredMailCapabilities(t *testing.T) {
 		"mail.move.structured-receipt-v1",
 		"mail.provider-body-format-v1",
 		"mail.thread.complete-v1",
+		"mail.attachments.inline-identity-v1",
 		"mail.shared-mailbox-send-v1",
 		"mcp.delegated-mailbox-v1",
 	}; !reflect.DeepEqual(got.Capabilities, want) {

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -790,12 +790,25 @@ func (c *Client) SearchMessages(ctx context.Context, target, query string, top i
 	})
 }
 
+// attachmentContentID returns the MIME Content-ID that an inline image is
+// referenced by from the HTML body (src="cid:..."). Graph exposes it only on
+// fileAttachment, not on the attachment base type, so the cast is required.
+func attachmentContentID(a models.Attachmentable) string {
+	fileAtt, ok := a.(models.FileAttachmentable)
+	if !ok {
+		return ""
+	}
+	return derefStr(fileAtt.GetContentId())
+}
+
 // Attachment represents a mail attachment
 type Attachment struct {
 	ID          string `json:"id"`
 	Name        string `json:"name" untrusted:"true"`
 	ContentType string `json:"contentType"`
 	Size        int32  `json:"size"`
+	IsInline    bool   `json:"isInline"`
+	ContentID   string `json:"contentId"`
 	Content     []byte `json:"-"`
 }
 
@@ -823,6 +836,8 @@ func (c *Client) DownloadAttachment(ctx context.Context, target, messageID, atta
 	att := &Attachment{
 		Name:        derefStr(resp.GetName()),
 		ContentType: derefStr(resp.GetContentType()),
+		IsInline:    resp.GetIsInline() != nil && *resp.GetIsInline(),
+		ContentID:   attachmentContentID(resp),
 	}
 	if resp.GetId() != nil {
 		att.ID = *resp.GetId()
@@ -861,6 +876,8 @@ func (c *Client) GetAttachments(ctx context.Context, target, messageID string) (
 		att := Attachment{
 			Name:        derefStr(a.GetName()),
 			ContentType: derefStr(a.GetContentType()),
+			IsInline:    a.GetIsInline() != nil && *a.GetIsInline(),
+			ContentID:   attachmentContentID(a),
 		}
 		if a.GetId() != nil {
 			att.ID = *a.GetId()

--- a/internal/graphapi/mail_attachments_test.go
+++ b/internal/graphapi/mail_attachments_test.go
@@ -1,0 +1,121 @@
+package graphapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// An inline image is the common case in a real thread and the one Graph reports
+// worst. A message whose attachments are all inline still reports
+// hasAttachments=false, so a caller that trusts that flag never asks for them at
+// all; and once it does ask, isInline and contentId are the only way to tie the
+// bytes back to the <img src="cid:..."> they fill. Outlook names every pasted
+// screenshot image.png, so two attachments on one message are otherwise
+// distinguishable only by their position in the response.
+func TestGetAttachmentsCarriesInlineImageIdentity(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		return graphJSONResponse(req, `{"value":[
+			{
+				"@odata.type": "#microsoft.graph.fileAttachment",
+				"id": "att-1",
+				"name": "image.png",
+				"contentType": "image/png",
+				"size": 65906,
+				"isInline": true,
+				"contentId": "11111111-2222-3333-4444-555555555555"
+			},
+			{
+				"@odata.type": "#microsoft.graph.fileAttachment",
+				"id": "att-2",
+				"name": "report.pdf",
+				"contentType": "application/pdf",
+				"size": 1024,
+				"isInline": false
+			}
+		]}`)
+	})
+
+	got, err := client.GetAttachments(context.Background(), "team@example.com", "AAA")
+	if err != nil {
+		t.Fatalf("GetAttachments: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("attachments = %d, want 2", len(got))
+	}
+
+	if !got[0].IsInline {
+		t.Error("inline image reported IsInline=false; a caller cannot then tell it apart " +
+			"from a file the sender deliberately attached")
+	}
+	if got[0].ContentID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("ContentID = %q, want the content ID the HTML body references", got[0].ContentID)
+	}
+	if got[1].IsInline {
+		t.Error("ordinary file attachment reported IsInline=true")
+	}
+	if got[1].ContentID != "" {
+		t.Errorf("ContentID = %q, want empty for an attachment with no content ID", got[1].ContentID)
+	}
+}
+
+// DownloadAttachment maps the same two fields from the single-resource response,
+// which is a separate code path from the collection above.
+func TestDownloadAttachmentCarriesInlineImageIdentity(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		return graphJSONResponse(req, `{
+			"@odata.type": "#microsoft.graph.fileAttachment",
+			"id": "att-1",
+			"name": "image.png",
+			"contentType": "image/png",
+			"size": 65906,
+			"isInline": true,
+			"contentId": "11111111-2222-3333-4444-555555555555",
+			"contentBytes": "aW1n"
+		}`)
+	})
+
+	got, err := client.DownloadAttachment(context.Background(), "", "AAA", "att-1")
+	if err != nil {
+		t.Fatalf("DownloadAttachment: %v", err)
+	}
+	if !got.IsInline || got.ContentID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("IsInline = %v, ContentID = %q — a downloaded inline image that cannot name "+
+			"its content ID cannot be placed back into the body it came from", got.IsInline, got.ContentID)
+	}
+	if string(got.Content) != "img" {
+		t.Errorf("Content = %q, want the decoded bytes", got.Content)
+	}
+}
+
+// Graph puts contentId on fileAttachment, not on the attachment base type, so
+// reading it needs a cast that an itemAttachment — a forwarded message or a
+// contact card — must miss rather than panic on.
+func TestGetAttachmentsToleratesNonFileAttachments(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		return graphJSONResponse(req, `{"value":[
+			{
+				"@odata.type": "#microsoft.graph.itemAttachment",
+				"id": "att-3",
+				"name": "Forwarded message",
+				"contentType": "message/rfc822",
+				"size": 4096,
+				"isInline": false
+			}
+		]}`)
+	})
+
+	got, err := client.GetAttachments(context.Background(), "", "AAA")
+	if err != nil {
+		t.Fatalf("GetAttachments: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("attachments = %d, want 1", len(got))
+	}
+	if got[0].ContentID != "" {
+		t.Errorf("ContentID = %q, want empty for an itemAttachment", got[0].ContentID)
+	}
+	if got[0].Name != "Forwarded message" {
+		t.Errorf("Name = %q", got[0].Name)
+	}
+}


### PR DESCRIPTION
Attachment JSON drops the provider's inline-image identity, so callers cannot reliably match downloaded images to HTML `cid:` references when names repeat. Include `isInline` and `contentId` in list/download attachment models, advertise `mail.attachments.inline-identity-v1`, and document the additive output fields. Non-file attachments and absent content IDs remain supported.

Validation: full `go test -race -count=1 ./...`, go vet, build, module tidiness and CI-pinned lint passed. Tests cover inline and ordinary files, non-file attachments and downloaded bytes. The built binary advertises the capability. No live mailbox operations were performed.

Suggested review order: #102 (smoke privacy) → #103 (attachment metadata) → #104 (delegated moves) → #105 (existing-draft edits). Each branch targets upstream main directly and can be reviewed independently. Applying all four in that order was rehearsed without conflicts.
