### PR TITLE
feat(mail): attach files and update recipients on existing drafts

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -102,6 +102,24 @@ generated history so formatting does not replace the quote. It returns the
 created draft and does not send it; omit `--draft` to send the reply
 immediately.
 
+To edit an existing draft without sending it:
+
+```bash
+olk mail drafts attach <DRAFT_ID> report.pdf --mailbox shared@example.com --json
+olk mail drafts update <DRAFT_ID> --cc colleague@example.com --mailbox shared@example.com --json
+olk mail drafts update <DRAFT_ID> --bcc= --dry-run --json
+```
+
+`attach` uploads one regular file under 3 MB. `update` replaces only the supplied
+To, CC or BCC lists; omit a flag to leave that list unchanged, or pass an empty
+string to clear it. The body, subject and reply history are left unchanged.
+Both commands honour `--mailbox`, `--no-write`, `--no-send`, `--dry-run`, `--json`
+and `--plain`. They check that the message is a draft before editing. Shared
+mailbox edits need `Mail.ReadWrite.Shared` and Full Access. JSON receipts include
+`id`, `mailbox` (empty for the signed-in user), and `dryRun`, plus `attachment`
+or `recipients`. In recipient receipts, null means unchanged and [] means clear.
+The new commands are CLI-only; the MCP tool allowlist is unchanged.
+
 For inline images, reference each image in the HTML as `cid:CID`, then supply
 the matching local file with a repeatable `--inline CID=PATH` flag. CIDs must be
 unique, files must be images, and each must be under 3 MB. This works on

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -51,7 +51,7 @@ olk mail move <ID> ID_OR_PATH
 olk mail delete <ID> --force
 olk mail attachments <ID> --attachment-id ID
 olk mail folders list|create|rename|delete  # list traverses visible child folders
-olk mail drafts list|create|send|delete
+olk mail drafts list|create|send|delete|attach|update
 olk mail drafts create --to EMAIL --subject SUBJECT --body '<img src="cid:logo">' --html --inline logo=logo.png
 olk mail flag <ID> flagged|complete|notFlagged
 olk mail categorize <ID> --category NAME
@@ -59,6 +59,24 @@ olk mail importance <ID> low|normal|high
 olk mail ooo get|set|off
 olk mail rules list|create|delete
 ```
+
+To edit an existing draft without sending it:
+
+```bash
+olk mail drafts attach <DRAFT_ID> report.pdf --mailbox shared@example.com --json
+olk mail drafts update <DRAFT_ID> --cc colleague@example.com --mailbox shared@example.com --json
+olk mail drafts update <DRAFT_ID> --bcc= --dry-run --json
+```
+
+`attach` uploads one regular file under 3 MB. `update` replaces only the supplied
+To, CC or BCC lists; omit a flag to leave that list unchanged, or pass an empty
+string to clear it. The body, subject and reply history are left unchanged.
+Both commands honour `--mailbox`, `--no-write`, `--no-send`, `--dry-run`, `--json`
+and `--plain`. They check that the message is a draft before editing. Shared
+mailbox edits need `Mail.ReadWrite.Shared` and Full Access. JSON receipts include
+`id`, `mailbox` (empty for the signed-in user), and `dryRun`, plus `attachment`
+or `recipients`. In recipient receipts, null means unchanged and [] means clear.
+The new commands are CLI-only; the MCP tool allowlist is unchanged.
 
 `mail reply --draft` creates a true threaded Outlook reply or reply-all draft,
 including Outlook's quoted history, and returns its draft ID and subject. For

--- a/internal/cmd/mail_drafts.go
+++ b/internal/cmd/mail_drafts.go
@@ -16,6 +16,8 @@ type MailDraftsCmd struct {
 	Create MailDraftsCreateCmd `cmd:"" help:"Create a draft message"`
 	Send   MailDraftsSendCmd   `cmd:"" help:"Send a draft message"`
 	Delete MailDraftsDeleteCmd `cmd:"" help:"Delete a draft message"`
+	Attach MailDraftsAttachCmd `cmd:"" help:"Attach a file to an existing draft"`
+	Update MailDraftsUpdateCmd `cmd:"" help:"Replace the recipients of an existing draft"`
 }
 
 // MailDraftsListCmd lists draft messages

--- a/internal/cmd/mail_drafts_attach.go
+++ b/internal/cmd/mail_drafts_attach.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+)
+
+// MailDraftsAttachCmd adds a regular file attachment to an existing draft.
+type MailDraftsAttachCmd struct {
+	ID   string `arg:"" help:"Draft message ID"`
+	File string `arg:"" help:"File to attach (under 3 MB)" type:"existingfile"`
+}
+
+func (c *MailDraftsAttachCmd) Run(ctx *RunContext) error {
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+	pathInfo, err := os.Stat(c.File)
+	if err != nil {
+		return fmt.Errorf("reading attachment: %w", err)
+	}
+	if !pathInfo.Mode().IsRegular() {
+		return fmt.Errorf("attachment must be a regular file")
+	}
+	file, err := os.Open(c.File)
+	if err != nil {
+		return fmt.Errorf("opening attachment: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("reading attachment: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("attachment must be a regular file")
+	}
+	if info.Size() >= graphapi.MaxInlineAttachmentBytes {
+		return fmt.Errorf("attachment must be under 3 MB")
+	}
+	content, err := io.ReadAll(io.LimitReader(file, graphapi.MaxInlineAttachmentBytes))
+	if err != nil {
+		return fmt.Errorf("reading attachment: %w", err)
+	}
+	if len(content) >= graphapi.MaxInlineAttachmentBytes {
+		return fmt.Errorf("attachment must be under 3 MB")
+	}
+	filename := filepath.Base(c.File)
+	contentType := mime.TypeByExtension(filepath.Ext(c.File))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	att := &graphapi.Attachment{Name: filename, ContentType: contentType, Size: int32(len(content))}
+	if !ctx.Flags.DryRun {
+		client, err := ctx.GraphClient()
+		if err != nil {
+			return err
+		}
+		att, err = client.AttachToDraft(ctx.Ctx, target, c.ID, filename, contentType, content)
+		if err != nil {
+			return err
+		}
+	}
+	receipt := struct {
+		ID         string               `json:"id"`
+		Mailbox    string               `json:"mailbox"`
+		DryRun     bool                 `json:"dryRun"`
+		Attachment *graphapi.Attachment `json:"attachment"`
+	}{c.ID, target, ctx.Flags.DryRun, att}
+	return ctx.Printer().Print([]string{"DRAFT_ID", "MAILBOX", "ATTACHMENT_ID", "NAME", "SIZE", "DRY_RUN"}, [][]string{{
+		c.ID, describeMailbox(target), att.ID, att.Name, strconv.FormatInt(int64(att.Size), 10), strconv.FormatBool(ctx.Flags.DryRun),
+	}}, receipt, 1, "")
+}

--- a/internal/cmd/mail_drafts_edits_test.go
+++ b/internal/cmd/mail_drafts_edits_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+)
+
+func TestDraftUpdateCommandClearAndOmit(t *testing.T) {
+	output, calls, err := runDraftEditCommand(t, []string{"mail", "drafts", "update"}, []string{"id", "--cc=", "--mailbox", "shared@example.com", "--json", "--no-send"}, func(req *http.Request) *http.Response {
+		if req.URL.Path != "/v1.0/users/shared@example.com/messages/id" {
+			t.Fatalf("path=%s", req.URL.Path)
+		}
+		if req.Method == http.MethodGet {
+			return graphJSONResponse(req, `{"isDraft":true}`)
+		}
+		if req.Method != http.MethodPatch {
+			t.Fatalf("method=%s", req.Method)
+		}
+		var payload map[string]json.RawMessage
+		if err := decodeGraphJSON(req.Body, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload) != 2 || string(payload["ccRecipients"]) != "[]" {
+			t.Fatalf("payload=%s", payload)
+		}
+		return graphJSONResponse(req, `{"id":"id"}`)
+	})
+	if err != nil || calls != 2 {
+		t.Fatalf("error=%v calls=%d", err, calls)
+	}
+	var envelope struct {
+		Results struct {
+			ID         string                   `json:"id"`
+			Recipients graphapi.DraftRecipients `json:"recipients"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Results.ID != "id" || envelope.Results.Recipients.CC == nil || envelope.Results.Recipients.To != nil {
+		t.Fatalf("output=%s", output)
+	}
+}
+
+func TestDraftEditCommandDryRunsAndValidation(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, sub string
+		args      []string
+		wantError bool
+	}{
+		{"update dry run", "update", []string{"id", "--to", "to@example.com", "--dry-run", "--json"}, false},
+		{"attach dry run", "attach", []string{"id", file, "--dry-run", "--json"}, false},
+		{"empty update", "update", []string{"id"}, true},
+		{"invalid recipient", "update", []string{"id", "--to", "invalid", "--dry-run"}, true},
+		{"invalid update mailbox", "update", []string{"id", "--cc=", "--mailbox", "invalid"}, true},
+		{"invalid attach mailbox", "attach", []string{"id", file, "--mailbox", "invalid"}, true},
+		{"guarded update", "update", []string{"id", "--cc=", "--no-write"}, true},
+		{"guarded attachment", "attach", []string{"id", file, "--no-write"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output, calls, err := runDraftEditCommand(t, []string{"mail", "drafts", tc.sub}, tc.args, func(req *http.Request) *http.Response { t.Fatalf("unexpected Graph request: %s", req.URL); return nil })
+			if (err != nil) != tc.wantError || calls != 0 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+			if !tc.wantError && (!json.Valid([]byte(output)) || !strings.Contains(output, `"dryRun": true`)) {
+				t.Fatalf("output=%s", output)
+			}
+		})
+	}
+}
+
+func TestDraftAttachCommandOutputsJSONAndPlain(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, format := range []string{"--json", "--plain"} {
+		output, calls, err := runDraftEditCommand(t, []string{"mail", "drafts", "attach"}, []string{"id", file, "--mailbox", "shared@example.com", format, "--no-send"}, func(req *http.Request) *http.Response {
+			if req.Method == http.MethodGet && req.URL.Path == "/v1.0/users/shared@example.com/messages/id" {
+				return graphJSONResponse(req, `{"isDraft":true}`)
+			}
+			if req.Method != http.MethodPost || req.URL.Path != "/v1.0/users/shared@example.com/messages/id/attachments" {
+				t.Fatalf("request=%s %s", req.Method, req.URL)
+			}
+			return graphJSONResponse(req, `{"id":"attachment-id","name":"report.txt","size":5}`)
+		})
+		if err != nil || calls != 2 {
+			t.Fatalf("error=%v calls=%d", err, calls)
+		}
+		if format == "--json" && !json.Valid([]byte(output)) {
+			t.Fatalf("invalid JSON: %s", output)
+		}
+		if format == "--plain" && !strings.Contains(output, "id\tshared@example.com\tattachment-id\treport.txt\t5\tfalse") {
+			t.Fatalf("plain output=%q", output)
+		}
+	}
+}
+
+func TestDraftAttachRejectsSizeBoundaryAndDirectory(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "large")
+	f, err := os.Create(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(graphapi.MaxInlineAttachmentBytes); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{file, dir} {
+		_, calls, err := runDraftEditCommand(t, []string{"mail", "drafts", "attach"}, []string{"id", path, "--dry-run"}, func(req *http.Request) *http.Response { t.Fatal("unexpected request"); return nil })
+		if err == nil || calls != 0 {
+			t.Fatalf("error=%v calls=%d", err, calls)
+		}
+	}
+}
+
+func runDraftEditCommand(t *testing.T, path, args []string, responder func(*http.Request) *http.Response) (output string, calls int, err error) {
+	t.Helper()
+	client := testMailListClient(t, func(req *http.Request) *http.Response { calls++; return responder(req) })
+	cli := &CLI{}
+	parser, err := newKongParser(cli)
+	if err != nil {
+		return "", calls, err
+	}
+	kctx, err := parser.Parse(append(path, args...))
+	if err != nil {
+		return "", calls, err
+	}
+	client.SetGuards(cli.NoWrite, cli.NoSend)
+	output, _, err = captureStd(func() error {
+		return kctx.Run(&RunContext{Ctx: context.Background(), Flags: &cli.RootFlags, client: client})
+	})
+	return output, calls, err
+}

--- a/internal/cmd/mail_drafts_update.go
+++ b/internal/cmd/mail_drafts_update.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rlrghb/olkcli/internal/graphapi"
+)
+
+// MailDraftsUpdateCmd replaces only the recipient lists supplied by the caller.
+type MailDraftsUpdateCmd struct {
+	ID  string   `arg:"" help:"Draft message ID"`
+	To  []string `help:"Replace To recipients; pass an empty string to clear" short:"t"`
+	CC  []string `help:"Replace CC recipients; pass an empty string to clear"`
+	BCC []string `help:"Replace BCC recipients; pass an empty string to clear"`
+}
+
+func (c *MailDraftsUpdateCmd) Run(ctx *RunContext) error {
+	if c.To == nil && c.CC == nil && c.BCC == nil {
+		return fmt.Errorf("nothing to update: give at least one of --to, --cc or --bcc")
+	}
+	target, err := resolveMailboxTarget(ctx.Flags.Mailbox)
+	if err != nil {
+		return err
+	}
+	recipients := graphapi.DraftRecipients{To: dropBlank(c.To), CC: dropBlank(c.CC), BCC: dropBlank(c.BCC)}
+	for _, list := range [][]string{recipients.To, recipients.CC, recipients.BCC} {
+		for _, address := range list {
+			if err := graphapi.ValidateEmail(address); err != nil {
+				return err
+			}
+		}
+	}
+	if !ctx.Flags.DryRun {
+		client, err := ctx.GraphClient()
+		if err != nil {
+			return err
+		}
+		if err := client.UpdateDraftRecipients(ctx.Ctx, target, c.ID, recipients); err != nil {
+			return err
+		}
+	}
+	receipt := struct {
+		ID         string                   `json:"id"`
+		Mailbox    string                   `json:"mailbox"`
+		DryRun     bool                     `json:"dryRun"`
+		Recipients graphapi.DraftRecipients `json:"recipients"`
+	}{c.ID, target, ctx.Flags.DryRun, recipients}
+	return ctx.Printer().Print([]string{"ID", "MAILBOX", "TO", "CC", "BCC", "DRY_RUN"}, [][]string{{
+		c.ID, describeMailbox(target), recipientPreview(recipients.To), recipientPreview(recipients.CC), recipientPreview(recipients.BCC), strconv.FormatBool(ctx.Flags.DryRun),
+	}}, receipt, 1, "")
+}
+
+// Preserve nil (omitted) versus empty (explicitly clear).
+func dropBlank(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	kept := make([]string, 0, len(values))
+	for _, value := range values {
+		if s := strings.TrimSpace(value); s != "" {
+			kept = append(kept, s)
+		}
+	}
+	return kept
+}
+
+func recipientPreview(values []string) string {
+	if values == nil {
+		return "(unchanged)"
+	}
+	if len(values) == 0 {
+		return "(clear)"
+	}
+	return strings.Join(values, ", ")
+}

--- a/internal/graphapi/draft_edits.go
+++ b/internal/graphapi/draft_edits.go
@@ -1,0 +1,132 @@
+package graphapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
+)
+
+// AttachToDraft adds a file attachment to an existing draft in the target
+// mailbox, or in the signed-in user's own mailbox when target is empty. The
+// Files must be under 3 MB; larger uploads need an upload session.
+func (c *Client) AttachToDraft(ctx context.Context, target, draftID, name, contentType string, content []byte) (*Attachment, error) {
+	if err := c.ensureWritable(); err != nil {
+		return nil, err
+	}
+	if err := validateID(draftID, "draft ID"); err != nil {
+		return nil, err
+	}
+
+	if len(content) >= MaxInlineAttachmentBytes {
+		return nil, fmt.Errorf("attachment must be under 3 MB")
+	}
+	if err := c.requireDraft(ctx, target, draftID); err != nil {
+		return nil, err
+	}
+
+	att := models.NewFileAttachment()
+	att.SetName(&name)
+	att.SetContentType(&contentType)
+	att.SetContentBytes(content)
+
+	created, err := c.targetUser(target).Messages().ByMessageId(draftID).Attachments().Post(ctx, att, nil)
+	if err != nil {
+		if target != "" {
+			return nil, sharedMailboxDraftError("attaching file to draft", target, err)
+		}
+		return nil, fmt.Errorf("attaching file to draft: %w", err)
+	}
+
+	if created == nil || derefStr(created.GetId()) == "" {
+		return nil, fmt.Errorf("attaching file to draft: Graph returned no attachment ID")
+	}
+	result := Attachment{}
+	if created.GetId() != nil {
+		result.ID = *created.GetId()
+	}
+	if created.GetName() != nil {
+		result.Name = *created.GetName()
+	}
+	if created.GetContentType() != nil {
+		result.ContentType = *created.GetContentType()
+	}
+	if created.GetSize() != nil {
+		result.Size = *created.GetSize()
+	}
+	return &result, nil
+}
+
+// DraftRecipients carries the recipient lists an UpdateDraftRecipients call
+// replaces. A nil slice leaves that list untouched; an empty slice clears it.
+type DraftRecipients struct {
+	To  []string `json:"to" untrusted:"true"`
+	CC  []string `json:"cc" untrusted:"true"`
+	BCC []string `json:"bcc" untrusted:"true"`
+}
+
+// UpdateDraftRecipients replaces the To, CC and BCC lists of an existing draft
+// in the target mailbox, or in the signed-in user's own mailbox when target is
+// empty. The body and subject are left alone: a reply draft's body includes
+// the quoted original, and rewriting it here would silently drop that.
+func (c *Client) UpdateDraftRecipients(ctx context.Context, target, draftID string, recipients DraftRecipients) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
+	if err := validateID(draftID, "draft ID"); err != nil {
+		return err
+	}
+
+	if recipients.To == nil && recipients.CC == nil && recipients.BCC == nil {
+		return fmt.Errorf("no recipient lists supplied")
+	}
+	patch := models.NewMessage()
+	if recipients.To != nil {
+		r, err := makeRecipients(recipients.To)
+		if err != nil {
+			return fmt.Errorf("invalid to recipient: %w", err)
+		}
+		patch.SetToRecipients(r)
+	}
+	if recipients.CC != nil {
+		r, err := makeRecipients(recipients.CC)
+		if err != nil {
+			return fmt.Errorf("invalid cc recipient: %w", err)
+		}
+		patch.SetCcRecipients(r)
+	}
+	if recipients.BCC != nil {
+		r, err := makeRecipients(recipients.BCC)
+		if err != nil {
+			return fmt.Errorf("invalid bcc recipient: %w", err)
+		}
+		patch.SetBccRecipients(r)
+	}
+
+	if err := c.requireDraft(ctx, target, draftID); err != nil {
+		return err
+	}
+	if _, err := c.targetUser(target).Messages().ByMessageId(draftID).Patch(ctx, patch, nil); err != nil {
+		if target != "" {
+			return sharedMailboxDraftError("updating draft recipients", target, err)
+		}
+		return fmt.Errorf("updating draft recipients: %w", err)
+	}
+	return nil
+}
+
+// requireDraft avoids modifying a received or already-sent message. Graph also
+// rejects recipient updates if the message is sent after this read.
+func (c *Client) requireDraft(ctx context.Context, target, draftID string) error {
+	message, err := c.targetUser(target).Messages().ByMessageId(draftID).Get(ctx, &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.ItemMessagesMessageItemRequestBuilderGetQueryParameters{Select: []string{"isDraft"}},
+	})
+	if err != nil {
+		return sharedMailboxReadError("checking draft", target, err)
+	}
+	if message == nil || message.GetIsDraft() == nil || !*message.GetIsDraft() {
+		return fmt.Errorf("message is not a draft")
+	}
+	return nil
+}

--- a/internal/graphapi/draft_edits_test.go
+++ b/internal/graphapi/draft_edits_test.go
@@ -1,0 +1,183 @@
+package graphapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDraftRecipientPatchPreservesOmissionAndClearsEmptyLists(t *testing.T) {
+	for _, target := range []string{"", "shared@example.com"} {
+		t.Run(target, func(t *testing.T) {
+			path := meBuilderPath + "/messages/draft-id"
+			if target != "" {
+				path = "/v1.0/users/" + target + "/messages/draft-id"
+			}
+			calls := 0
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				calls++
+				if req.URL.Path != path {
+					t.Fatalf("path = %s", req.URL.Path)
+				}
+				switch req.Method {
+				case http.MethodGet:
+					if req.URL.Query().Get("$select") != "isDraft" {
+						t.Fatalf("select = %s", req.URL.RawQuery)
+					}
+					return graphJSONResponse(req, `{"isDraft":true}`)
+				case http.MethodPatch:
+					var got map[string]any
+					if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+						t.Fatal(err)
+					}
+					want := map[string]any{"@odata.type": "#microsoft.graph.message", "ccRecipients": []any{}, "bccRecipients": []any{map[string]any{"emailAddress": map[string]any{"address": "bcc@example.com"}}}}
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("PATCH = %#v, want %#v", got, want)
+					}
+					return graphJSONResponse(req, `{"id":"draft-id"}`)
+				default:
+					t.Fatalf("unexpected method: %s", req.Method)
+					return nil
+				}
+			})
+			client.noSend = true
+			err := client.UpdateDraftRecipients(context.Background(), target, "draft-id", DraftRecipients{CC: []string{}, BCC: []string{"bcc@example.com"}})
+			if err != nil || calls != 2 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestDraftAttachmentUploadPayloadAndTarget(t *testing.T) {
+	for _, target := range []string{"", "shared@example.com"} {
+		t.Run(target, func(t *testing.T) {
+			base := meBuilderPath + "/messages/draft-id"
+			if target != "" {
+				base = "/v1.0/users/" + target + "/messages/draft-id"
+			}
+			calls := 0
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				calls++
+				if req.Method == http.MethodGet && req.URL.Path == base {
+					return graphJSONResponse(req, `{"isDraft":true}`)
+				}
+				if req.Method != http.MethodPost || req.URL.Path != base+"/attachments" {
+					t.Fatalf("request = %s %s", req.Method, req.URL)
+				}
+				var got map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+					t.Fatal(err)
+				}
+				want := map[string]any{"@odata.type": "#microsoft.graph.fileAttachment", "name": "report.txt", "contentType": "text/plain", "contentBytes": "aGVsbG8="}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("payload=%#v", got)
+				}
+				return graphJSONResponse(req, `{"id":"attachment-id","name":"report.txt","contentType":"text/plain","size":5}`)
+			})
+			client.noSend = true
+			att, err := client.AttachToDraft(context.Background(), target, "draft-id", "report.txt", "text/plain", []byte("hello"))
+			if err != nil || calls != 2 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+			if att.ID != "attachment-id" || att.Size != 5 {
+				t.Fatalf("attachment=%#v", att)
+			}
+		})
+	}
+}
+
+func TestDraftEditsRejectInvalidInputsBeforeRequests(t *testing.T) {
+	ctx := context.Background()
+	client := &Client{}
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{"empty update", func() error { return client.UpdateDraftRecipients(ctx, "", "draft-id", DraftRecipients{}) }},
+		{"invalid recipient", func() error {
+			return client.UpdateDraftRecipients(ctx, "", "draft-id", DraftRecipients{To: []string{"invalid"}})
+		}},
+		{"invalid ID", func() error { return client.UpdateDraftRecipients(ctx, "", "", DraftRecipients{To: []string{}}) }},
+		{"oversize", func() error {
+			_, err := client.AttachToDraft(ctx, "", "draft-id", "f", "text/plain", make([]byte, MaxInlineAttachmentBytes))
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+	client.noWrite = true
+	if err := client.UpdateDraftRecipients(ctx, "shared@example.com", "id", DraftRecipients{CC: []string{}}); !errors.Is(err, ErrNoWrite) {
+		t.Fatalf("error=%v", err)
+	}
+	if _, err := client.AttachToDraft(ctx, "shared@example.com", "id", "f", "text/plain", nil); !errors.Is(err, ErrNoWrite) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDraftEditsRefuseNonDraftAndMissingDraftState(t *testing.T) {
+	for _, body := range []string{`{"isDraft":false}`, `{}`} {
+		for _, attach := range []bool{true, false} {
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				if req.Method != http.MethodGet {
+					t.Fatalf("unexpected mutation: %s", req.Method)
+				}
+				return graphJSONResponse(req, body)
+			})
+			var err error
+			if attach {
+				_, err = client.AttachToDraft(context.Background(), "", "id", "f", "text/plain", nil)
+			} else {
+				err = client.UpdateDraftRecipients(context.Background(), "", "id", DraftRecipients{CC: []string{}})
+			}
+			if err == nil || !strings.Contains(err.Error(), "not a draft") {
+				t.Fatalf("error=%v", err)
+			}
+		}
+	}
+}
+
+func TestDraftAttachmentEmptyResponseIsAnError(t *testing.T) {
+	client := testGraphClient(t, func(req *http.Request) *http.Response {
+		if req.Method == http.MethodGet {
+			return graphJSONResponse(req, `{"isDraft":true}`)
+		}
+		return &http.Response{StatusCode: http.StatusNoContent, Header: http.Header{}, Request: req}
+	})
+	if _, err := client.AttachToDraft(context.Background(), "", "id", "f", "text/plain", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDraftEditsPreserveProviderErrors(t *testing.T) {
+	for _, attach := range []bool{false, true} {
+		for _, failRead := range []bool{false, true} {
+			client := testGraphClient(t, func(req *http.Request) *http.Response {
+				if req.Method == http.MethodGet && !failRead {
+					return graphJSONResponse(req, `{"isDraft":true}`)
+				}
+				response := graphJSONResponse(req, `{"error":{"code":"ErrorAccessDenied","message":"Access is denied"}}`)
+				response.StatusCode = http.StatusForbidden
+				return response
+			})
+			var err error
+			if attach {
+				_, err = client.AttachToDraft(context.Background(), "shared@example.com", "id", "f", "text/plain", nil)
+			} else {
+				err = client.UpdateDraftRecipients(context.Background(), "shared@example.com", "id", DraftRecipients{To: []string{}})
+			}
+			code, status := ErrorMetadata(err)
+			if code != errorAccessDeniedCode || status != http.StatusForbidden {
+				t.Fatalf("error=%v code=%s status=%d", err, code, status)
+			}
+		}
+	}
+}

--- a/internal/graphapi/mail.go
+++ b/internal/graphapi/mail.go
@@ -429,6 +429,7 @@ func (c *Client) SendMessage(ctx context.Context, target string, opts *SendMessa
 // https://learn.microsoft.com/en-us/graph/outlook-send-mail-from-other-user
 const (
 	errorSendAsDeniedCode = "ErrorSendAsDenied"
+	errorAccessDeniedCode = "ErrorAccessDenied"
 
 	sendGrantHint = "Sending as another mailbox needs three separate grants: the Mail.Send.Shared " +
 		"scope (sign in again with --scope Mail.Send.Shared), Send As or Send on Behalf Of on that " +
@@ -515,7 +516,7 @@ func sharedMailboxReadError(action, target string, err error) error {
 func delegatedPermissionRefusal(err error, message string) bool {
 	code, status := ErrorMetadata(err)
 	lower := strings.ToLower(message)
-	return code == errorSendAsDeniedCode || code == "ErrorAccessDenied" ||
+	return code == errorSendAsDeniedCode || code == errorAccessDeniedCode ||
 		strings.Contains(lower, "access is denied") ||
 		strings.Contains(lower, "forbidden") ||
 		(status == 403 && strings.Contains(lower, "denied"))


### PR DESCRIPTION
Add `mail drafts attach <ID> <FILE>` and `mail drafts update <ID> --to|--cc|--bcc` so an existing reply draft can receive a file or different recipients without replacing its quoted body. Omitted recipient lists stay unchanged; an explicitly empty value clears that list.

Both commands support delegated mailboxes, capability guards, dry runs and JSON/TSV receipts. Check draft state before editing, enforce regular-file and bounded-upload limits, preserve provider errors, and handle missing attachment responses. These commands remain CLI-only; the MCP allowlist is unchanged.

Validation: full `go test -race -count=1 ./...`, go vet, build, module tidiness and CI-pinned lint passed. Request-level tests cover exact PATCH/upload payloads, own/delegated routes, recipient clearing, non-draft refusal, size boundaries, missing responses and provider errors; CLI tests cover guards, formats and dry runs. Built-binary help and dry-run checks passed. No live mailbox operations were performed.

Provider contracts: [message updates](https://learn.microsoft.com/en-us/graph/api/message-update?view=graph-rest-1.0) and [attachment uploads](https://learn.microsoft.com/en-us/graph/api/message-post-attachments?view=graph-rest-1.0).

Suggested review order: #102 (smoke privacy) → #103 (attachment metadata) → #104 (delegated moves) → #105 (existing-draft edits). Each branch targets upstream main directly and can be reviewed independently. Applying all four in that order was rehearsed without conflicts.
